### PR TITLE
Bump mobile wallet to 1.1.3

### DIFF
--- a/.changeset/cold-carpets-kneel.md
+++ b/.changeset/cold-carpets-kneel.md
@@ -1,5 +1,0 @@
----
-"@alephium/mobile-wallet": patch
----
-
-Fix keyboard overlap in assets list

--- a/.changeset/khaki-melons-burn.md
+++ b/.changeset/khaki-melons-burn.md
@@ -1,5 +1,0 @@
----
-"@alephium/mobile-wallet": patch
----
-
-Allow user to enable device passcode/screen lock code/pattern to unlock app/transact

--- a/.changeset/silver-falcons-guess.md
+++ b/.changeset/silver-falcons-guess.md
@@ -1,5 +1,0 @@
----
-"@alephium/mobile-wallet": patch
----
-
-Fix being stuck in empty black screen

--- a/apps/mobile-wallet/CHANGELOG.md
+++ b/apps/mobile-wallet/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @alephium/mobile-wallet
 
+## 1.1.3
+
+### Patch Changes
+
+- a03242a: Fix keyboard overlap in assets list
+- d7e9844: Allow user to enable device passcode/screen lock code/pattern to unlock app/transact
+- d8955f8: Fix being stuck in empty black screen
+
 ## 1.1.2
 
 ### Patch Changes

--- a/apps/mobile-wallet/android/app/build.gradle
+++ b/apps/mobile-wallet/android/app/build.gradle
@@ -89,7 +89,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.1.2"
+        versionName "1.1.3"
     }
     signingConfigs {
         debug {

--- a/apps/mobile-wallet/app.config.js
+++ b/apps/mobile-wallet/app.config.js
@@ -21,7 +21,7 @@ export default {
     name: 'Alephium',
     owner: 'alephium-dev',
     slug: 'alephium-mobile-wallet',
-    version: '1.1.2',
+    version: '1.1.3',
     orientation: 'portrait',
     icon: './assets/icon.png',
     scheme: ['wc', 'alephium'],

--- a/apps/mobile-wallet/ios/Alephium/Info.plist
+++ b/apps/mobile-wallet/ios/Alephium/Info.plist
@@ -23,7 +23,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.1.2</string>
+    <string>1.1.3</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/apps/mobile-wallet/package.json
+++ b/apps/mobile-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alephium/mobile-wallet",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
PR created so that I can build an internal release with the current version number which will later on be promoted to a production release if everything goes well.