### PR TITLE
Fix mac password in CI

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -58,14 +58,13 @@ jobs:
           args: ${{ steps.get-args.outputs.args }}
           github_token: ${{ secrets.github_token }}
           release: ${{ startsWith(github.ref, 'refs/tags/alephium-desktop-wallet@') }}
-          mac_certs: ${{ secrets.mac_certs }}
-          mac_certs_password: ${{ secrets.mac_certs_password }}
+          mac_certs: ${{ secrets.MAC_CERTS }}
+          mac_certs_password: ${{ secrets.MAC_CERTS_PASSWORD }}
         env:
-          APPLE_ID: ${{ secrets.apple_id }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.apple_app_specific_password }}
-          APPLE_ID_PASSWORD: ${{ secrets.apple_id_password }}
-          APPLEID: ${{ secrets.apple_id }}
-          APPLEIDPASS: ${{ secrets.apple_id_password }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLEID: ${{ secrets.APPLE_ID }}
+          APPLEIDPASS: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
 
   generate-lockfile:


### PR DESCRIPTION
The problem was that we were using the password of our apple ID as the value of the `APPLE_ID_PASSWORD` and `APPLEIDPASS` vars whereas instead it should have been a password generated specifically for notarization. 

I deleted the `APPLE_ID_PASSWORD` secret from our CI so that we don't get confused again and I created `APPLE_APP_SPECIFIC_PASSWORD` and assigned it to `APPLE_ID_PASSWORD` and `APPLEIDPASS`.