### PR TITLE
Fix fund password deletion and verification

### DIFF
--- a/apps/mobile-wallet/src/features/fund-password/FundPasswordReminderModal.tsx
+++ b/apps/mobile-wallet/src/features/fund-password/FundPasswordReminderModal.tsx
@@ -57,7 +57,7 @@ const FundPasswordReminderModal = ({ isOpen, onClose }: FundPasswordModalProps) 
   const handleSetPasswordPress = () => {
     onClose()
 
-    navigation.navigate('FundPasswordScreen', { origin: 'settings' })
+    navigation.navigate('FundPasswordScreen', { origin: 'settings', newPassword: true })
   }
 
   return (

--- a/apps/mobile-wallet/src/features/fund-password/FundPasswordScreen.tsx
+++ b/apps/mobile-wallet/src/features/fund-password/FundPasswordScreen.tsx
@@ -63,7 +63,7 @@ const FundPasswordScreen = ({ navigation, ...props }: FundPasswordScreenProps) =
     handlePasswordChange: handleConfirmedNewPasswordChange,
     isPasswordCorrect: isEditingPasswordConfirmed,
     error: newPasswordError
-  } = usePassword({ correctPassword: newPassword, errorMessage: "New passwords don't match" })
+  } = usePassword({ correctPassword: newPassword, errorMessage: "New passwords don't match", isValidation: true })
 
   useFocusEffect(
     useCallback(() => {

--- a/apps/mobile-wallet/src/features/fund-password/FundPasswordScreen.tsx
+++ b/apps/mobile-wallet/src/features/fund-password/FundPasswordScreen.tsx
@@ -103,16 +103,20 @@ const FundPasswordScreen = ({ navigation, ...props }: FundPasswordScreenProps) =
   }
 
   const handleDeletePress = async () => {
-    showAlert('Delete fund password', async () => {
-      await deleteFundPassword()
-      dispatch(fundPasswordUseToggled(false))
-      showToast({
-        text1: 'Deleted',
-        text2: 'Fund password was deleted.',
-        type: 'info'
-      })
-      navigation.goBack()
-      sendAnalytics({ event: 'Deleted fund password', props: { origin: props.route.params.origin } })
+    triggerFundPasswordAuthGuard({
+      successCallback: () => {
+        showAlert('Delete fund password', async () => {
+          await deleteFundPassword()
+          dispatch(fundPasswordUseToggled(false))
+          showToast({
+            text1: 'Deleted',
+            text2: 'Fund password was deleted.',
+            type: 'info'
+          })
+          navigation.goBack()
+          sendAnalytics({ event: 'Deleted fund password', props: { origin: props.route.params.origin } })
+        })
+      }
     })
   }
 

--- a/apps/mobile-wallet/src/features/fund-password/FundPasswordScreen.tsx
+++ b/apps/mobile-wallet/src/features/fund-password/FundPasswordScreen.tsx
@@ -48,15 +48,15 @@ interface FundPasswordScreenProps
 
 const FundPasswordScreen = ({ navigation, ...props }: FundPasswordScreenProps) => {
   const cameFromBackupScreen = props.route.params.origin === 'backup'
+  const isSettingNewPassword = props.route.params.newPassword
   const theme = useTheme()
   const { setHeaderOptions } = useHeaderContext()
   const currentFundPassword = useFundPassword()
   const dispatch = useAppDispatch()
-  const [isEditingPassword, setIsEditingPassword] = useState(props.route.params.newPassword)
   const { fundPasswordModal, triggerFundPasswordAuthGuard } = useFundPasswordGuard()
 
+  const [isEditingPassword, setIsEditingPassword] = useState<boolean>()
   const [password, setPassword] = useState('')
-
   const [newPassword, setNewPassword] = useState('')
   const {
     password: confirmedNewPassword,
@@ -147,11 +147,11 @@ const FundPasswordScreen = ({ navigation, ...props }: FundPasswordScreenProps) =
       headerOptions={{ type: cameFromBackupScreen ? 'default' : 'stack' }}
       {...props}
     >
-      {isEditingPassword ? (
+      {isEditingPassword || isSettingNewPassword ? (
         <>
           <ScreenSection fill verticalGap>
             <Input
-              label="New fund password"
+              label={isEditingPassword ? 'New fund password' : 'Fund password'}
               value={newPassword}
               onChangeText={setNewPassword}
               secureTextEntry
@@ -160,7 +160,7 @@ const FundPasswordScreen = ({ navigation, ...props }: FundPasswordScreenProps) =
               blurOnSubmit={false}
             />
             <Input
-              label="Confirm new fund password"
+              label={isEditingPassword ? 'Confirm new fund password' : 'Confirm fund password'}
               value={confirmedNewPassword}
               onChangeText={handleConfirmedNewPasswordChange}
               secureTextEntry

--- a/apps/mobile-wallet/src/hooks/usePassword.ts
+++ b/apps/mobile-wallet/src/hooks/usePassword.ts
@@ -21,6 +21,7 @@ import { Dispatch, SetStateAction, useState } from 'react'
 interface UsePasswordProps {
   correctPassword: string
   errorMessage?: string
+  isValidation?: boolean
 }
 
 interface UsePasswordReturn {
@@ -31,7 +32,7 @@ interface UsePasswordReturn {
   error?: string
 }
 
-const usePassword = ({ correctPassword, errorMessage }: UsePasswordProps): UsePasswordReturn => {
+const usePassword = ({ correctPassword, errorMessage, isValidation }: UsePasswordProps): UsePasswordReturn => {
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string>()
 
@@ -39,7 +40,10 @@ const usePassword = ({ correctPassword, errorMessage }: UsePasswordProps): UsePa
 
   const handlePasswordChange = (text: string) => {
     setPassword(text)
-    setError(text !== correctPassword ? errorMessage || 'Password is wrong' : '')
+
+    if (!isValidation || (error === undefined && text.length === correctPassword.length) || error !== undefined) {
+      setError(text !== correctPassword ? errorMessage || 'Password is wrong' : '')
+    }
   }
 
   return { password, handlePasswordChange, isPasswordCorrect, error, setPassword }

--- a/apps/mobile-wallet/src/screens/BackupMnemonic/VerificationSuccessScreen.tsx
+++ b/apps/mobile-wallet/src/screens/BackupMnemonic/VerificationSuccessScreen.tsx
@@ -72,7 +72,7 @@ const VerificationSuccessScreen = ({ navigation, ...props }: VerificationSuccess
           <Button
             variant="highlight"
             title="Continue"
-            onPress={() => navigation.navigate('FundPasswordScreen', { origin: 'backup' })}
+            onPress={() => navigation.navigate('FundPasswordScreen', { origin: 'backup', newPassword: true })}
           />
         )}
       </ScreenSection>

--- a/apps/mobile-wallet/src/screens/Settings/SettingsScreen.tsx
+++ b/apps/mobile-wallet/src/screens/Settings/SettingsScreen.tsx
@@ -231,12 +231,9 @@ const SettingsScreen = ({ navigation, ...props }: ScreenProps) => {
                   <Ionicons name="chevron-forward-outline" size={16} color={theme.font.primary} />
                 ) : (
                   <Toggle
-                    value={isUsingFundPassword}
+                    value={false}
                     onValueChange={() =>
-                      navigation.navigate('FundPasswordScreen', {
-                        origin: 'settings',
-                        newPassword: !isUsingFundPassword
-                      })
+                      navigation.navigate('FundPasswordScreen', { origin: 'settings', newPassword: true })
                     }
                   />
                 )}


### PR DESCRIPTION
It's weird that when a user sets up a fund password for the first time, the confirmation input field shows an error the moment they type the first character (see video). In my [other PR you mentioned](https://github.com/alephium/alephium-frontend/pull/573#issuecomment-2143854794):

> Also, to make brute forcing less trivial, the password check should be done when tapping on submit, not before:

But there's no point brute forcing your own new password, you are simply trying to set it. I brought back my changes in this case, without affecting the brute force fix of yours.

https://github.com/alephium/alephium-frontend/assets/1579899/44a3dc93-e2bd-4708-b422-b9a9f367c657

Secondly, the fund password should be asked before deleting it, the same way it is asked before editing it (see video). I fixed that in this PR.


https://github.com/alephium/alephium-frontend/assets/1579899/ab5d83f5-768c-4d25-bc04-53f4c078dd34

Lastly, there were more places where we redirect to `FundPasswordScreen` that need the new `newPassword` prop:
- `FundPasswordReminderModal`
- `VerificationSuccessScreen`

I fixed that as well!