### PR TITLE
Simplify desktop wallet build and release

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags: ['alephium-desktop-wallet@[0-9]+.[0-9]+.[0-9]+*']
 
+env:
+  GH_TOKEN: ${{ secrets.github_token }}
+  ADBLOCK: true
+
 jobs:
   release-desktop-wallet:
     runs-on: ${{ matrix.os }}
@@ -26,40 +30,53 @@ jobs:
           echo '${{ secrets.api_key }}' > ~/private_keys/AuthKey_${{ secrets.api_key_id }}.p8
           echo '${{ secrets.mac_certs }}' | base64 -d > applecert.p12
 
-      - name: Extract args
-        if: startsWith(matrix.os, 'macos')
-        id: get-args
-        run: echo "args=--universal" >> $GITHUB_OUTPUT
-        shell: bash
-
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
         if: startsWith(matrix.os, 'ubuntu')
 
-      - name: Build & release Electron app
-        uses: nop33/action-electron-builder@v1.8.2
-        if: ${{ startsWith(github.ref, 'refs/tags/alephium-desktop-wallet@') }}
-        with:
-          package_root: 'apps/desktop-wallet'
-          build_script_name: 'ci:build'
-          is_monorepo: true
-          release: true
-          github_token: ${{ secrets.github_token }}
-          mac_certs: ${{ secrets.MAC_CERTS }}
-          mac_certs_password: ${{ secrets.MAC_CERTS_PASSWORD }}
-          args: ${{ steps.get-args.outputs.args }}
+      - name: Build & release macOS Electron app
+        if: startsWith(matrix.os, 'macos')
         env:
+          CSC_LINK: ${{ secrets.MAC_CERTS }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLEID: ${{ secrets.APPLE_ID }}
           APPLEIDPASS: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+        run: |
+          cd apps/desktop-wallet
+          pnpm install
+          pnpm ci:build
+          pnpm electron-builder --universal --publish always
+
+      - name: Build & release Windows Electron app
+        if: startsWith(matrix.os, 'windows')
+        env:
+          # Replace WINDOWS_ vars with CSC_ ones if you want to use the code signing tool of electron-builder
+          # CSC_LINK: ${{ secrets.WINDOW_CERTS }}
+          # CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERTS_PASSWORD }}
+          # Following vars are needed in the apps/desktop-wallet/.signWindows.js file
           WINDOWS_SIGN_USER_NAME: ${{ secrets.WINDOWS_SIGN_USER_NAME }}
           WINDOWS_SIGN_PASSWORD: ${{ secrets.WINDOWS_SIGN_PASSWORD }}
           WINDOWS_SIGN_CREDENTIAL_ID: ${{ secrets.WINDOWS_SIGN_CREDENTIAL_ID }}
           WINDOWS_SIGN_TOTP_SECRET: ${{ secrets.WINDOWS_SIGN_TOTP_SECRET }}
+        run: |
+          cd apps/desktop-wallet
+          pnpm install
+          pnpm ci:build
+          pnpm electron-builder --publish always
+
+      - name: Build & release Linux Electron app
+        if: startsWith(matrix.os, 'ubuntu')
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+        run: |
+          cd apps/desktop-wallet
+          pnpm install
+          pnpm ci:build
+          pnpm electron-builder --publish always
 
       - name: Upload notarization-error.log
         if: always()

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -23,16 +23,13 @@ jobs:
       - name: 🏗 Setup monorepo
         uses: ./.github/actions/setup-monorepo
 
+      # macOS
       - name: Prepare for app notarization
         if: startsWith(matrix.os, 'macos')
         run: |
           mkdir -p ~/private_keys/
           echo '${{ secrets.api_key }}' > ~/private_keys/AuthKey_${{ secrets.api_key_id }}.p8
           echo '${{ secrets.mac_certs }}' | base64 -d > applecert.p12
-
-      - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
-        if: startsWith(matrix.os, 'ubuntu')
 
       - name: Build & release macOS Electron app
         if: startsWith(matrix.os, 'macos')
@@ -46,11 +43,20 @@ jobs:
           APPLEIDPASS: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         run: |
+          echo "Enter desktop wallet dir, install deps, build app, package it with electron-builder, and release it"
           cd apps/desktop-wallet
           pnpm install
           pnpm ci:build
           pnpm electron-builder --universal --publish always
 
+      - name: Upload notarization-error.log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: notarization-error-log
+          path: ${{ github.workspace }}/apps/desktop-wallet/notarization-error.log
+
+      # Windows
       - name: Build & release Windows Electron app
         if: startsWith(matrix.os, 'windows')
         env:
@@ -63,24 +69,24 @@ jobs:
           WINDOWS_SIGN_CREDENTIAL_ID: ${{ secrets.WINDOWS_SIGN_CREDENTIAL_ID }}
           WINDOWS_SIGN_TOTP_SECRET: ${{ secrets.WINDOWS_SIGN_TOTP_SECRET }}
         run: |
+          echo "Enter desktop wallet dir, install deps, build app, package it with electron-builder, and release it"
           cd apps/desktop-wallet
           pnpm install
           pnpm ci:build
           pnpm electron-builder --publish always
+
+      # Linux
+      - name: Install Snapcraft
+        uses: samuelmeuli/action-snapcraft@v2
+        if: startsWith(matrix.os, 'ubuntu')
 
       - name: Build & release Linux Electron app
         if: startsWith(matrix.os, 'ubuntu')
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
         run: |
+          echo "Enter desktop wallet dir, install deps, build app, package it with electron-builder, and release it"
           cd apps/desktop-wallet
           pnpm install
           pnpm ci:build
           pnpm electron-builder --publish always
-
-      - name: Upload notarization-error.log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: notarization-error-log
-          path: ${{ github.workspace }}/apps/desktop-wallet/notarization-error.log

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -47,7 +47,7 @@ jobs:
           cd apps/desktop-wallet
           pnpm install
           pnpm ci:build
-          pnpm electron-builder --universal --publish always
+          pnpm electron-builder --mac --universal --publish always
 
       - name: Upload notarization-error.log
         if: always()
@@ -73,7 +73,7 @@ jobs:
           cd apps/desktop-wallet
           pnpm install
           pnpm ci:build
-          pnpm electron-builder --publish always
+          pnpm electron-builder --windows --publish always
 
       # Linux
       - name: Install Snapcraft
@@ -89,4 +89,4 @@ jobs:
           cd apps/desktop-wallet
           pnpm install
           pnpm ci:build
-          pnpm electron-builder --publish always
+          pnpm electron-builder --linux --publish always

--- a/apps/desktop-wallet/.signWindows.js
+++ b/apps/desktop-wallet/.signWindows.js
@@ -90,20 +90,7 @@ async function sign(configuration) {
     console.log('---CONFIG FILE CONTENTS END---\n')
     fs.writeFileSync(destConfig, sourceConfig, { encoding: 'utf-8', flag: 'w' })
 
-    let execCmd = path.join(ARCHIVE_PATH, CODESIGNTOOL_WINDOWS_RUN_CMD)
-    let batScriptContents = fs.readFileSync(execCmd, { encoding: 'utf-8', flag: 'r' })
-
-    console.log('\n---BAT SCRIPT FILE CONTENTS START---')
-    console.log(batScriptContents)
-    console.log('---BAT SCRIPT FILE CONTENTS END---\n')
-
-    console.log('\nTweaking bat script to add -Xmx and " around args...')
-    batScriptContents = batScriptContents.replace(/java -jar/g, 'java -Xmx2048M -jar').replace(/\$@/g, `"\$@"`)
-
-    console.log('\n---BAT SCRIPT FILE CONTENTS AFTER TWEAKING START---')
-    console.log(batScriptContents)
-    console.log('---BAT SCRIPT FILE CONTENTS AFTER TWEAKING END---\n')
-    fs.writeFileSync(execCmd, batScriptContents, { encoding: 'utf-8', flag: 'w' })
+    const execCmd = path.join(ARCHIVE_PATH, CODESIGNTOOL_WINDOWS_RUN_CMD)
     fs.chmodSync(execCmd, '0755')
 
     process.env['CODE_SIGN_TOOL_PATH'] = ARCHIVE_PATH

--- a/apps/desktop-wallet/locales/en-US/translation.json
+++ b/apps/desktop-wallet/locales/en-US/translation.json
@@ -452,5 +452,6 @@
   "Copy ID": "Copy ID",
   "To delete this wallet use it without a passphrase": "To delete this wallet use it without a passphrase",
   "To export this wallet use it without a passphrase": "To export this wallet use it without a passphrase",
-  "The proposal does not include a list of required chains": "The proposal does not include a list of required chains"
+  "The proposal does not include a list of required chains": "The proposal does not include a list of required chains",
+  "All UTXOs are already consolidated for this address. No consolidation is needed.": "All UTXOs are already consolidated for this address. No consolidation is needed."
 }

--- a/apps/desktop-wallet/package.json
+++ b/apps/desktop-wallet/package.json
@@ -100,7 +100,7 @@
     "cross-env": "^7.0.3",
     "dayjs": "^1.10.7",
     "electron": "22.3.25",
-    "electron-builder": "^23.0.3",
+    "electron-builder": "^24.13.3",
     "electron-devtools-installer": "^3.2.0",
     "eslint": "^8.48.0",
     "eslint-config-prettier": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,8 +221,8 @@ importers:
         specifier: 22.3.25
         version: 22.3.25
       electron-builder:
-        specifier: ^23.0.3
-        version: 23.6.0(electron-builder-squirrel-windows@24.13.3(dmg-builder@23.6.0))
+        specifier: ^24.13.3
+        version: 24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       electron-devtools-installer:
         specifier: ^3.2.0
         version: 3.2.0
@@ -1293,9 +1293,6 @@ importers:
   packages/typescript-config: {}
 
 packages:
-
-  7zip-bin@5.1.1:
-    resolution: {integrity: sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==}
 
   7zip-bin@5.2.0:
     resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
@@ -5127,10 +5124,6 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
-  builder-util-runtime@9.1.1:
-    resolution: {integrity: sha512-azRhYLEoDvRDR8Dhis4JatELC/jUvYjm4cVSj7n9dauGTOM2eeNn9KS0z6YA6oDsjI1xphjNbY6PZZeHPzzqaw==}
-    engines: {node: '>=12.0.0'}
-
   builder-util-runtime@9.2.4:
     resolution: {integrity: sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==}
     engines: {node: '>=12.0.0'}
@@ -5138,9 +5131,6 @@ packages:
   builder-util-runtime@9.2.5-alpha.4:
     resolution: {integrity: sha512-XGquk0b7ieYcIyMZESksJm+9gT9mDRJ5ckkhym2cyB87CPMHGLt8uhN1liZlgkBfLU/aMicR7x6XanO0z64Qzg==}
     engines: {node: '>=12.0.0'}
-
-  builder-util@23.6.0:
-    resolution: {integrity: sha512-QiQHweYsh8o+U/KNCZFSvISRnvRctb8m/2rB2I1JdByzvNKxPeFLlHFRPQRXab6aYeXc18j9LpsDLJ3sGQmWTQ==}
 
   builder-util@24.13.1:
     resolution: {integrity: sha512-NhbCSIntruNDTOVI9fdXz0dihaqX2YuE1D6zZMrwiErzH4ELZHE6mdiB40wEgZNprDia+FghRFgKoAqMZRRjSA==}
@@ -5949,8 +5939,8 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
-  dmg-builder@23.6.0:
-    resolution: {integrity: sha512-jFZvY1JohyHarIAlTbfQOk+HnceGjjAdFjVn3n8xlDWKsYNqbO4muca6qXEZTfGXeQMG7TYim6CeS5XKSfSsGA==}
+  dmg-builder@24.13.3:
+    resolution: {integrity: sha512-rcJUkMfnJpfCboZoOOPf4L29TRtEieHNOeAbYPWPxlaBw/Z1RKrRA86dOI9rwaI4tQSc/RD82zTNHprfUHXsoQ==}
 
   dmg-license@1.0.11:
     resolution: {integrity: sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==}
@@ -6026,8 +6016,8 @@ packages:
   electron-builder-squirrel-windows@24.13.3:
     resolution: {integrity: sha512-oHkV0iogWfyK+ah9ZIvMDpei1m9ZRpdXcvde1wTpra2U8AFDNNpqJdnin5z+PM1GbQ5BoaKCWas2HSjtR0HwMg==}
 
-  electron-builder@23.6.0:
-    resolution: {integrity: sha512-y8D4zO+HXGCNxFBV/JlyhFnoQ0Y0K7/sFH+XwIbj47pqaW8S6PGYQbjoObolKBR1ddQFPt4rwp4CnwMJrW3HAw==}
+  electron-builder@24.13.3:
+    resolution: {integrity: sha512-yZSgVHft5dNVlo31qmJAe4BVKQfFdwpRw7sFp1iQglDRCDD6r22zfRJuZlhtB5gp9FHUxCMEoWGq10SkCnMAIg==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -9534,10 +9524,6 @@ packages:
     peerDependencies:
       react: '*'
 
-  read-config-file@6.2.0:
-    resolution: {integrity: sha512-gx7Pgr5I56JtYz+WuqEbQHj/xWo+5Vwua2jhb1VwM4Wid5PqYmZ4i00ZB0YEGIfkVBsCv9UrjgyqCiQfS/Oosg==}
-    engines: {node: '>=12.0.0'}
-
   read-config-file@6.3.2:
     resolution: {integrity: sha512-M80lpCjnE6Wt6zb98DoW8WHR09nzMSpu8XHtPkiTHrJ5Az9CybfeQhTJ8D7saeBHpGhLPIVyA8lcL6ZmdKwY6Q==}
     engines: {node: '>=12.0.0'}
@@ -9994,9 +9980,9 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
-  simple-update-notifier@1.1.0:
-    resolution: {integrity: sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==}
-    engines: {node: '>=8.10.0'}
+  simple-update-notifier@2.0.0:
+    resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
+    engines: {node: '>=10'}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -11585,8 +11571,6 @@ packages:
     resolution: {integrity: sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==}
 
 snapshots:
-
-  7zip-bin@5.1.1: {}
 
   7zip-bin@5.2.0: {}
 
@@ -14462,13 +14446,13 @@ snapshots:
   '@eslint/eslintrc@0.4.3':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.5
       espree: 7.3.1
       globals: 13.24.0
       ignore: 4.0.6
       import-fresh: 3.3.0
       js-yaml: 3.14.1
-      minimatch: 3.1.2
+      minimatch: 9.0.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -14824,8 +14808,8 @@ snapshots:
   '@humanwhocodes/config-array@0.5.0':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
-      minimatch: 3.1.2
+      debug: 4.3.5
+      minimatch: 9.0.5
     transitivePeerDependencies:
       - supports-color
 
@@ -17641,7 +17625,7 @@ snapshots:
 
   app-builder-bin@4.0.0: {}
 
-  app-builder-lib@24.13.3(dmg-builder@23.6.0(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@23.6.0)):
+  app-builder-lib@24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/notarize': 2.2.1
@@ -17655,9 +17639,9 @@ snapshots:
       builder-util-runtime: 9.2.4
       chromium-pickle-js: 0.2.0
       debug: 4.3.5
-      dmg-builder: 23.6.0(electron-builder-squirrel-windows@24.13.3)
+      dmg-builder: 24.13.3(electron-builder-squirrel-windows@24.13.3)
       ejs: 3.1.10
-      electron-builder-squirrel-windows: 24.13.3(dmg-builder@23.6.0)
+      electron-builder-squirrel-windows: 24.13.3(dmg-builder@24.13.3)
       electron-publish: 24.13.1
       form-data: 4.0.0
       fs-extra: 10.1.0
@@ -18265,13 +18249,6 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  builder-util-runtime@9.1.1:
-    dependencies:
-      debug: 4.3.4
-      sax: 1.3.0
-    transitivePeerDependencies:
-      - supports-color
-
   builder-util-runtime@9.2.4:
     dependencies:
       debug: 4.3.5
@@ -18283,28 +18260,6 @@ snapshots:
     dependencies:
       debug: 4.3.5
       sax: 1.3.0
-    transitivePeerDependencies:
-      - supports-color
-
-  builder-util@23.6.0:
-    dependencies:
-      7zip-bin: 5.1.1
-      '@types/debug': 4.1.12
-      '@types/fs-extra': 9.0.13
-      app-builder-bin: 4.0.0
-      bluebird-lst: 1.0.9
-      builder-util-runtime: 9.1.1
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4
-      fs-extra: 10.0.1
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
-      is-ci: 3.0.1
-      js-yaml: 4.1.0
-      source-map-support: 0.5.21
-      stat-mode: 1.0.0
-      temp-file: 3.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19180,12 +19135,12 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  dmg-builder@23.6.0(electron-builder-squirrel-windows@24.13.3):
+  dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@23.6.0(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@23.6.0))
-      builder-util: 23.6.0
-      builder-util-runtime: 9.1.1
-      fs-extra: 10.0.1
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+      builder-util: 24.13.1
+      builder-util-runtime: 9.2.4
+      fs-extra: 10.1.0
       iconv-lite: 0.6.3
       js-yaml: 4.1.0
     optionalDependencies:
@@ -19270,9 +19225,9 @@ snapshots:
     dependencies:
       jake: 10.8.7
 
-  electron-builder-squirrel-windows@24.13.3(dmg-builder@23.6.0):
+  electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@23.6.0(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@23.6.0))
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       archiver: 5.3.2
       builder-util: 24.13.1
       fs-extra: 10.1.0
@@ -19280,19 +19235,18 @@ snapshots:
       - dmg-builder
       - supports-color
 
-  electron-builder@23.6.0(electron-builder-squirrel-windows@24.13.3(dmg-builder@23.6.0)):
+  electron-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
     dependencies:
-      '@types/yargs': 17.0.32
-      app-builder-lib: 24.13.3(dmg-builder@23.6.0(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@23.6.0))
-      builder-util: 23.6.0
-      builder-util-runtime: 9.1.1
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+      builder-util: 24.13.1
+      builder-util-runtime: 9.2.4
       chalk: 4.1.2
-      dmg-builder: 23.6.0(electron-builder-squirrel-windows@24.13.3)
-      fs-extra: 10.0.1
+      dmg-builder: 24.13.3(electron-builder-squirrel-windows@24.13.3)
+      fs-extra: 10.1.0
       is-ci: 3.0.1
       lazy-val: 1.0.5
-      read-config-file: 6.2.0
-      simple-update-notifier: 1.1.0
+      read-config-file: 6.3.2
+      simple-update-notifier: 2.0.0
       yargs: 17.7.2
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
@@ -23824,14 +23778,6 @@ snapshots:
       lodash: 4.17.21
       react: 18.2.0
 
-  read-config-file@6.2.0:
-    dependencies:
-      dotenv: 9.0.2
-      dotenv-expand: 5.1.0
-      js-yaml: 4.1.0
-      json5: 2.2.3
-      lazy-val: 1.0.5
-
   read-config-file@6.3.2:
     dependencies:
       config-file-ts: 0.2.6
@@ -24402,9 +24348,9 @@ snapshots:
     dependencies:
       is-arrayish: 0.3.2
 
-  simple-update-notifier@1.1.0:
+  simple-update-notifier@2.0.0:
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.2
 
   sisteransi@1.0.5: {}
 


### PR DESCRIPTION
For a while I want to get rid of the unmaintained `action-electron-builder` action which we had to fork to make it work. In this PR [this whole JS file](https://github.com/nop33/action-electron-builder/blob/master/index.js) is replaced by simple GitHub Action steps.
