### PR TITLE
Remove error analytics

### DIFF
--- a/apps/desktop-wallet/posthog-filter-out.json
+++ b/apps/desktop-wallet/posthog-filter-out.json
@@ -1,0 +1,38 @@
+[
+  {
+    "property": "message",
+    "type": "string",
+    "operator": "not_contains",
+    "value": "No metadata for network ID"
+  },
+  {
+    "property": "message",
+    "type": "string",
+    "operator": "not_contains",
+    "value": "No internet connection"
+  },
+  {
+    "property": "message",
+    "type": "string",
+    "operator": "not_contains",
+    "value": "WebSocket connection failed"
+  },
+  {
+    "property": "message",
+    "type": "string",
+    "operator": "not_contains",
+    "value": "Socket stalled"
+  },
+  {
+    "property": "message",
+    "type": "string",
+    "operator": "is_not",
+    "value": "Could not parse WalletConnect session request"
+  },
+  {
+    "property": "origin",
+    "type": "string",
+    "operator": "is_not",
+    "value": "Auto lock"
+  }
+]

--- a/apps/desktop-wallet/src/contexts/walletconnect.tsx
+++ b/apps/desktop-wallet/src/contexts/walletconnect.tsx
@@ -390,10 +390,13 @@ export const WalletConnectContextProvider: FC = ({ children }) => {
             throw new Error(`Method not supported: ${request.method}`)
         }
       } catch (e) {
-        console.error('Error while parsing WalletConnect session request', e)
-        posthog.capture('Error', { message: 'Could not parse WalletConnect session request' })
+        const message = 'Could not parse WalletConnect session request'
+        const reason = getHumanReadableError(e, '')
+
+        console.error(message, reason)
+        posthog.capture('Error', { message, reason })
         respondToWalletConnectWithError(event, {
-          message: getHumanReadableError(e, 'Error while parsing WalletConnect session request'),
+          message: getHumanReadableError(e, message),
           code: WALLETCONNECT_ERRORS.PARSING_SESSION_REQUEST_FAILED
         })
       }

--- a/apps/desktop-wallet/src/contexts/walletconnect.tsx
+++ b/apps/desktop-wallet/src/contexts/walletconnect.tsx
@@ -165,10 +165,13 @@ export const WalletConnectContextProvider: FC = ({ children }) => {
       setActiveSessions(getActiveWalletConnectSessions(client))
     } catch (e) {
       setWalletConnectClientStatus('uninitialized')
-      console.error('Could not initialize WalletConnect client', e)
-      posthog.capture('Error', {
-        message: `Could not initialize WalletConnect client: ${getHumanReadableError(e, '')}`
-      })
+      const message = 'Could not initialize WalletConnect client'
+      const reason = getHumanReadableError(e, '')
+
+      if (!reason.includes('No internet connection') && !reason.includes('WebSocket connection failed')) {
+        console.error(message, e)
+        posthog.capture('Error', { message, reason })
+      }
     }
   }, [posthog])
 

--- a/apps/desktop-wallet/src/contexts/walletconnect.tsx
+++ b/apps/desktop-wallet/src/contexts/walletconnect.tsx
@@ -168,7 +168,11 @@ export const WalletConnectContextProvider: FC = ({ children }) => {
       const message = 'Could not initialize WalletConnect client'
       const reason = getHumanReadableError(e, '')
 
-      if (!reason.includes('No internet connection') && !reason.includes('WebSocket connection failed')) {
+      if (
+        !reason.includes('No internet connection') &&
+        !reason.includes('WebSocket connection failed') &&
+        !reason.includes('Socket stalled')
+      ) {
         console.error(message, e)
         posthog.capture('Error', { message, reason })
       }

--- a/apps/desktop-wallet/src/hooks/useWalletLock.ts
+++ b/apps/desktop-wallet/src/hooks/useWalletLock.ts
@@ -74,7 +74,7 @@ const useWalletLock = () => {
       await migrateUserData(encryptedWallet.id, password, version)
     } catch (e) {
       console.error(e)
-      posthog.capture('Error', { message: 'User data migration failed ' })
+      posthog.capture('Error', { message: 'User data migration failed' })
       dispatch(userDataMigrationFailed())
     }
 

--- a/apps/desktop-wallet/src/modals/AddressSweepModal.tsx
+++ b/apps/desktop-wallet/src/modals/AddressSweepModal.tsx
@@ -79,7 +79,6 @@ const AddressSweepModal = ({ sweepAddress, onClose, onSuccessfulSweep }: Address
         setFee(fees)
       } catch (e) {
         dispatch(transactionBuildFailed(getHumanReadableError(e, t('Error while building transaction'))))
-        posthog.capture('Error', { message: 'Building transaction' })
       }
       setIsLoading(false)
     }

--- a/apps/desktop-wallet/src/modals/SendModals/CallContract/BuildTxModalContent.tsx
+++ b/apps/desktop-wallet/src/modals/SendModals/CallContract/BuildTxModalContent.tsx
@@ -17,7 +17,6 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { fromHumanReadableAmount } from '@alephium/shared'
-import { usePostHog } from 'posthog-js/react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -44,7 +43,6 @@ interface CallContractBuildTxModalContentProps {
 
 const CallContractBuildTxModalContent = ({ data, onSubmit, onCancel }: CallContractBuildTxModalContentProps) => {
   const { t } = useTranslation()
-  const posthog = usePostHog()
   const {
     gasAmount,
     gasAmountError,
@@ -70,9 +68,8 @@ const CallContractBuildTxModalContent = ({ data, onSubmit, onCancel }: CallContr
       setIsAmountValid(!alphAmount || isAmountWithinRange(fromHumanReadableAmount(alphAmount), availableBalance))
     } catch (e) {
       console.error(e)
-      posthog.capture('Error', { message: 'Could not determine if amount is valid' })
     }
-  }, [alphAmount, availableBalance, posthog])
+  }, [alphAmount, availableBalance])
 
   if (fromAddress === undefined) {
     onCancel()

--- a/apps/desktop-wallet/src/modals/SendModals/GasSettings.tsx
+++ b/apps/desktop-wallet/src/modals/SendModals/GasSettings.tsx
@@ -22,7 +22,6 @@ import {
   MINIMAL_GAS_AMOUNT,
   MINIMAL_GAS_PRICE
 } from '@alephium/shared'
-import { usePostHog } from 'posthog-js/react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -47,7 +46,6 @@ const GasSettings = ({
   onGasPriceChange
 }: GasSettingsProps) => {
   const { t } = useTranslation()
-  const posthog = usePostHog()
 
   const [expectedFee, setExpectedFee] = useState<bigint>()
 
@@ -60,9 +58,8 @@ const GasSettings = ({
       setExpectedFee(BigInt(gasAmount) * fromHumanReadableAmount(gasPrice))
     } catch (e) {
       console.error(e)
-      posthog.capture('Error', { message: 'Could not set expected fee' })
     }
-  }, [gasAmount, gasPrice, posthog])
+  }, [gasAmount, gasPrice])
 
   return (
     <>

--- a/apps/desktop-wallet/src/modals/SendModals/SendModal.tsx
+++ b/apps/desktop-wallet/src/modals/SendModals/SendModal.tsx
@@ -157,7 +157,6 @@ function SendModal<PT extends { fromAddress: Address }, T extends PT>({
         if (error.includes('consolidating') || error.includes('consolidate')) {
           setIsConsolidateUTXOsModalVisible(true)
           setConsolidationRequired(true)
-          posthog.capture('Error', { message: 'Could not build tx, consolidation required' })
         } else {
           const errorMessage = getHumanReadableError(e, t('Error while building transaction'))
 
@@ -165,7 +164,6 @@ function SendModal<PT extends { fromAddress: Address }, T extends PT>({
             dispatch(transactionBuildFailed('Your address does not have enough balance for this transaction'))
           } else {
             dispatch(transactionBuildFailed(errorMessage))
-            posthog.capture('Error', { message: 'Could not build tx' })
           }
 
           if (isRequestToApproveContractCall && onTransactionBuildFail) {
@@ -182,7 +180,6 @@ function SendModal<PT extends { fromAddress: Address }, T extends PT>({
       isConsolidateUTXOsModalVisible,
       isRequestToApproveContractCall,
       onTransactionBuildFail,
-      posthog,
       t,
       txContext
     ]

--- a/apps/desktop-wallet/src/modals/WalletConnect/SignUnsignedTxModal.tsx
+++ b/apps/desktop-wallet/src/modals/WalletConnect/SignUnsignedTxModal.tsx
@@ -77,7 +77,6 @@ const SignUnsignedTxModal = ({
       } catch (e) {
         const message = 'Could not decode unsigned tx'
         const errorMessage = getHumanReadableError(e, t(message))
-        posthog.capture('Error', { message })
         dispatch(unsignedTransactionDecodingFailed(errorMessage))
 
         onSignFail({
@@ -90,7 +89,7 @@ const SignUnsignedTxModal = ({
     }
 
     decodeUnsignedTx()
-  }, [dispatch, onClose, onSignFail, posthog, t, txData.unsignedTx])
+  }, [dispatch, onSignFail, t, txData.unsignedTx])
 
   const handleSign = async () => {
     if (!decodedUnsignedTx) return

--- a/apps/desktop-wallet/src/storage/addresses/addressesActions.ts
+++ b/apps/desktop-wallet/src/storage/addresses/addressesActions.ts
@@ -31,7 +31,6 @@ import { explorer } from '@alephium/web3'
 import { createAction, createAsyncThunk } from '@reduxjs/toolkit'
 import dayjs from 'dayjs'
 import { chunk } from 'lodash'
-import { posthog } from 'posthog-js'
 
 import {
   fetchAddressesBalances,
@@ -79,7 +78,6 @@ export const syncAddressesData = createAsyncThunk<
     await dispatch(syncAddressesTokensBalances(addresses))
     return await dispatch(syncAddressesTransactions(addresses)).unwrap()
   } catch (e) {
-    posthog.capture('Error', { message: 'Synching address data' })
     return rejectWithValue({
       text: getHumanReadableError(e, i18n.t("Encountered error while synching your addresses' data.")),
       type: 'alert'
@@ -199,7 +197,6 @@ export const syncAddressesAlphHistoricBalances = createAsyncThunk(
         }
       } catch (e) {
         console.error('Could not parse amount history data', e)
-        posthog.capture('Error', { message: 'Could not parse amount history data' })
       }
 
       addressesBalances.push({

--- a/apps/mobile-wallet/package.json
+++ b/apps/mobile-wallet/package.json
@@ -131,6 +131,8 @@
     "transformIgnorePatterns": [
       "node_modules/(?!(?:.pnpm/)?((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|nanoid))"
     ],
-    "setupFiles": ["./jestSetupFile.ts"]
+    "setupFiles": [
+      "./jestSetupFile.ts"
+    ]
   }
 }

--- a/apps/mobile-wallet/src/components/WalletSwitchButton.tsx
+++ b/apps/mobile-wallet/src/components/WalletSwitchButton.tsx
@@ -64,6 +64,7 @@ const WalletSwitchButton = ({ style }: WalletSwitchButtonProps) => {
       setNbOfTaps(0)
     }
 
+    // TODO: Shouldn't this be 69?
     if (nbOfTaps === 68) {
       setIsDoingMagic(true)
       sendAnalytics('Activated magic')

--- a/apps/mobile-wallet/src/contexts/SendContext.tsx
+++ b/apps/mobile-wallet/src/contexts/SendContext.tsx
@@ -109,8 +109,6 @@ export const SendContextProvider = ({ children }: { children: ReactNode }) => {
       setUnsignedTxData(data)
     } catch (e) {
       showExceptionToast(e, 'Could not build transaction')
-
-      sendAnalytics('Error', { message: 'Could not build consolidation transactions' })
     }
   }, [address])
 
@@ -133,8 +131,6 @@ export const SendContextProvider = ({ children }: { children: ReactNode }) => {
           await buildConsolidationTransactions()
         } else {
           showExceptionToast(e, 'Could not build transaction')
-
-          sendAnalytics('Error', { message: 'Could not build transaction' })
         }
       }
     },

--- a/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectContext.tsx
+++ b/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectContext.tsx
@@ -541,7 +541,6 @@ export const WalletConnectContextProvider = ({ children }: { children: ReactNode
         } else {
           if (!['alph_requestNodeApi', 'alph_requestExplorerApi'].includes(requestEvent.params.request.method)) {
             showExceptionToast(e, 'Could not build transaction')
-            sendAnalytics('Error', { message: 'Could not build transaction' })
             console.error(e)
           }
           respondToWalletConnectWithError(requestEvent, {

--- a/apps/mobile-wallet/src/screens/new-wallet/ImportWalletSeedScreen.tsx
+++ b/apps/mobile-wallet/src/screens/new-wallet/ImportWalletSeedScreen.tsx
@@ -19,7 +19,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { StackScreenProps } from '@react-navigation/stack'
 import { colord } from 'colord'
 import { BlurView } from 'expo-blur'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Alert, KeyboardAvoidingView, ScrollView } from 'react-native'
 import { FadeIn } from 'react-native-reanimated'
 import styled, { useTheme } from 'styled-components/native'
@@ -89,7 +89,7 @@ const ImportWalletSeedScreen = ({ navigation, ...props }: ImportWalletSeedScreen
 
   const handleEnterPress = () => possibleMatches.length > 0 && selectWord(possibleMatches[0])
 
-  const importWallet = useCallback(async () => {
+  const importWallet = async () => {
     // This should never happen, but if it does, let the user restart the process of creating a wallet
     if (!name) {
       Alert.alert('Could not proceed', 'Missing wallet name', [
@@ -122,7 +122,7 @@ const ImportWalletSeedScreen = ({ navigation, ...props }: ImportWalletSeedScreen
     } finally {
       setLoading(false)
     }
-  }, [name, selectedWords, dispatch, navigation, deviceHasEnrolledBiometrics])
+  }
 
   const handleWordInputChange = (inputText: string) => {
     const parsedInput = inputText.split(' ')[0]


### PR DESCRIPTION
I want to avoid the issue of floading the analytics with errors because of a `useEffect`, like it happened with the GH API rate limits. I went through both our wallets in search of the places we report things to PostHog and removed some. @mvaivre I would like to review them with you and think of a way to ensure that we won't end up with the same problem in the future.