### PR TITLE
Fix being stuck in empty Landing screen

### DIFF
--- a/.changeset/silver-falcons-guess.md
+++ b/.changeset/silver-falcons-guess.md
@@ -1,0 +1,5 @@
+---
+"@alephium/mobile-wallet": patch
+---
+
+Fix being stuck in empty black screen

--- a/apps/mobile-wallet/src/features/auto-lock/useAutoLock.tsx
+++ b/apps/mobile-wallet/src/features/auto-lock/useAutoLock.tsx
@@ -31,7 +31,7 @@ interface UseAutoLockProps {
 let lockTimer: number | undefined
 
 const useAutoLock = ({ unlockApp, onAuthRequired }: UseAutoLockProps) => {
-  const appState = useRef(AppState.currentState)
+  const appState = useRef<AppStateStatus>('active')
   const settingsLoadedFromStorage = useAppSelector((s) => s.settings.loadedFromStorage)
   const isCameraOpen = useAppSelector((s) => s.app.isCameraOpen)
   const isWalletUnlocked = useAppSelector((s) => s.wallet.isUnlocked)

--- a/apps/mobile-wallet/src/screens/LandingScreen.tsx
+++ b/apps/mobile-wallet/src/screens/LandingScreen.tsx
@@ -89,11 +89,9 @@ const LandingScreen = ({ navigation, ...props }: LandingScreenProps) => {
   }
 
   useEffect(() => {
-    try {
-      getWalletMetadata().then((metadata) => setShowNewWalletButtons(!metadata))
-    } catch (e) {
-      showExceptionToast(e, t('Wallet metadata not found'))
-    }
+    getWalletMetadata()
+      .then((metadata) => setShowNewWalletButtons(!metadata))
+      .catch((e) => showExceptionToast(e, t('Wallet metadata not found')))
   }, [t])
 
   return (


### PR DESCRIPTION
- #752

My theory is that the “the app is now active” is never triggered because , for some reason, the appState.current ref is not set to active. I don’t see any reasons why not to initialize the ref with active, just to
 be sure. We currently initialize it with AppState.currentState, but I
think it’s safe to assume that the app is active when our code is running for the first time.