### PR TITLE
Fix iOS WC crash, show version, capture WC client init error

### DIFF
--- a/.changeset/green-cheetahs-press.md
+++ b/.changeset/green-cheetahs-press.md
@@ -1,0 +1,5 @@
+---
+'@alephium/mobile-wallet': patch
+---
+
+Display version number in settings screen

--- a/.changeset/tiny-rice-trade.md
+++ b/.changeset/tiny-rice-trade.md
@@ -1,0 +1,5 @@
+---
+'@alephium/mobile-wallet': patch
+---
+
+Fix iOS crash due to WalletConnect client initialization

--- a/apps/desktop-wallet/src/App.tsx
+++ b/apps/desktop-wallet/src/App.tsx
@@ -106,6 +106,7 @@ const App = () => {
   useEffect(() => {
     if (posthog.__loaded)
       posthog.people.set({
+        desktop_wallet_version: import.meta.env.VITE_VERSION,
         wallets: wallets.length,
         theme: settings.theme,
         devTools: settings.devTools,

--- a/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectContext.tsx
+++ b/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectContext.tsx
@@ -128,8 +128,11 @@ export const WalletConnectContextProvider = ({ children }: { children: ReactNode
     } catch (e) {
       setWalletConnectClientStatus('uninitialized')
       console.error('Could not initialize WalletConnect client', e)
+      posthog?.capture('Error', {
+        message: `Could not initialize WalletConnect client: ${getHumanReadableError(e, '')}`
+      })
     }
-  }, [])
+  }, [posthog])
 
   const respondToWalletConnect = useCallback(
     async (event: SessionRequestEvent, response: EngineTypes.RespondParams['response']) => {

--- a/apps/mobile-wallet/src/hooks/useInterval.ts
+++ b/apps/mobile-wallet/src/hooks/useInterval.ts
@@ -18,6 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { useEffect, useRef } from 'react'
 
+// TODO: Same as in desktop wallet, move to shared
 const useInterval = (callback: () => void, delay: number, shouldPause = false) => {
   const savedCallback = useRef<() => void>(() => null)
 

--- a/apps/mobile-wallet/src/screens/Settings/SettingsScreen.tsx
+++ b/apps/mobile-wallet/src/screens/Settings/SettingsScreen.tsx
@@ -17,9 +17,11 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { StackScreenProps } from '@react-navigation/stack'
+import dayjs from 'dayjs'
+import * as Application from 'expo-application'
 import { capitalize } from 'lodash'
 import { usePostHog } from 'posthog-react-native'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Alert, Platform } from 'react-native'
 import { Portal } from 'react-native-portalize'
 import { useTheme } from 'styled-components'
@@ -83,6 +85,11 @@ const SettingsScreen = ({ navigation, ...props }: ScreenProps) => {
   const [authenticationPrompt, setAuthenticationPrompt] = useState('')
   const [loadingText, setLoadingText] = useState('')
   const [authCallback, setAuthCallback] = useState<() => void>(() => () => null)
+  const [latestUpdate, setLatestUpdate] = useState<Date>()
+
+  useEffect(() => {
+    if (Platform.OS === 'android') Application.getLastUpdateTimeAsync().then((date) => setLatestUpdate(date))
+  }, [])
 
   const toggleBiometrics = async () => {
     if (isBiometricsEnabled) {
@@ -218,6 +225,22 @@ const SettingsScreen = ({ navigation, ...props }: ScreenProps) => {
             variant="alert"
             onPress={handleDeleteButtonPress}
           />
+        </ScreenSection>
+        <ScreenSection>
+          <ScreenSectionTitle>App</ScreenSectionTitle>
+          <BoxSurface>
+            <Row title="App version">
+              <AppText>{Application.nativeApplicationVersion}</AppText>
+            </Row>
+            <Row title="Build version">
+              <AppText>{Application.nativeBuildVersion}</AppText>
+            </Row>
+            {latestUpdate && (
+              <Row title="Latest update">
+                <AppText>{dayjs(latestUpdate).toString()}</AppText>
+              </Row>
+            )}
+          </BoxSurface>
         </ScreenSection>
       </ScrollScreenStyled>
 


### PR DESCRIPTION
I wanted to see some analytics of how many installations we have in each version of our wallet, basically group by version number. Even though we track the dw version in every event, we don't capture it as a person property. This PR fixes that.

~~I am also addressing the issue at #206~~

