### PR TITLE
[1.0.8] Fix bottom modal padding

### DIFF
--- a/apps/mobile-wallet/src/components/AddressFlatListScreen.tsx
+++ b/apps/mobile-wallet/src/components/AddressFlatListScreen.tsx
@@ -50,7 +50,6 @@ const AddressFlatListScreen = ({
           isSelected={address.hash === selectedAddress}
           style={{
             marginTop: index === 0 ? 20 : undefined,
-            marginBottom: index === addresses.length - 1 ? 40 : undefined,
             marginLeft: DEFAULT_MARGIN,
             marginRight: DEFAULT_MARGIN
           }}

--- a/apps/mobile-wallet/src/components/layout/BottomModal.tsx
+++ b/apps/mobile-wallet/src/components/layout/BottomModal.tsx
@@ -137,7 +137,7 @@ const BottomModal = ({ Content, isOpen, onClose, maximisedContent, customMinHeig
           ? customMinHeight
           : shouldMaximizeOnOpen.value
             ? maxHeight
-            : contentHeight.value + insets.bottom + VERTICAL_GAP
+            : contentHeight.value + VERTICAL_GAP
 
         shouldMaximizeOnOpen.value ? handleMaximize() : handleMinimize()
       })()

--- a/apps/mobile-wallet/src/components/layout/ModalContent.tsx
+++ b/apps/mobile-wallet/src/components/layout/ModalContent.tsx
@@ -44,30 +44,44 @@ export const ModalContent = ({
   onLayout,
   contentContainerStyle,
   ...props
-}: ModalContentProps) => (
-  <GHScrollView
-    {...scrollDefaultProps}
-    {...props}
-    contentContainerStyle={getDefaultContentContainerStyle({ verticalGap, contentContainerStyle })}
-  >
-    {children}
-  </GHScrollView>
-)
+}: ModalContentProps) => {
+  const insets = useSafeAreaInsets()
+
+  return (
+    <GHScrollView
+      {...scrollDefaultProps}
+      {...props}
+      contentContainerStyle={getDefaultContentContainerStyle({
+        verticalGap,
+        contentContainerStyle: [contentContainerStyle, { paddingBottom: insets.bottom }]
+      })}
+    >
+      {children}
+    </GHScrollView>
+  )
+}
 
 export const ModalFlatListContent = <T,>({
   children,
   verticalGap,
   contentContainerStyle,
   ...props
-}: ModalFlatListContentProps<T>) => (
-  <GHFlatList
-    contentContainerStyle={getDefaultContentContainerStyle({ verticalGap, contentContainerStyle })}
-    {...scrollDefaultProps}
-    {...props}
-  >
-    {children}
-  </GHFlatList>
-)
+}: ModalFlatListContentProps<T>) => {
+  const insets = useSafeAreaInsets()
+
+  return (
+    <GHFlatList
+      contentContainerStyle={getDefaultContentContainerStyle({
+        verticalGap,
+        contentContainerStyle: [contentContainerStyle, { paddingBottom: insets.bottom }]
+      })}
+      {...scrollDefaultProps}
+      {...props}
+    >
+      {children}
+    </GHFlatList>
+  )
+}
 
 export const Modal = ({ children, style, ...props }: ScreenProps) => {
   const insets = useSafeAreaInsets()
@@ -92,8 +106,7 @@ export const ScrollModal = ({ children, style, ...props }: ScrollSectionProps) =
 const getDefaultContentContainerStyle = ({ verticalGap, contentContainerStyle }: ModalContentProps) => [
   {
     gap: verticalGap ? (typeof verticalGap === 'number' ? verticalGap || 0 : VERTICAL_GAP) : 0,
-    paddingTop: 10,
-    paddingBottom: 20
+    paddingTop: 10
   },
   contentContainerStyle
 ]


### PR DESCRIPTION
The trick was to move `inset.bottom` from the container to the content