### PR TITLE
Fix DW release GH action

### DIFF
--- a/.changeset/big-ligers-whisper.md
+++ b/.changeset/big-ligers-whisper.md
@@ -1,0 +1,5 @@
+---
+'alephium-desktop-wallet': patch
+---
+
+Fix UTXO consolidation error handling

--- a/.changeset/tasty-pianos-sit.md
+++ b/.changeset/tasty-pianos-sit.md
@@ -1,0 +1,5 @@
+---
+'alephium-desktop-wallet': patch
+---
+
+Manage multiple WalletConnect connections

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -16,10 +16,18 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
 
-      - name: Install Node.js
-        uses: actions/setup-node@v4
+      - name: Install Bun package manager
+        uses: oven-sh/setup-bun@v1
+
+      - name: Install NPM dependencies
+        run: bun install --yarn
+
+      - name: Change packageManager field in package.json from bun to yarn
+        uses: jossef/action-set-json-field@v2.1
         with:
-          node-version: 16
+          file: package.json
+          field: packageManager
+          value: yarn@1.22.21
 
       - name: Prepare for app notarization
         if: startsWith(matrix.os, 'macos')

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -42,7 +42,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
 
       - name: Build & release Electron app
-        uses: coparse-inc/action-electron-builder@v1
+        uses: coparse-inc/action-electron-builder@v1.0.0
         if: ${{ startsWith(github.ref, 'refs/tags/alephium-desktop-wallet@') }}
         with:
           package_root: 'apps/desktop-wallet'
@@ -116,7 +116,7 @@ jobs:
         run: cd packages/shared && yarn run compile
 
       - name: Build & release Electron app
-        uses: coparse-inc/action-electron-builder@v1
+        uses: coparse-inc/action-electron-builder@v1.0.0
         if: ${{ startsWith(github.ref, 'refs/tags/alephium-desktop-wallet@') }}
         with:
           package_root: 'apps/desktop-wallet'

--- a/README.md
+++ b/README.md
@@ -71,6 +71,28 @@ bunx changeset add # or `bunx changeset` for short
 
 ## Releasing
 
+### Release candidates
+
+```shell
+bunx changeset pre enter rc # Enters the pre-release mode
+bunx changeset version # Compiles all chancesets into changelogs and bumps the package versions
+git add # Add changelogs and version bumps
+git commit -m "Bump versions"
+bunx changeset tag # Creates tags with new package versions
+
+git push --follow-tags # Push new tags to trigger release candidate GH actions
+```
+
+This will trigger the release GitHub actions, but append the `rc` suffix at the end of the tags.
+
+To move on with the production release, first exit the `pre` mode with:
+
+```shell
+bunx changeset pre exit
+```
+
+and then delete all the files and diff that was generated while in the "pre-release" mode.
+
 ### Production
 
 Create a PR that includes the bump'ed versions:
@@ -96,24 +118,4 @@ git pull origin master
 bunx changeset tag
 
 git push --follow-tags
-```
-
-### Release candidates
-
-The process for release candidates is a bit different.
-
-```shell
-bunx changeset pre enter rc
-bunx changeset version
-bunx changeset tag
-
-git push --follow-tags
-```
-
-This will trigger the release GitHub actions, but append the `rc` suffix at the end of the tags.
-
-To move on with the production release, first exit the `pre` mode with:
-
-```shell
-bunx changeset pre exit
 ```


### PR DESCRIPTION
@mvaivre Unfortunately the GitHub action we are using for code-signing and releasing the DW (action-electron-builder) only supports NPM and Yarn. This PR fixes the release workflow using Yarn instead of Bun.

https://github.com/coparse-inc/action-electron-builder/blob/master/index.js#L109

It also fixes some more things related to releasing and updates the docs.