### PR TITLE
Respond to WalletConnect while app in background

### DIFF
--- a/.changeset/clean-bikes-thank.md
+++ b/.changeset/clean-bikes-thank.md
@@ -1,5 +1,0 @@
----
-"@alephium/mobile-wallet": patch
----
-
-Improve dApp experience by responding to WalletConnect requests while the app is in the background

--- a/.changeset/clean-bikes-thank.md
+++ b/.changeset/clean-bikes-thank.md
@@ -1,0 +1,5 @@
+---
+"@alephium/mobile-wallet": patch
+---
+
+Improve dApp experience by responding to WalletConnect requests while the app is in the background

--- a/apps/mobile-wallet/CHANGELOG.md
+++ b/apps/mobile-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @alephium/mobile-wallet
 
+## 1.0.5
+
+### Patch Changes
+
+- ad9fd6d: Improve dApp experience by responding to WalletConnect requests while the app is in the background
+
 ## 1.0.4
 
 ### Patch Changes

--- a/apps/mobile-wallet/android/app/build.gradle
+++ b/apps/mobile-wallet/android/app/build.gradle
@@ -87,7 +87,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.0.4"
+        versionName "1.0.5"
 
         buildConfigField("boolean", "REACT_NATIVE_UNSTABLE_USE_RUNTIME_SCHEDULER_ALWAYS", (findProperty("reactNative.unstable_useRuntimeSchedulerAlways") ?: true).toString())
     }

--- a/apps/mobile-wallet/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile-wallet/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.CAMERA"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
@@ -7,6 +8,7 @@
   <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
   <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
+  <uses-permission android:name="android.permission.WAKE_LOCK"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
   <queries>
     <intent>

--- a/apps/mobile-wallet/app.config.js
+++ b/apps/mobile-wallet/app.config.js
@@ -36,6 +36,9 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: 'org.alephium.mobilewallet',
+      infoPlist: {
+        BGTaskSchedulerPermittedIdentifiers: ['$(PRODUCT_BUNDLE_PACKAGE_TYPE)']
+      },
       config: {
         usesNonExemptEncryption: false
       }
@@ -45,6 +48,7 @@ export default {
         foregroundImage: './assets/adaptive-icon.png',
         backgroundColor: '#000000'
       },
+      permissions: ['android.permission.FOREGROUND_SERVICE', 'android.permission.WAKE_LOCK'],
       package: 'org.alephium.wallet'
     },
     web: {

--- a/apps/mobile-wallet/app.config.js
+++ b/apps/mobile-wallet/app.config.js
@@ -20,7 +20,7 @@ export default {
   expo: {
     name: 'Alephium',
     slug: 'alephium-mobile-wallet',
-    version: '1.0.4',
+    version: '1.0.5',
     orientation: 'portrait',
     icon: './assets/icon.png',
     scheme: ['wc', 'alephium'],

--- a/apps/mobile-wallet/ios/Alephium/Info.plist
+++ b/apps/mobile-wallet/ios/Alephium/Info.plist
@@ -23,7 +23,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0.4</string>
+    <string>1.0.5</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/apps/mobile-wallet/ios/Alephium/Info.plist
+++ b/apps/mobile-wallet/ios/Alephium/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>BGTaskSchedulerPermittedIdentifiers</key>
+    <array>
+      <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    </array>
     <key>CADisableMinimumFrameDurationOnPhone</key>
     <true/>
     <key>CFBundleDevelopmentRegion</key>

--- a/apps/mobile-wallet/ios/Podfile.lock
+++ b/apps/mobile-wallet/ios/Podfile.lock
@@ -461,6 +461,8 @@ PODS:
     - glog
   - react-native-aes (2.0.0):
     - React-Core
+  - react-native-background-actions (3.0.1):
+    - React-Core
   - react-native-compat (2.11.0):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
@@ -679,6 +681,7 @@ DEPENDENCIES:
   - React-jsinspector (from `../../../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../../../node_modules/react-native/ReactCommon/logger`)
   - react-native-aes (from `../../../node_modules/react-native-aes-crypto`)
+  - react-native-background-actions (from `../../../node_modules/react-native-background-actions`)
   - "react-native-compat (from `../../../node_modules/@walletconnect/react-native-compat`)"
   - react-native-get-random-values (from `../../../node_modules/react-native-get-random-values`)
   - "react-native-netinfo (from `../../../node_modules/@react-native-community/netinfo`)"
@@ -833,6 +836,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/logger"
   react-native-aes:
     :path: "../../../node_modules/react-native-aes-crypto"
+  react-native-background-actions:
+    :path: "../../../node_modules/react-native-background-actions"
   react-native-compat:
     :path: "../../../node_modules/@walletconnect/react-native-compat"
   react-native-get-random-values:
@@ -953,6 +958,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 194e32c6aab382d88713ad3dd0025c5f5c4ee072
   React-logger: cebf22b6cf43434e471dc561e5911b40ac01d289
   react-native-aes: c75c46aa744bef7c2415fdf7f5b2dcb75ca4364d
+  react-native-background-actions: ecffd3f0864140ef6cf21c29be6819a02b531a52
   react-native-compat: d411b454141009ceca781cd1ca44132cace77c45
   react-native-get-random-values: dee677497c6a740b71e5612e8dbd83e7539ed5bb
   react-native-netinfo: 48c5f79a84fbc3ba1d28a8b0d04adeda72885fa8

--- a/apps/mobile-wallet/package.json
+++ b/apps/mobile-wallet/package.json
@@ -76,6 +76,7 @@
     "react-hook-form": "^7.42.1",
     "react-native": "0.72.6",
     "react-native-aes-crypto": "^2.1.0",
+    "react-native-background-actions": "^3.0.1",
     "react-native-gesture-handler": "^2.12.1",
     "react-native-get-random-values": "~1.9.0",
     "react-native-modalize": "^2.1.1",

--- a/apps/mobile-wallet/package.json
+++ b/apps/mobile-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alephium/mobile-wallet",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "main": "index.ts",
   "scripts": {

--- a/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectContext.tsx
+++ b/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectContext.tsx
@@ -134,6 +134,8 @@ export const WalletConnectContextProvider = ({ children }: { children: ReactNode
 
   const activeSessionMetadata = activeSessions.find((s) => s.topic === sessionRequestEvent?.topic)?.peer.metadata
   const isAuthenticated = !!mnemonic
+  const isWalletConnectClientReady =
+    isWalletConnectEnabled && walletConnectClient && walletConnectClientStatus === 'initialized'
 
   const initializeWalletConnectClient = useCallback(async () => {
     try {
@@ -539,7 +541,7 @@ export const WalletConnectContextProvider = ({ children }: { children: ReactNode
 
   useEffect(() => {
     const handleAppStateChange = async (nextAppState: AppStateStatus) => {
-      if (nextAppState === 'background' && walletConnectClient) {
+      if (nextAppState === 'background' && isWalletConnectClientReady) {
         const backgroundTask = async () => {
           while (BackgroundService.isRunning()) {
             console.log('Keeping app alive to be able to respond to WalletConnect')
@@ -569,10 +571,10 @@ export const WalletConnectContextProvider = ({ children }: { children: ReactNode
     const subscription = AppState.addEventListener('change', handleAppStateChange)
 
     return subscription.remove
-  }, [onSessionRequest, walletConnectClient])
+  }, [isWalletConnectClientReady])
 
   useEffect(() => {
-    if (!isWalletConnectEnabled || !walletConnectClient || walletConnectClientStatus !== 'initialized') return
+    if (!isWalletConnectClientReady) return
 
     console.log('👉 SUBSCRIBING TO WALLETCONNECT SESSION EVENTS.')
 
@@ -598,8 +600,7 @@ export const WalletConnectContextProvider = ({ children }: { children: ReactNode
       walletConnectClient.off('proposal_expire', onProposalExpire)
     }
   }, [
-    walletConnectClientStatus,
-    isWalletConnectEnabled,
+    isWalletConnectClientReady,
     onProposalExpire,
     onSessionDelete,
     onSessionEvent,

--- a/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectContext.tsx
+++ b/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectContext.tsx
@@ -90,6 +90,7 @@ import { sleep } from '~/utils/misc'
 import { getActiveWalletConnectSessions, isNetworkValid, parseSessionProposalEvent } from '~/utils/walletConnect'
 
 const MaxRequestNumToKeep = 10
+const FOUR_HOURS_IN_SECONDS = 60 * 60 * 4
 
 interface WalletConnectContextValue {
   walletConnectClient?: SignClient
@@ -542,9 +543,13 @@ export const WalletConnectContextProvider = ({ children }: { children: ReactNode
   useEffect(() => {
     const handleAppStateChange = async (nextAppState: AppStateStatus) => {
       if (nextAppState === 'background' && isWalletConnectClientReady) {
+        let secondsPassed = 0
+
+        // Keep app alive for max 4 hours
         const backgroundTask = async () => {
-          while (BackgroundService.isRunning()) {
+          while (BackgroundService.isRunning() && secondsPassed < FOUR_HOURS_IN_SECONDS) {
             console.log('Keeping app alive to be able to respond to WalletConnect')
+            secondsPassed += 1
             await sleep(1000)
           }
         }

--- a/apps/mobile-wallet/src/navigation/BackupMnemonicNavigation.tsx
+++ b/apps/mobile-wallet/src/navigation/BackupMnemonicNavigation.tsx
@@ -53,7 +53,12 @@ const BackupMnemonicProgressHeader = () => {
   const { headerOptions, screenScrollY } = useHeaderContext()
 
   return (
-    <ProgressHeader options={{ headerTitle: 'Backup', ...headerOptions }} workflow="backup" scrollY={screenScrollY} />
+    <ProgressHeader
+      options={{ headerTitle: 'Backup', ...headerOptions }}
+      titleAlwaysVisible
+      workflow="backup"
+      scrollY={screenScrollY}
+    />
   )
 }
 

--- a/apps/mobile-wallet/src/navigation/RootStackNavigation.tsx
+++ b/apps/mobile-wallet/src/navigation/RootStackNavigation.tsx
@@ -76,10 +76,7 @@ SplashScreen.preventAutoHideAsync()
 
 const RootStackNavigation = () => {
   const theme = useTheme()
-  const mnemonic = useAppSelector((s) => s.wallet.mnemonic)
   const dispatch = useAppDispatch()
-
-  const isAuthenticated = !!mnemonic
 
   const handleStateChange = (state?: NavigationState) => {
     if (state && isNavStateRestorable(state)) dispatch(routeChanged(state))
@@ -105,71 +102,36 @@ const RootStackNavigation = () => {
           <AppUnlockHandler>
             <Analytics>
               <WalletConnectContextProvider>
-                <RootStack.Navigator initialRouteName="LandingScreen">
-                  {/* Sub-navigation with custom header. Showing the header only when authenticated fixes the
-                    reanimated bug while still allowing animated transitions between screens */}
-                  <RootStack.Group screenOptions={{ headerShown: isAuthenticated }}>
-                    <RootStack.Screen
-                      name="SendNavigation"
-                      component={SendNavigation}
-                      options={{
-                        headerShown: false
-                      }}
-                    />
-                    <RootStack.Screen
-                      name="ReceiveNavigation"
-                      component={ReceiveNavigation}
-                      options={{
-                        headerShown: false
-                      }}
-                    />
-                    <RootStack.Screen
-                      name="BackupMnemonicNavigation"
-                      component={BackupMnemonicNavigation}
-                      options={{
-                        headerShown: false
-                      }}
-                    />
-                  </RootStack.Group>
-                  {/* Screens without header */}
-                  <RootStack.Group screenOptions={{ headerShown: false }}>
-                    <RootStack.Screen
-                      name="LandingScreen"
-                      component={LandingScreen}
-                      options={{ cardStyleInterpolator: CardStyleInterpolators.forFadeFromCenter }}
-                    />
-                    <RootStack.Screen
-                      name="LoginWithPinScreen"
-                      component={LoginWithPinScreen}
-                      options={{ cardStyleInterpolator: CardStyleInterpolators.forFadeFromCenter }}
-                    />
+                <RootStack.Navigator initialRouteName="LandingScreen" screenOptions={{ headerShown: false }}>
+                  <RootStack.Group screenOptions={{ cardStyleInterpolator: CardStyleInterpolators.forFadeFromCenter }}>
+                    <RootStack.Screen name="LandingScreen" component={LandingScreen} />
+                    <RootStack.Screen name="LoginWithPinScreen" component={LoginWithPinScreen} />
                     <RootStack.Screen name="NewWalletSuccessScreen" component={NewWalletSuccessScreen} />
-                    <RootStack.Screen
-                      name="InWalletTabsNavigation"
-                      component={InWalletTabsNavigation}
-                      options={{ cardStyleInterpolator: CardStyleInterpolators.forFadeFromCenter }}
-                    />
-                    <RootStack.Screen name="PinCodeCreationScreen" component={PinCodeCreationScreen} />
-                    <RootStack.Screen name="SettingsScreen" component={SettingsScreen} />
-                    <RootStack.Screen name="NewContactScreen" component={NewContactScreen} />
-                    <RootStack.Screen name="ContactScreen" component={ContactScreen} />
-                    <RootStack.Screen name="NewAddressScreen" component={NewAddressScreen} />
-                    <RootStack.Screen name="EditContactScreen" component={EditContactScreen} />
-                    <RootStack.Screen name="EditAddressScreen" component={EditAddressScreen} />
-                    <RootStack.Screen name="AddressDiscoveryScreen" component={AddressDiscoveryScreen} />
-                    <RootStack.Screen name="NewWalletNameScreen" component={NewWalletNameScreen} />
-                    <RootStack.Screen name="NewWalletIntroScreen" component={NewWalletIntroScreen} />
-                    <RootStack.Screen name="SelectImportMethodScreen" component={SelectImportMethodScreen} />
-                    <RootStack.Screen name="DecryptScannedMnemonicScreen" component={DecryptScannedMnemonicScreen} />
-                    <RootStack.Screen name="ImportWalletSeedScreen" component={ImportWalletSeedScreen} />
-                    <RootStack.Screen name="AddBiometricsScreen" component={AddBiometricsScreen} />
-                    <RootStack.Screen name="EditWalletNameScreen" component={EditWalletNameScreen} />
-                    <RootStack.Screen name="CustomNetworkScreen" component={CustomNetworkScreen} />
-                    <RootStack.Screen
-                      name="ImportWalletAddressDiscoveryScreen"
-                      component={ImportWalletAddressDiscoveryScreen}
-                    />
+                    <RootStack.Screen name="InWalletTabsNavigation" component={InWalletTabsNavigation} />
                   </RootStack.Group>
+                  <RootStack.Screen name="SendNavigation" component={SendNavigation} />
+                  <RootStack.Screen name="ReceiveNavigation" component={ReceiveNavigation} />
+                  <RootStack.Screen name="BackupMnemonicNavigation" component={BackupMnemonicNavigation} />
+                  <RootStack.Screen name="PinCodeCreationScreen" component={PinCodeCreationScreen} />
+                  <RootStack.Screen name="SettingsScreen" component={SettingsScreen} />
+                  <RootStack.Screen name="NewContactScreen" component={NewContactScreen} />
+                  <RootStack.Screen name="ContactScreen" component={ContactScreen} />
+                  <RootStack.Screen name="NewAddressScreen" component={NewAddressScreen} />
+                  <RootStack.Screen name="EditContactScreen" component={EditContactScreen} />
+                  <RootStack.Screen name="EditAddressScreen" component={EditAddressScreen} />
+                  <RootStack.Screen name="AddressDiscoveryScreen" component={AddressDiscoveryScreen} />
+                  <RootStack.Screen name="NewWalletNameScreen" component={NewWalletNameScreen} />
+                  <RootStack.Screen name="NewWalletIntroScreen" component={NewWalletIntroScreen} />
+                  <RootStack.Screen name="SelectImportMethodScreen" component={SelectImportMethodScreen} />
+                  <RootStack.Screen name="DecryptScannedMnemonicScreen" component={DecryptScannedMnemonicScreen} />
+                  <RootStack.Screen name="ImportWalletSeedScreen" component={ImportWalletSeedScreen} />
+                  <RootStack.Screen name="AddBiometricsScreen" component={AddBiometricsScreen} />
+                  <RootStack.Screen name="EditWalletNameScreen" component={EditWalletNameScreen} />
+                  <RootStack.Screen name="CustomNetworkScreen" component={CustomNetworkScreen} />
+                  <RootStack.Screen
+                    name="ImportWalletAddressDiscoveryScreen"
+                    component={ImportWalletAddressDiscoveryScreen}
+                  />
                 </RootStack.Navigator>
               </WalletConnectContextProvider>
             </Analytics>

--- a/apps/mobile-wallet/src/screens/BackupMnemonic/BackupIntroScreen.tsx
+++ b/apps/mobile-wallet/src/screens/BackupMnemonic/BackupIntroScreen.tsx
@@ -16,20 +16,22 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { useFocusEffect } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
 import LottieView from 'lottie-react-native'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { Portal } from 'react-native-portalize'
 import styled from 'styled-components/native'
 
 import backupAnimationSrc from '~/animations/lottie/backup.json'
 import AuthenticationModal from '~/components/AuthenticationModal'
-import Button from '~/components/buttons/Button'
+import Button, { BackButton } from '~/components/buttons/Button'
 import FooterButtonContainer from '~/components/buttons/FooterButtonContainer'
 import BottomModal from '~/components/layout/BottomModal'
 import { ScreenSection } from '~/components/layout/Screen'
 import ScrollScreen, { ScrollScreenProps } from '~/components/layout/ScrollScreen'
 import CenteredInstructions from '~/components/text/CenteredInstructions'
+import { useHeaderContext } from '~/contexts/HeaderContext'
 import { SendNavigationParamList } from '~/navigation/SendNavigation'
 import MnemonicModal from '~/screens/Settings/MnemonicModal'
 
@@ -38,12 +40,22 @@ interface BackupIntroScreenProps
     ScrollScreenProps {}
 
 const BackupIntroScreen = ({ navigation, ...props }: BackupIntroScreenProps) => {
+  const { setHeaderOptions, screenScrollHandler } = useHeaderContext()
+
   const [isAuthenticationModalVisible, setIsAuthenticationModalVisible] = useState(false)
   const [isMnemonicModalVisible, setIsMnemonicModalVisible] = useState(false)
 
+  useFocusEffect(
+    useCallback(() => {
+      setHeaderOptions({
+        headerLeft: () => <BackButton onPress={() => navigation.goBack()} />
+      })
+    }, [navigation, setHeaderOptions])
+  )
+
   return (
     <>
-      <ScrollScreen fill {...props}>
+      <ScrollScreen fill onScroll={screenScrollHandler} {...props}>
         <ScreenSection fill centered verticallyCentered>
           <StyledAnimation source={backupAnimationSrc} autoPlay />
         </ScreenSection>

--- a/apps/mobile-wallet/src/screens/new-wallet/ImportWalletSeedScreen.tsx
+++ b/apps/mobile-wallet/src/screens/new-wallet/ImportWalletSeedScreen.tsx
@@ -47,7 +47,8 @@ interface ImportWalletSeedScreenProps
   extends StackScreenProps<RootStackParamList, 'ImportWalletSeedScreen'>,
     ScreenProps {}
 
-const enablePasteForDevelopment = false
+// Only used for dev
+const devMnemonicToRestore = ''
 
 const ImportWalletSeedScreen = ({ navigation, ...props }: ImportWalletSeedScreenProps) => {
   const dispatch = useAppDispatch()
@@ -104,7 +105,7 @@ const ImportWalletSeedScreen = ({ navigation, ...props }: ImportWalletSeedScreen
 
       setLoading(true)
 
-      const mnemonicToImport = enablePasteForDevelopment ? typedInput : selectedWords.map(({ word }) => word).join(' ')
+      const mnemonicToImport = devMnemonicToRestore || selectedWords.map(({ word }) => word).join(' ')
 
       const wallet = await generateAndStoreWallet(name, pin, mnemonicToImport)
 
@@ -121,7 +122,7 @@ const ImportWalletSeedScreen = ({ navigation, ...props }: ImportWalletSeedScreen
 
       setLoading(false)
     },
-    [name, typedInput, selectedWords, dispatch, navigation, deviceHasBiometricsData]
+    [name, selectedWords, dispatch, navigation, deviceHasBiometricsData]
   )
 
   const handleWordInputChange = (inputText: string) => {
@@ -132,7 +133,7 @@ const ImportWalletSeedScreen = ({ navigation, ...props }: ImportWalletSeedScreen
   const handleWalletImport = () => importWallet(pin)
 
   // Alephium's node code uses 12 as the minimal mnemomic length.
-  const isImportButtonEnabled = selectedWords.length >= 12 || enablePasteForDevelopment
+  const isImportButtonEnabled = selectedWords.length >= 12 || !!devMnemonicToRestore
 
   return (
     <KeyboardAvoidingView behavior="height" style={{ flex: 1 }}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16263,7 +16263,7 @@ packages:
       react-native: '>=0.47.0'
     dependencies:
       eventemitter3: 4.0.7
-      react-native: 0.72.6(@babel/core@7.23.6)(@babel/preset-env@7.23.6)(react@18.2.0)
+      react-native: 0.72.6(@babel/core@7.23.6)(@babel/preset-env@7.23.8)(react@18.2.0)
     dev: false
 
   /react-native-gesture-handler@2.14.0(react-native@0.72.6)(react@18.2.0):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -681,6 +681,9 @@ importers:
       react-native-aes-crypto:
         specifier: ^2.1.0
         version: 2.1.1(patch_hash=sm7rpv6bikakdvmsl6ekayqewu)
+      react-native-background-actions:
+        specifier: ^3.0.1
+        version: 3.0.1(react-native@0.72.6)
       react-native-gesture-handler:
         specifier: ^2.12.1
         version: 2.14.0(react-native@0.72.6)(react@18.2.0)
@@ -16253,6 +16256,15 @@ packages:
     resolution: {integrity: sha512-huAt7k43myFiY0bPnvoaCP0oBjTMw4VsL2mjkmCPzzDA56Sm3ps5xXIejPo5Z9qfnei9iijHzATV8eRNMEPtbQ==}
     dev: false
     patched: true
+
+  /react-native-background-actions@3.0.1(react-native@0.72.6):
+    resolution: {integrity: sha512-xlEjUM2PP+OEQQkr9Z4c4+dRIzhbCh1xAeakL8FKGDib2a3dki2kMR4ZTw+9oHspHn9VF1Fuu78mWXR5zqkVaA==}
+    peerDependencies:
+      react-native: '>=0.47.0'
+    dependencies:
+      eventemitter3: 4.0.7
+      react-native: 0.72.6(@babel/core@7.23.6)(@babel/preset-env@7.23.6)(react@18.2.0)
+    dev: false
 
   /react-native-gesture-handler@2.14.0(react-native@0.72.6)(react@18.2.0):
     resolution: {integrity: sha512-cOmdaqbpzjWrOLUpX3hdSjsMby5wq3PIEdMq7okJeg9DmCzanysHSrktw1cXWNc/B5MAgxAn9J7Km0/4UIqKAQ==}


### PR DESCRIPTION
Related to #193 

So, it seems that simply having a timer to keep the app active while in the background prevents React Native from going to "sleep" mode, and all WalletConnect requests seem to receive responses! I've tested this on Android simulator and physical device as well as iOS simulator and it works! I look forward to seeing if it also works on an iOS physical device.