### PR TITLE
Set allowBackup to false & fix crash

### DIFF
--- a/.changeset/orange-beans-lick.md
+++ b/.changeset/orange-beans-lick.md
@@ -1,0 +1,5 @@
+---
+"@alephium/mobile-wallet": patch
+---
+
+Disable app backup on Android

--- a/apps/mobile-wallet/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile-wallet/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>

--- a/apps/mobile-wallet/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile-wallet/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
       <data android:scheme="https"/>
     </intent>
   </queries>
-  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme">
+  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme">
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
     <meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="50.0.0"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>

--- a/apps/mobile-wallet/app.config.js
+++ b/apps/mobile-wallet/app.config.js
@@ -45,6 +45,7 @@ export default {
       }
     },
     android: {
+      allowBackup: false,
       adaptiveIcon: {
         foregroundImage: './assets/adaptive-icon.png',
         backgroundColor: '#000000'

--- a/apps/mobile-wallet/app.config.js
+++ b/apps/mobile-wallet/app.config.js
@@ -50,7 +50,11 @@ export default {
         foregroundImage: './assets/adaptive-icon.png',
         backgroundColor: '#000000'
       },
-      permissions: ['android.permission.FOREGROUND_SERVICE', 'android.permission.WAKE_LOCK'],
+      permissions: [
+        'android.permission.FOREGROUND_SERVICE',
+        'android.permission.FOREGROUND_SERVICE_DATA_SYNC',
+        'android.permission.WAKE_LOCK'
+      ],
       package: 'org.alephium.wallet'
     },
     web: {

--- a/apps/mobile-wallet/eas.json
+++ b/apps/mobile-wallet/eas.json
@@ -23,6 +23,7 @@
         "releaseStatus": "draft"
       },
       "ios": {
+        "ascAppId": "6469043072",
         "companyName": "Panda Software SA"
       }
     }

--- a/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectContext.tsx
+++ b/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectContext.tsx
@@ -140,7 +140,7 @@ export const WalletConnectContextProvider = ({ children }: { children: ReactNode
   const [walletConnectClientInitializationAttempts, setWalletConnectClientInitializationAttempts] = useState(0)
 
   const activeSessionMetadata = activeSessions.find((s) => s.topic === sessionRequestEvent?.topic)?.peer.metadata
-  const isAuthenticated = !!mnemonic
+  const walletIsUnlocked = !!mnemonic
   const isWalletConnectClientReady =
     isWalletConnectEnabled && walletConnectClient && walletConnectClientStatus === 'initialized'
 
@@ -566,7 +566,7 @@ export const WalletConnectContextProvider = ({ children }: { children: ReactNode
 
   useEffect(() => {
     const handleAppStateChange = async (nextAppState: AppStateStatus) => {
-      if (nextAppState === 'background' && isWalletConnectEnabled) {
+      if (nextAppState === 'background' && isWalletConnectEnabled && walletIsUnlocked) {
         let secondsPassed = 0
 
         // Keep app alive for max 4 hours
@@ -600,7 +600,7 @@ export const WalletConnectContextProvider = ({ children }: { children: ReactNode
     const subscription = AppState.addEventListener('change', handleAppStateChange)
 
     return subscription.remove
-  }, [isWalletConnectEnabled])
+  }, [isWalletConnectEnabled, walletIsUnlocked])
 
   useEffect(() => {
     if (!isWalletConnectClientReady) return
@@ -943,7 +943,7 @@ export const WalletConnectContextProvider = ({ children }: { children: ReactNode
   }, [isSessionRequestModalOpen, sessionRequestEvent])
 
   useEffect(() => {
-    if (!isAuthenticated || !url || !url.startsWith('wc:') || wcDeepLink.current === url) return
+    if (!walletIsUnlocked || !url || !url.startsWith('wc:') || wcDeepLink.current === url) return
 
     if (!isWalletConnectEnabled) {
       showToast({
@@ -957,7 +957,7 @@ export const WalletConnectContextProvider = ({ children }: { children: ReactNode
 
       wcDeepLink.current = url
     }
-  }, [isAuthenticated, isWalletConnectEnabled, pairWithDapp, url, walletConnectClient])
+  }, [walletIsUnlocked, isWalletConnectEnabled, pairWithDapp, url, walletConnectClient])
 
   const resetWalletConnectClientInitializationAttempts = () => {
     if (walletConnectClientInitializationAttempts === MAX_WALLETCONNECT_RETRIES)

--- a/apps/mobile-wallet/src/persistent-storage/config.ts
+++ b/apps/mobile-wallet/src/persistent-storage/config.ts
@@ -19,7 +19,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import * as SecureStore from 'expo-secure-store'
 
 export const defaultSecureStoreConfig = {
-  keychainAccessible: SecureStore.WHEN_UNLOCKED,
+  keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
   keychainService: 'mobile-wallet-key-service'
 }
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "pnpm": {
     "patchedDependencies": {
       "framer-motion@10.17.12": "patches/framer-motion@10.17.12.patch",
-      "react-native-aes-crypto@2.1.1": "patches/react-native-aes-crypto@2.1.1.patch"
+      "react-native-aes-crypto@2.1.1": "patches/react-native-aes-crypto@2.1.1.patch",
+      "react-native-background-actions@3.0.1": "patches/react-native-background-actions@3.0.1.patch"
     },
     "overrides": {
       "ip@<=2.0.0": ">=2.0.1",

--- a/patches/react-native-background-actions@3.0.1.patch
+++ b/patches/react-native-background-actions@3.0.1.patch
@@ -2,7 +2,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 deleted file mode 100644
 index 470a319c057e512da8a383036c2f7ddcc84aac75..0000000000000000000000000000000000000000
 diff --git a/android/src/main/AndroidManifest.xml b/android/src/main/AndroidManifest.xml
-index b67ef4d1837363489a1749acb852997a6c93c1b5..cf8cab4b89c710cdd6bb3087552d9cd8ad2b0c83 100644
+index b67ef4d1837363489a1749acb852997a6c93c1b5..6aa30a826c2f17a35ccd30b64291d3d20006e864 100644
 --- a/android/src/main/AndroidManifest.xml
 +++ b/android/src/main/AndroidManifest.xml
 @@ -1,6 +1,6 @@
@@ -10,7 +10,7 @@ index b67ef4d1837363489a1749acb852997a6c93c1b5..cf8cab4b89c710cdd6bb3087552d9cd8
      <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
      <application>
 -        <service android:name=".RNBackgroundActionsTask"/>
-+        <service android:name=".RNBackgroundActionsTask" android:foregroundServiceType="shortService"/>
++        <service android:name=".RNBackgroundActionsTask" android:foregroundServiceType="dataSync" />
      </application>
  </manifest>
 diff --git a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java b/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java

--- a/patches/react-native-background-actions@3.0.1.patch
+++ b/patches/react-native-background-actions@3.0.1.patch
@@ -1,0 +1,30 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+deleted file mode 100644
+index 470a319c057e512da8a383036c2f7ddcc84aac75..0000000000000000000000000000000000000000
+diff --git a/android/src/main/AndroidManifest.xml b/android/src/main/AndroidManifest.xml
+index b67ef4d1837363489a1749acb852997a6c93c1b5..cf8cab4b89c710cdd6bb3087552d9cd8ad2b0c83 100644
+--- a/android/src/main/AndroidManifest.xml
++++ b/android/src/main/AndroidManifest.xml
+@@ -1,6 +1,6 @@
+ <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.asterinet.react.bgactions">
+     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+     <application>
+-        <service android:name=".RNBackgroundActionsTask"/>
++        <service android:name=".RNBackgroundActionsTask" android:foregroundServiceType="shortService"/>
+     </application>
+ </manifest>
+diff --git a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java b/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java
+index 315dbd4c10155c54302fa04e3bef5067d78003cb..9900fc0654f1cfd75acd77b46734ea144c3dcb40 100644
+--- a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java
++++ b/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java
+@@ -41,7 +41,9 @@ final public class RNBackgroundActionsTask extends HeadlessJsTaskService {
+             notificationIntent = new Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER);
+         }
+         final PendingIntent contentIntent;
+-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
++        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
++            contentIntent = PendingIntent.getActivity(context,0, notificationIntent, PendingIntent.FLAG_MUTABLE | PendingIntent.FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT);
++        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+             contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, PendingIntent.FLAG_MUTABLE);
+         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+             contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ patchedDependencies:
   react-native-aes-crypto@2.1.1:
     hash: sm7rpv6bikakdvmsl6ekayqewu
     path: patches/react-native-aes-crypto@2.1.1.patch
+  react-native-background-actions@3.0.1:
+    hash: tnqysah4biy4sx3b6vswe7bwhu
+    path: patches/react-native-background-actions@3.0.1.patch
 
 importers:
 
@@ -704,7 +707,7 @@ importers:
         version: 2.1.1(patch_hash=sm7rpv6bikakdvmsl6ekayqewu)
       react-native-background-actions:
         specifier: ^3.0.1
-        version: 3.0.1(react-native@0.73.4)
+        version: 3.0.1(patch_hash=tnqysah4biy4sx3b6vswe7bwhu)(react-native@0.73.4)
       react-native-gesture-handler:
         specifier: ^2.12.1
         version: 2.14.0(react-native@0.73.4)(react@18.2.0)
@@ -16488,7 +16491,7 @@ packages:
     dev: false
     patched: true
 
-  /react-native-background-actions@3.0.1(react-native@0.73.4):
+  /react-native-background-actions@3.0.1(patch_hash=tnqysah4biy4sx3b6vswe7bwhu)(react-native@0.73.4):
     resolution: {integrity: sha512-xlEjUM2PP+OEQQkr9Z4c4+dRIzhbCh1xAeakL8FKGDib2a3dki2kMR4ZTw+9oHspHn9VF1Fuu78mWXR5zqkVaA==}
     peerDependencies:
       react-native: '>=0.47.0'
@@ -16496,6 +16499,7 @@ packages:
       eventemitter3: 4.0.7
       react-native: 0.73.4(@babel/core@7.23.6)(@babel/preset-env@7.23.8)(react@18.2.0)
     dev: false
+    patched: true
 
   /react-native-gesture-handler@2.14.0(react-native@0.73.4)(react@18.2.0):
     resolution: {integrity: sha512-cOmdaqbpzjWrOLUpX3hdSjsMby5wq3PIEdMq7okJeg9DmCzanysHSrktw1cXWNc/B5MAgxAn9J7Km0/4UIqKAQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ patchedDependencies:
     hash: sm7rpv6bikakdvmsl6ekayqewu
     path: patches/react-native-aes-crypto@2.1.1.patch
   react-native-background-actions@3.0.1:
-    hash: tnqysah4biy4sx3b6vswe7bwhu
+    hash: 3u44z2aocqips4ucm32wcdde3y
     path: patches/react-native-background-actions@3.0.1.patch
 
 importers:
@@ -707,7 +707,7 @@ importers:
         version: 2.1.1(patch_hash=sm7rpv6bikakdvmsl6ekayqewu)
       react-native-background-actions:
         specifier: ^3.0.1
-        version: 3.0.1(patch_hash=tnqysah4biy4sx3b6vswe7bwhu)(react-native@0.73.4)
+        version: 3.0.1(patch_hash=3u44z2aocqips4ucm32wcdde3y)(react-native@0.73.4)
       react-native-gesture-handler:
         specifier: ^2.12.1
         version: 2.14.0(react-native@0.73.4)(react@18.2.0)
@@ -16491,7 +16491,7 @@ packages:
     dev: false
     patched: true
 
-  /react-native-background-actions@3.0.1(patch_hash=tnqysah4biy4sx3b6vswe7bwhu)(react-native@0.73.4):
+  /react-native-background-actions@3.0.1(patch_hash=3u44z2aocqips4ucm32wcdde3y)(react-native@0.73.4):
     resolution: {integrity: sha512-xlEjUM2PP+OEQQkr9Z4c4+dRIzhbCh1xAeakL8FKGDib2a3dki2kMR4ZTw+9oHspHn9VF1Fuu78mWXR5zqkVaA==}
     peerDependencies:
       react-native: '>=0.47.0'


### PR DESCRIPTION
Metamask does the same: https://github.com/MetaMask/metamask-mobile/blob/910313340e43c24473d057825a5a810d32a55a6e/android/app/src/main/AndroidManifest.xml#L28

Same as Rainbow: https://github.com/rainbow-me/rainbow/blob/74d054fa48e7649c7c18376e4da9e78df80d295d/android/app/src/main/AndroidManifest.xml#L25

Possibly related to #352

- [x] Confirm that the change of `WHEN_UNLOCKED_THIS_DEVICE_ONLY` does not break existing wallets