### PR TITLE
Export only approved translation strings

### DIFF
--- a/.github/workflows/translations-sync-dw.yml
+++ b/.github/workflows/translations-sync-dw.yml
@@ -24,6 +24,7 @@ jobs:
           upload_sources: true
           upload_translations: true
           download_translations: true
+          export_only_approved: true
           localization_branch_name: l10n_crowdin_translations
           create_pull_request: true
           pull_request_title: 'New Crowdin translations'


### PR DESCRIPTION
I found this option in the [cli docs](https://crowdin.github.io/crowdin-cli/commands/crowdin-download-translations) as well as in the [source code of the action](https://github.com/crowdin/github-action/blob/master/action.yml#L75C3-L78). 

We need to do a pass through all our translations and approve them otherwise unapproved translations will be overridden. I went through some of out translations and I found typos and other issues in some. I approved only some. I could use some help here :) 