### PR TITLE
Remove Android https deep link

### DIFF
--- a/apps/mobile-wallet/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile-wallet/android/app/src/main/AndroidManifest.xml
@@ -34,12 +34,6 @@
         <data android:scheme="wc"/>
         <data android:scheme="alephium"/>
       </intent-filter>
-      <intent-filter android:autoVerify="true" data-generated="true">
-        <action android:name="android.intent.action.VIEW"/>
-        <data android:scheme="https" android:host="alephium.wallet.link"/>
-        <category android:name="android.intent.category.BROWSABLE"/>
-        <category android:name="android.intent.category.DEFAULT"/>
-      </intent-filter>
     </activity>
     <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false"/>
   </application>

--- a/apps/mobile-wallet/app.config.js
+++ b/apps/mobile-wallet/app.config.js
@@ -45,20 +45,7 @@ export default {
         foregroundImage: './assets/adaptive-icon.png',
         backgroundColor: '#000000'
       },
-      package: 'org.alephium.wallet',
-      intentFilters: [
-        {
-          action: 'VIEW',
-          autoVerify: true,
-          data: [
-            {
-              scheme: 'https',
-              host: 'alephium.wallet.link'
-            }
-          ],
-          category: ['BROWSABLE', 'DEFAULT']
-        }
-      ]
+      package: 'org.alephium.wallet'
     },
     web: {
       favicon: './assets/favicon.png'


### PR DESCRIPTION
Closes #207

We don't need the HTTPS link anymore since the SDK only redirects to `alephium://`:
- https://github.com/alephium/alephium-web3/blob/master/packages/walletconnect/src/constants.ts#L38
- https://github.com/alephium/alephium-web3/blob/master/packages/walletconnect/src/provider.ts#L466