### PR TITLE
EAS GitHub workflows

### DIFF
--- a/.github/actions/setup-monorepo/action.yml
+++ b/.github/actions/setup-monorepo/action.yml
@@ -1,0 +1,54 @@
+name: Setup Monorepo
+description: Prepare and install everything for the monorepo
+
+inputs:
+  node-version:
+    description: Version of Node to use
+    default: 18.x
+
+  pnpm-version:
+    description: Version of pnpm to use
+    default: 8.x
+
+  eas-version:
+    description: Version of EAS CLI to use
+    default: latest
+
+  expo-token:
+    description: Expo token to authenticate with
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: 🏗 Setup pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: ${{ inputs.pnpm-version }}
+
+    - name: 🏗 Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+
+    - name: 🏗 Setup Expo
+      uses: expo/expo-github-action@v8
+      with:
+        eas-version: ${{ inputs.eas-version }}
+        token: ${{ inputs.expo-token }}
+
+    - name: 📦 Install dependencies
+      run: pnpm install
+      shell: bash
+
+    - name: ♻️ Restore cache
+      uses: actions/cache@v3
+      with:
+        key: turbo-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          turbo-${{ runner.os }}
+        path: |
+          node_modules/.cache/turbo
+          apps/*/.turbo
+          packages/*/.turbo

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -1,0 +1,41 @@
+name: Build mobile wallet with EAS
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Platform to build for
+        type: choice
+        required: true
+        default: android
+        options:
+          - android
+          - ios-registered-devices
+          - ios-testflight
+
+jobs:
+  eas-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repository
+        uses: actions/checkout@v3
+
+      - name: 🏗 Setup monorepo
+        uses: ./.github/actions/setup-monorepo
+        with:
+          expo-token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: 🤖 Build and submit Android draft release on internal track
+        if: ${{ github.event.inputs.platform == 'android' }}
+        working-directory: apps/mobile-wallet
+        run: eas build --platform=android --profile=production --non-interactive --wait --auto-submit
+
+      - name: 🍏📱 Build iOS internal release for registered devices only
+        if: ${{ github.event.inputs.platform == 'ios-registered-devices' }}
+        working-directory: apps/mobile-wallet
+        run: eas build --platform=ios --profile=internal --non-interactive --wait
+
+      - name: 🍏✈️ Build and submit iOS TestFlight release
+        if: ${{ github.event.inputs.platform == 'ios-testflight' }}
+        working-directory: apps/mobile-wallet
+        run: eas build --platform=ios --profile=production --non-interactive --wait --auto-submit

--- a/apps/mobile-wallet/README.md
+++ b/apps/mobile-wallet/README.md
@@ -34,7 +34,7 @@ In most cases, we'll need to build a production version and submitted to Google 
 
 ```shell
 eas build  --platform android --profile production
-eas submit --platform android --profile internal
+eas submit --platform android
 ```
 
 #### Creating an standalone APK
@@ -53,7 +53,7 @@ In most cases we want to release a TestFlight version so that we can have an ope
 
 ```shell
 eas build --platform ios --profile production
-eas submit --platform ios --profile production
+eas submit --platform ios
 ```
 
 #### Internal release
@@ -62,5 +62,5 @@ Only registered iOS devices will get internal releases.
 
 ```shell
 eas build --platform ios --profile internal
-eas submit --platform ios --profile production
+eas submit --platform ios
 ```

--- a/apps/mobile-wallet/app.config.js
+++ b/apps/mobile-wallet/app.config.js
@@ -19,6 +19,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 export default {
   expo: {
     name: 'Alephium',
+    owner: 'alephium-dev',
     slug: 'alephium-mobile-wallet',
     version: '1.0.4',
     orientation: 'portrait',

--- a/apps/mobile-wallet/eas.json
+++ b/apps/mobile-wallet/eas.json
@@ -17,16 +17,11 @@
     }
   },
   "submit": {
-    "internal": {
+    "production": {
       "android": {
         "track": "internal",
-        "releaseStatus": "draft",
-        "serviceAccountKeyPath": "keys/pc-api-9048873233656925435-296-b7675cb8d0ff.json"
+        "releaseStatus": "draft"
       },
-      "ios": {}
-    },
-    "production": {
-      "android": {},
       "ios": {
         "companyName": "Panda Software SA"
       }


### PR DESCRIPTION
Closes #190

We can now trigger EAS builds from our CI!

Once this PR is merged, the following options will be available in our GitHub Actions:

- `android`: This triggers an `eas build` and `submit` of a draft internal release. The release can then be later promoted to an open-beta and production through the Google Play Console website. No need to build another one
- `ios-registered-devices`: This triggers an `eas build` for the registered iOS devices. Once the build passes, a URL will be printed in the logs that the registered iOS devices can open to get the new version.
- `ios-testflight`: This is similar to `android` but for iOS: It triggers an `eas build` and `submit`. The TestFlight version can be promoted to a production release through the Apple Store Connect website.