### PR TITLE
Show fungible tokens with broken metadata in the correct tab

### DIFF
--- a/.changeset/beige-frogs-rhyme.md
+++ b/.changeset/beige-frogs-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@alephium/explorer": patch
+---
+
+Show fungible tokens with broken metadata in the correct tab

--- a/apps/explorer/src/api/assets/assetsApi.ts
+++ b/apps/explorer/src/api/assets/assetsApi.ts
@@ -99,10 +99,11 @@ export const assetsQueries = createQueriesCollection({
       queryKey: ['unverifiedFungibleToken', assetId],
       queryFn: (): Promise<UnverifiedFungibleTokenMetadata> =>
         fungibleTokensMetadata.fetch(assetId).then((r) => {
-          const parsedDecimals = parseInt(r.decimals)
+          const parsedDecimals = r?.decimals ? parseInt(r.decimals) : 0
 
           return {
             ...r,
+            id: assetId,
             type: 'fungible',
             decimals: Number.isInteger(parsedDecimals) ? parsedDecimals : 0,
             verified: false

--- a/apps/explorer/src/components/Amount.tsx
+++ b/apps/explorer/src/components/Amount.tsx
@@ -93,34 +93,47 @@ const Amount = ({
 
   const [integralPart, fractionalPart] = amount.split('.')
 
+  const RawAmountComponent = () => (
+    <>
+      <RawAmount data-tooltip-id="default" data-tooltip-content={convertToPositive(value as bigint).toString()}>
+        {value?.toString()}
+      </RawAmount>
+      <Suffix>?</Suffix>
+    </>
+  )
+
   return (
     <span className={className} tabIndex={tabIndex ?? -1}>
       {assetType === 'fungible' || isFiat ? (
-        <>
-          <NumberContainer
-            data-tooltip-id="default"
-            data-tooltip-content={
-              (!fullPrecision &&
-                value &&
-                getAmount({ value, isFiat, decimals, nbOfDecimalsToShow, fullPrecision: true })) ||
-              undefined
-            }
-          >
-            {displaySign && <span>{isNegative ? '-' : '+'}</span>}
-            {fadeDecimals ? (
-              <>
-                <span>{integralPart}</span>
-                {fractionalPart && <Decimals>.{fractionalPart}</Decimals>}
-                {quantitySymbol && <span>{quantitySymbol}</span>}
-              </>
-            ) : fractionalPart ? (
-              `${integralPart}.${fractionalPart}`
-            ) : (
-              integralPart
-            )}
-          </NumberContainer>
-          <Suffix color={overrideSuffixColor ? color : undefined}> {usedSuffix ?? 'ALPH'}</Suffix>
-        </>
+        !usedSuffix && !decimals ? (
+          <RawAmountComponent />
+        ) : (
+          <>
+            <NumberContainer
+              data-tooltip-id="default"
+              data-tooltip-content={
+                (!fullPrecision &&
+                  value &&
+                  getAmount({ value, isFiat, decimals, nbOfDecimalsToShow, fullPrecision: true })) ||
+                undefined
+              }
+            >
+              {displaySign && <span>{isNegative ? '-' : '+'}</span>}
+              {fadeDecimals ? (
+                <>
+                  <span>{integralPart}</span>
+                  {fractionalPart && <Decimals>.{fractionalPart}</Decimals>}
+                  {quantitySymbol && <span>{quantitySymbol}</span>}
+                </>
+              ) : fractionalPart ? (
+                `${integralPart}.${fractionalPart}`
+              ) : (
+                integralPart
+              )}
+            </NumberContainer>
+            <Suffix color={overrideSuffixColor ? color : undefined}> {usedSuffix}</Suffix>
+          </>
+        )
       ) : assetType === 'non-fungible' && assetId ? (
         <NFT>
           {displaySign && <span>{isNegative ? '-' : '+'}</span>}
@@ -129,13 +142,8 @@ const Amount = ({
           </NFTName>
           <NFTInlineLogo assetId={assetId} size={15} showTooltip />
         </NFT>
-      ) : isUnknownToken ? (
-        <>
-          <RawAmount data-tooltip-id="default" data-tooltip-content={convertToPositive(value as bigint).toString()}>
-            {value?.toString()}
-          </RawAmount>
-          <Suffix>?</Suffix>
-        </>
+      ) : isUnknownToken || !decimals ? (
+        <RawAmountComponent />
       ) : (
         '-'
       )}


### PR DESCRIPTION
... instead of showing them in the "unknown" tab.
Also patched an issue when decimals are not provided when they should be. 

_Note: typing should be improved in the future following my work on the tanstack branch (more fields can be optional, we should cast less types etc.)_