### PR TITLE
Bump desktop wallet to 2.3.7

### DIFF
--- a/.changeset/moody-peaches-peel.md
+++ b/.changeset/moody-peaches-peel.md
@@ -1,5 +1,0 @@
----
-"alephium-desktop-wallet": patch
----
-
-Fix missing default address

--- a/apps/desktop-wallet/CHANGELOG.md
+++ b/apps/desktop-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # alephium-desktop-wallet
 
+## 2.3.7
+
+### Patch Changes
+
+- 2e044c9: Fix missing default address
+
 ## 2.3.5
 
 ### Patch Changes

--- a/apps/desktop-wallet/package.json
+++ b/apps/desktop-wallet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "alephium-desktop-wallet",
   "description": "The official Alephium wallet",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "author": "Alephium dev <dev@alephium.org>",
   "main": "public/electron.js",
   "homepage": "./",


### PR DESCRIPTION
I've released an RC. I've tested it by setting all addresses to `isDefault: false` and importing a new wallet.

If no-one reports an issue, I'll release in production tomorrow morning (14.08.24).