### PR TITLE
Fix GitHub API rate issue

### DIFF
--- a/.changeset/breezy-shrimps-wink.md
+++ b/.changeset/breezy-shrimps-wink.md
@@ -1,0 +1,5 @@
+---
+"alephium-desktop-wallet": patch
+---
+
+Hide token tag for tokens not in token list

--- a/.changeset/clean-windows-sort.md
+++ b/.changeset/clean-windows-sort.md
@@ -1,0 +1,5 @@
+---
+"alephium-desktop-wallet": patch
+---
+
+Handle failure of token list API call

--- a/apps/desktop-wallet/src/components/AnnouncementBanner.tsx
+++ b/apps/desktop-wallet/src/components/AnnouncementBanner.tsx
@@ -54,20 +54,23 @@ const AnnouncementBanner = ({ className }: AnnouncementBannerProps) => {
     setWasShownOnMount(true)
   }, 6000)
 
-  useThrottledGitHubApi(async ({ lastAnnouncementHashChecked }) => {
-    const response = await fetch(links.announcement)
-    const { content: contentBase64, sha: contentSHA } = await response.json()
+  useThrottledGitHubApi({
+    key: 'lastTimeGitHubApiWasCalledForAnnoumcenent',
+    githubApiCallback: async ({ lastAnnouncementHashChecked }) => {
+      const response = await fetch(links.announcement)
+      const { content: contentBase64, sha: contentSHA } = await response.json()
 
-    setContentHash(contentSHA)
+      setContentHash(contentSHA)
 
-    if (contentSHA === lastAnnouncementHashChecked) return
+      if (contentSHA === lastAnnouncementHashChecked) return
 
-    try {
-      const announcementContent = JSON.parse(atob(contentBase64)) as Announcement
+      try {
+        const announcementContent = JSON.parse(atob(contentBase64)) as Announcement
 
-      setAnnouncement(announcementContent)
-    } catch (e) {
-      console.error('Could not parse announcement content')
+        setAnnouncement(announcementContent)
+      } catch (e) {
+        console.error('Could not parse announcement content')
+      }
     }
   })
 

--- a/apps/desktop-wallet/src/components/AnnouncementBanner.tsx
+++ b/apps/desktop-wallet/src/components/AnnouncementBanner.tsx
@@ -55,7 +55,7 @@ const AnnouncementBanner = ({ className }: AnnouncementBannerProps) => {
   }, 6000)
 
   useThrottledGitHubApi({
-    lastGithubCallTimestampKey: 'lastTimeGitHubApiWasCalledForAnnoumcenent',
+    lastGithubCallTimestampKey: 'lastTimeGitHubApiWasCalledForAnnouncenent',
     githubApiCallback: async ({ lastAnnouncementHashChecked }) => {
       const response = await fetch(links.announcement)
       const { content: contentBase64, sha: contentSHA } = await response.json()

--- a/apps/desktop-wallet/src/components/AnnouncementBanner.tsx
+++ b/apps/desktop-wallet/src/components/AnnouncementBanner.tsx
@@ -55,7 +55,7 @@ const AnnouncementBanner = ({ className }: AnnouncementBannerProps) => {
   }, 6000)
 
   useThrottledGitHubApi({
-    key: 'lastTimeGitHubApiWasCalledForAnnoumcenent',
+    lastGithubCallTimestampKey: 'lastTimeGitHubApiWasCalledForAnnoumcenent',
     githubApiCallback: async ({ lastAnnouncementHashChecked }) => {
       const response = await fetch(links.announcement)
       const { content: contentBase64, sha: contentSHA } = await response.json()

--- a/apps/desktop-wallet/src/hooks/useLatestGitHubRelease.ts
+++ b/apps/desktop-wallet/src/hooks/useLatestGitHubRelease.ts
@@ -47,7 +47,7 @@ const useLatestGitHubRelease = () => {
   }
 
   useThrottledGitHubApi({
-    key: 'lastTimeGitHubApiWasCalledForLatestVersion',
+    lastGithubCallTimestampKey: 'lastTimeGitHubApiWasCalledForLatestVersion',
     githubApiCallback: async () => {
       const version = await electron?.updater.checkForUpdates()
 

--- a/apps/desktop-wallet/src/hooks/useLatestGitHubRelease.ts
+++ b/apps/desktop-wallet/src/hooks/useLatestGitHubRelease.ts
@@ -46,18 +46,21 @@ const useLatestGitHubRelease = () => {
     }
   }
 
-  useThrottledGitHubApi(async () => {
-    const version = await electron?.updater.checkForUpdates()
+  useThrottledGitHubApi({
+    key: 'lastTimeGitHubApiWasCalledForLatestVersion',
+    githubApiCallback: async () => {
+      const version = await electron?.updater.checkForUpdates()
 
-    if (!version) {
-      try {
-        await checkForManualDownload()
-      } catch (e) {
-        posthog.capture('Error', { message: 'Checking for latest release version for manual download' })
-        console.error(e)
+      if (!version) {
+        try {
+          await checkForManualDownload()
+        } catch (e) {
+          posthog.capture('Error', { message: 'Checking for latest release version for manual download' })
+          console.error(e)
+        }
+      } else if (isVersionNewer(version)) {
+        setNewVersion(version)
       }
-    } else if (isVersionNewer(version)) {
-      setNewVersion(version)
     }
   })
 

--- a/apps/desktop-wallet/src/hooks/useThrottledGitHubApi.ts
+++ b/apps/desktop-wallet/src/hooks/useThrottledGitHubApi.ts
@@ -18,22 +18,27 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { useState } from 'react'
 
-import { AppMetaData, isRcVersion, KEY_APPMETADATA, toAppMetaData } from '@/utils/app-data'
+import { AppMetaData, AppMetadataGitHub, isRcVersion, KEY_APPMETADATA, toAppMetaData } from '@/utils/app-data'
 import { useTimeout } from '@/utils/hooks'
 
 // TODO: Move to shared
 const ONE_HOUR_IN_MS = 1000 * 60 * 60
 
-const useThrottledGitHubApi = (githubApiCallback: (appMetadata: AppMetaData) => Promise<void>) => {
+interface ThrottledGitHubApiProps {
+  key: keyof AppMetadataGitHub
+  githubApiCallback: (appMetadata: AppMetaData) => Promise<void>
+}
+
+const useThrottledGitHubApi = ({ key, githubApiCallback }: ThrottledGitHubApiProps) => {
   const [timeoutDelay, setTimeoutDelay] = useState(0)
 
   const timeoutCallback = () => {
     const now = new Date()
-    const lastTimeGitHubApiWasCalled = getLastTimeGitHubApiWasCalled()
+    const lastTimeGitHubApiWasCalled = getLastTimeGitHubApiWasCalled(key)
     const timePassedSinceGitHubApiWasCalledInMs = now.getTime() - lastTimeGitHubApiWasCalled.getTime()
 
     if (timePassedSinceGitHubApiWasCalledInMs > ONE_HOUR_IN_MS) {
-      const updatedAppMetadata = storeAppMetadata({ lastTimeGitHubApiWasCalled: now })
+      const updatedAppMetadata = storeAppMetadata({ [key]: now })
 
       setTimeoutDelay(ONE_HOUR_IN_MS)
       githubApiCallback(updatedAppMetadata)
@@ -45,8 +50,9 @@ const useThrottledGitHubApi = (githubApiCallback: (appMetadata: AppMetaData) => 
   useTimeout(timeoutCallback, timeoutDelay)
 }
 
-const getLastTimeGitHubApiWasCalled = (): Date => {
-  const { lastTimeGitHubApiWasCalled } = getAppMetadata()
+const getLastTimeGitHubApiWasCalled = (key: ThrottledGitHubApiProps['key']): Date => {
+  const appMetadata = getAppMetadata()
+  const lastTimeGitHubApiWasCalled = appMetadata[key]
 
   return isRcVersion || !lastTimeGitHubApiWasCalled ? new Date(0) : lastTimeGitHubApiWasCalled
 }

--- a/apps/desktop-wallet/src/hooks/useThrottledGitHubApi.ts
+++ b/apps/desktop-wallet/src/hooks/useThrottledGitHubApi.ts
@@ -50,7 +50,9 @@ const useThrottledGitHubApi = ({ lastGithubCallTimestampKey, githubApiCallback }
   useTimeout(timeoutCallback, timeoutDelay)
 }
 
-const getLastTimeGitHubApiWasCalled = (lastGithubCallTimestampKey: ThrottledGitHubApiProps['key']): Date => {
+const getLastTimeGitHubApiWasCalled = (
+  lastGithubCallTimestampKey: ThrottledGitHubApiProps['lastGithubCallTimestampKey']
+): Date => {
   const appMetadata = getAppMetadata()
   const lastTimeGitHubApiWasCalled = appMetadata[lastGithubCallTimestampKey]
 

--- a/apps/desktop-wallet/src/hooks/useThrottledGitHubApi.ts
+++ b/apps/desktop-wallet/src/hooks/useThrottledGitHubApi.ts
@@ -25,20 +25,20 @@ import { useTimeout } from '@/utils/hooks'
 const ONE_HOUR_IN_MS = 1000 * 60 * 60
 
 interface ThrottledGitHubApiProps {
-  key: keyof AppMetadataGitHub
+  lastGithubCallTimestampKey: keyof AppMetadataGitHub
   githubApiCallback: (appMetadata: AppMetaData) => Promise<void>
 }
 
-const useThrottledGitHubApi = ({ key, githubApiCallback }: ThrottledGitHubApiProps) => {
+const useThrottledGitHubApi = ({ lastGithubCallTimestampKey, githubApiCallback }: ThrottledGitHubApiProps) => {
   const [timeoutDelay, setTimeoutDelay] = useState(0)
 
   const timeoutCallback = () => {
     const now = new Date()
-    const lastTimeGitHubApiWasCalled = getLastTimeGitHubApiWasCalled(key)
+    const lastTimeGitHubApiWasCalled = getLastTimeGitHubApiWasCalled(lastGithubCallTimestampKey)
     const timePassedSinceGitHubApiWasCalledInMs = now.getTime() - lastTimeGitHubApiWasCalled.getTime()
 
     if (timePassedSinceGitHubApiWasCalledInMs > ONE_HOUR_IN_MS) {
-      const updatedAppMetadata = storeAppMetadata({ [key]: now })
+      const updatedAppMetadata = storeAppMetadata({ [lastGithubCallTimestampKey]: now })
 
       setTimeoutDelay(ONE_HOUR_IN_MS)
       githubApiCallback(updatedAppMetadata)
@@ -50,9 +50,9 @@ const useThrottledGitHubApi = ({ key, githubApiCallback }: ThrottledGitHubApiPro
   useTimeout(timeoutCallback, timeoutDelay)
 }
 
-const getLastTimeGitHubApiWasCalled = (key: ThrottledGitHubApiProps['key']): Date => {
+const getLastTimeGitHubApiWasCalled = (lastGithubCallTimestampKey: ThrottledGitHubApiProps['key']): Date => {
   const appMetadata = getAppMetadata()
-  const lastTimeGitHubApiWasCalled = appMetadata[key]
+  const lastTimeGitHubApiWasCalled = appMetadata[lastGithubCallTimestampKey]
 
   return isRcVersion || !lastTimeGitHubApiWasCalled ? new Date(0) : lastTimeGitHubApiWasCalled
 }

--- a/apps/desktop-wallet/src/pages/UnlockedWallet/OverviewPage/AssetsList.tsx
+++ b/apps/desktop-wallet/src/pages/UnlockedWallet/OverviewPage/AssetsList.tsx
@@ -25,7 +25,6 @@ import styled, { useTheme } from 'styled-components'
 import { fadeIn } from '@/animations'
 import Amount from '@/components/Amount'
 import AssetLogo from '@/components/AssetLogo'
-import Badge from '@/components/Badge'
 import FocusableContent from '@/components/FocusableContent'
 import HashEllipsed from '@/components/HashEllipsed'
 import NFTCard from '@/components/NFTCard'
@@ -185,11 +184,11 @@ const TokenListRow = ({ asset, isExpanded }: TokenListRowProps) => {
           </TokenName>
           {asset.symbol && <TokenSymbol>{asset.symbol}</TokenSymbol>}
         </NameColumn>
-        {asset.verified === false && (
+        {/* {asset.verified === false && (
           <Column>
             <Badge color={theme.global.highlight}>{t('Unverified')}</Badge>
           </Column>
-        )}
+        )} */}
         <TableCellAmount>
           {stateUninitialized ? (
             <SkeletonLoader height="20px" width="30%" />

--- a/apps/desktop-wallet/src/utils/app-data.ts
+++ b/apps/desktop-wallet/src/utils/app-data.ts
@@ -26,9 +26,9 @@ export interface AppMetadataGitHub {
   lastTimeGitHubApiWasCalledForAnnouncenent: Date
 }
 
-export interface AppMetaData extends AppMetadataGitHub {
+export type AppMetaData = {
   lastAnnouncementHashChecked: string
-}
+} & AppMetadataGitHub
 
 export type TypeConstructors = DateConstructor | StringConstructor | NumberConstructor | BooleanConstructor
 

--- a/apps/desktop-wallet/src/utils/app-data.ts
+++ b/apps/desktop-wallet/src/utils/app-data.ts
@@ -23,7 +23,7 @@ export const isRcVersion: boolean = currentVersion.includes('-rc.')
 
 export interface AppMetadataGitHub {
   lastTimeGitHubApiWasCalledForLatestVersion: Date
-  lastTimeGitHubApiWasCalledForAnnoumcenent: Date
+  lastTimeGitHubApiWasCalledForAnnouncenent: Date
 }
 
 export interface AppMetaData extends AppMetadataGitHub {
@@ -34,7 +34,7 @@ export type TypeConstructors = DateConstructor | StringConstructor | NumberConst
 
 export const APPMETADATA_KEYS: Record<string, TypeConstructors> = {
   lastTimeGitHubApiWasCalledForLatestVersion: Date,
-  lastTimeGitHubApiWasCalledForAnnoumcenent: Date,
+  lastTimeGitHubApiWasCalledForAnnouncenent: Date,
   lastAnnouncementHashChecked: String
 }
 

--- a/apps/desktop-wallet/src/utils/app-data.ts
+++ b/apps/desktop-wallet/src/utils/app-data.ts
@@ -21,15 +21,20 @@ export const KEY_APPMETADATA = 'alephium/desktop-wallet/appmetadata'
 export const currentVersion: string = import.meta.env.VITE_VERSION
 export const isRcVersion: boolean = currentVersion.includes('-rc.')
 
-export interface AppMetaData {
-  lastTimeGitHubApiWasCalled: Date
+export interface AppMetadataGitHub {
+  lastTimeGitHubApiWasCalledForLatestVersion: Date
+  lastTimeGitHubApiWasCalledForAnnoumcenent: Date
+}
+
+export interface AppMetaData extends AppMetadataGitHub {
   lastAnnouncementHashChecked: string
 }
 
 export type TypeConstructors = DateConstructor | StringConstructor | NumberConstructor | BooleanConstructor
 
 export const APPMETADATA_KEYS: Record<string, TypeConstructors> = {
-  lastTimeGitHubApiWasCalled: Date,
+  lastTimeGitHubApiWasCalledForLatestVersion: Date,
+  lastTimeGitHubApiWasCalledForAnnoumcenent: Date,
   lastAnnouncementHashChecked: String
 }
 

--- a/packages/shared/src/store/assets/assetsActions.ts
+++ b/packages/shared/src/store/assets/assetsActions.ts
@@ -84,7 +84,6 @@ export const syncFungibleTokensInfo = createAsyncThunk(
   async (tokenIds: Asset['id'][]): Promise<FungibleTokenBasicMetadata[]> => {
     let tokensMetadata: FungibleTokenBasicMetadata[] = []
 
-    // TODO: What happens if this fails? Is there an infinite loop again?
     try {
       tokensMetadata = (
         await Promise.all(
@@ -115,7 +114,6 @@ export const syncNFTsInfo = createAsyncThunk('assets/syncNFTsInfo', async (token
   let nfts: NFT[] = []
   let nftsMetadata: NFTMetadata[] = []
 
-  // TODO: What happens if this fails? Is there an infinite loop again?
   try {
     nftsMetadata = (
       await Promise.all(

--- a/packages/shared/src/store/assets/fungibleTokensSlice.ts
+++ b/packages/shared/src/store/assets/fungibleTokensSlice.ts
@@ -47,6 +47,10 @@ const fungibleTokensSlice = createSlice({
       .addCase(syncVerifiedFungibleTokens.pending, (state) => {
         state.loadingVerified = true
       })
+      .addCase(syncVerifiedFungibleTokens.rejected, (state) => {
+        state.loadingVerified = false
+        state.status = 'initialization-failed'
+      })
       .addCase(syncFungibleTokensInfo.pending, (state) => {
         state.loadingUnverified = true
       })
@@ -66,6 +70,7 @@ const fungibleTokensSlice = createSlice({
           )
           state.status = 'initialized'
         }
+        state.loadingVerified = false
       })
       .addCase(syncFungibleTokensInfo.fulfilled, (state, action) => {
         const metadata = action.payload
@@ -87,9 +92,6 @@ const fungibleTokensSlice = createSlice({
       .addCase(customNetworkSettingsSaved, resetState)
       .addMatcher(isAnyOf(syncFungibleTokensInfo.fulfilled, syncFungibleTokensInfo.rejected), (state) => {
         state.loadingUnverified = false
-      })
-      .addMatcher(isAnyOf(syncVerifiedFungibleTokens.fulfilled, syncVerifiedFungibleTokens.rejected), (state) => {
-        state.loadingVerified = false
       })
       .addMatcher(isAnyOf(syncUnknownTokensInfo.fulfilled, syncUnknownTokensInfo.rejected), (state) => {
         state.loadingTokenTypes = false

--- a/packages/shared/src/store/assets/fungibleTokensSlice.ts
+++ b/packages/shared/src/store/assets/fungibleTokensSlice.ts
@@ -74,9 +74,6 @@ const fungibleTokensSlice = createSlice({
       })
       .addCase(syncFungibleTokensInfo.fulfilled, (state, action) => {
         const metadata = action.payload
-        const initiallyUnknownTokenIds = action.meta.arg
-
-        state.checkedUnknownTokenIds = [...initiallyUnknownTokenIds, ...state.checkedUnknownTokenIds]
 
         if (metadata) {
           fungibleTokensAdapter.upsertMany(
@@ -90,7 +87,10 @@ const fungibleTokensSlice = createSlice({
       })
       .addCase(networkPresetSwitched, resetState)
       .addCase(customNetworkSettingsSaved, resetState)
-      .addMatcher(isAnyOf(syncFungibleTokensInfo.fulfilled, syncFungibleTokensInfo.rejected), (state) => {
+      .addMatcher(isAnyOf(syncFungibleTokensInfo.fulfilled, syncFungibleTokensInfo.rejected), (state, action) => {
+        const initiallyUnknownTokenIds = action.meta.arg
+
+        state.checkedUnknownTokenIds = [...initiallyUnknownTokenIds, ...state.checkedUnknownTokenIds]
         state.loadingUnverified = false
       })
       .addMatcher(isAnyOf(syncUnknownTokensInfo.fulfilled, syncUnknownTokensInfo.rejected), (state) => {

--- a/packages/shared/src/types/assets.ts
+++ b/packages/shared/src/types/assets.ts
@@ -69,7 +69,7 @@ export interface FungibleTokensState extends EntityState<FungibleToken> {
   loadingVerified: boolean
   loadingUnverified: boolean
   loadingTokenTypes: boolean
-  status: 'initialized' | 'uninitialized'
+  status: 'initialized' | 'uninitialized' | 'initialization-failed'
   checkedUnknownTokenIds: FungibleToken['id'][]
 }
 


### PR DESCRIPTION
Here is a quick solution of 2 problems:
1. Infinite loop when GitHub API request fails: If the retry strategy fails, we stop querying until the user re-launches the app
2. Announcement & last version check conflict: We were reusing the same timestamp to throttle these GitHub API requests. The quickest way to solve this that I thought of is to store a serate timestamp for each.