### PR TITLE
Delete linux/arm/v7 from explorer dockerfile

### DIFF
--- a/.github/workflows/publish-docker-explorer.yml
+++ b/.github/workflows/publish-docker-explorer.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           context: ./apps/explorer
           file: ./apps/explorer/docker/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           tags: |
             docker.io/alephium/explorer:${{ steps.get_version.outputs.current-version }}
             docker.io/alephium/explorer:latest


### PR DESCRIPTION
The GH workflow for building the explorer image gets stuck, see https://github.com/alephium/alephium-frontend/issues/533.

@killerwhile recommended we remove the `linux/arm/v7` platform. This fixes the workflow: https://github.com/alephium/alephium-frontend/actions/runs/8810828481/job/24183821652

> the docker image for the frontend is probably not needed for linux/arm/v7, we are deploying on mac (arm64) or intel-family (amd64)

cc @polarker

Closes https://github.com/alephium/alephium-frontend/issues/533.