### PR TITLE
Add AUD

### DIFF
--- a/.changeset/brave-ears-approve.md
+++ b/.changeset/brave-ears-approve.md
@@ -1,0 +1,5 @@
+---
+"alephium-desktop-wallet": patch
+---
+
+Add Australian Dollar fiat currency option

--- a/.changeset/shy-ads-fry.md
+++ b/.changeset/shy-ads-fry.md
@@ -1,0 +1,5 @@
+---
+"@alephium/mobile-wallet": patch
+---
+
+Add Australian Dollar fiat currency option

--- a/packages/shared/src/currencies.ts
+++ b/packages/shared/src/currencies.ts
@@ -69,5 +69,10 @@ export const CURRENCIES: Record<Currency, CurrencyData> = {
     name: 'Canadian Dollar',
     ticker: 'CAD',
     symbol: '$'
+  },
+  AUD: {
+    name: 'Australian Dollar',
+    ticker: 'AUD',
+    symbol: 'A$'
   }
 }

--- a/packages/shared/src/currencies.ts
+++ b/packages/shared/src/currencies.ts
@@ -68,7 +68,7 @@ export const CURRENCIES: Record<Currency, CurrencyData> = {
   CAD: {
     name: 'Canadian Dollar',
     ticker: 'CAD',
-    symbol: '$'
+    symbol: 'CA$'
   },
   AUD: {
     name: 'Australian Dollar',

--- a/packages/shared/src/types/currencies.ts
+++ b/packages/shared/src/types/currencies.ts
@@ -16,4 +16,4 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB' | 'TRY' | 'CAD'
+export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB' | 'TRY' | 'CAD' | 'AUD'


### PR DESCRIPTION
I went for `A$` as a symbol. From Wikipedia:

> The Australian dollar ([sign](https://en.wikipedia.org/wiki/Currency_sign): $; [code](https://en.wikipedia.org/wiki/ISO_4217): AUD; also abbreviated A$ or sometimes AU$ to distinguish it from other [dollar-denominated currencies](https://en.wikipedia.org/wiki/Dollar);

I also updated the Canadian dollar symbol from `$` to `CA$`. From Wikipedia:

> There is no standard disambiguating form, but the abbreviations Can$, CA$ and C$ are frequently used for distinction from other [dollar](https://en.wikipedia.org/wiki/Dollar)-denominated currencies (though C$ remains ambiguous with the [Nicaraguan córdoba](https://en.wikipedia.org/wiki/Nicaraguan_c%C3%B3rdoba))

---

Closes #422 