### PR TITLE
Delete many Redux selectors and use Tanstack data

### DIFF
--- a/apps/desktop-wallet/src/api/addressesListedFungibleTokensDataHooks.ts
+++ b/apps/desktop-wallet/src/api/addressesListedFungibleTokensDataHooks.ts
@@ -17,7 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { AddressHash } from '@alephium/shared'
-import { ALPH, TokenInfo } from '@alephium/token-list'
+import { ALPH } from '@alephium/token-list'
 import { explorer } from '@alephium/web3'
 import { useQueries } from '@tanstack/react-query'
 import { useMemo } from 'react'
@@ -27,6 +27,7 @@ import { addressTokensBalanceQuery } from '@/api/addressQueries'
 import { useAddressesLastTransactionHashes } from '@/api/addressTransactionsDataHooks'
 import { useFungibleTokenList } from '@/api/fungibleTokenListDataHooks'
 import { useAppSelector } from '@/hooks/redux'
+import { ListedFT } from '@/types/tokens'
 
 export const useAddressesListedFungibleTokens = (addressHash?: AddressHash) => {
   const { data: fungibleTokenList, isLoading: isLoadingFungibleTokenList } = useFungibleTokenList()
@@ -51,7 +52,7 @@ export const useAddressesListedFungibleTokens = (addressHash?: AddressHash) => {
           return acc
         },
         // Include ALPH in the results
-        (alphBalances.balance > 0 ? [ALPH] : []) as TokenInfo[]
+        (alphBalances.balance > 0 ? [ALPH] : []) as ListedFT[]
       ),
       isLoading: results.some(({ isLoading }) => isLoading)
     })

--- a/apps/desktop-wallet/src/api/addressesUnlistedTokensHooks.ts
+++ b/apps/desktop-wallet/src/api/addressesUnlistedTokensHooks.ts
@@ -22,6 +22,7 @@ import { useQueries } from '@tanstack/react-query'
 import { chunk } from 'lodash'
 
 import { useAddressesUnlistedTokenTypes } from '@/api/utilHooks'
+import { UnlistedFT } from '@/types/tokens'
 import { isDefined } from '@/utils/misc'
 
 export const useAddressesUnlistedNonStandardTokenIds = (addressHash?: AddressHash) => {
@@ -49,7 +50,7 @@ export const useAddressesUnlistedFungibleTokens = (addressHash?: AddressHash) =>
       staleTime: Infinity
     })),
     combine: (results) => ({
-      data: results.flatMap(({ data }) => data && data.map(convertDecimalsToNumber)).filter(isDefined),
+      data: results.flatMap(({ data }) => data && data.map(convertDecimalsToNumber)).filter(isDefined) as UnlistedFT[],
       isLoading: results.some(({ isLoading }) => isLoading)
     })
   })

--- a/apps/desktop-wallet/src/api/useAddressesDisplayTokens.ts
+++ b/apps/desktop-wallet/src/api/useAddressesDisplayTokens.ts
@@ -1,0 +1,111 @@
+/*
+Copyright 2018 - 2024 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { AddressHash } from '@alephium/shared'
+import { orderBy } from 'lodash'
+import { useMemo } from 'react'
+
+import { useAddressesTokensBalances } from '@/api/addressesBalancesDataHooks'
+import { useAddressesListedFungibleTokens } from '@/api/addressesListedFungibleTokensDataHooks'
+import { useAddressesNfts } from '@/api/addressesNftsDataHooks'
+import { useAddressesTokensWorth } from '@/api/addressesTokensPricesDataHooks'
+import {
+  useAddressesUnlistedFungibleTokens,
+  useAddressesUnlistedNonStandardTokenIds
+} from '@/api/addressesUnlistedTokensHooks'
+import { ListedFTDisplay, NFTDisplay, NonStandardTokenDisplay, TokenDisplay, UnlistedFTDisplay } from '@/types/tokens'
+
+const useAddressesDisplayTokens = (addressHash?: AddressHash) => {
+  const { data: tokensBalances, isLoading: isLoadingTokensBalances } = useAddressesTokensBalances(addressHash)
+  const { data: tokensWorth, isLoading: isLoadingTokensWorth } = useAddressesTokensWorth(addressHash)
+  const { data: listedFTs, isLoading: isLoadingListedFTs } = useAddressesListedFungibleTokens(addressHash)
+  const { data: unlistedFTs, isLoading: isLoadingUnlistedFTs } = useAddressesUnlistedFungibleTokens(addressHash)
+  const { data: NFTs, isLoading: isLoadingNFTs } = useAddressesNfts(addressHash)
+  const { data: nonStandardTokens, isLoading: isLoadingNonStandardTokens } =
+    useAddressesUnlistedNonStandardTokenIds(addressHash)
+
+  return {
+    isLoadingFTs: isLoadingTokensBalances || isLoadingTokensWorth || isLoadingListedFTs || isLoadingUnlistedFTs,
+    isLoadingNFTs,
+    isLoadingNonStandardTokens,
+    data: useMemo(
+      () => [
+        ...orderBy(
+          listedFTs.map((token) => {
+            const balances = tokensBalances[token.id]
+            const availableBalance = balances ? balances.balance - balances.lockedBalance : undefined
+
+            return {
+              type: 'listedFT',
+              worth: tokensWorth[token.id],
+              balance: balances?.balance,
+              availableBalance,
+              ...token
+            } as ListedFTDisplay
+          }),
+          [(token) => token.worth ?? -1, (token) => token.name.toLowerCase()],
+          ['desc', 'asc']
+        ),
+        ...orderBy(
+          unlistedFTs.map((token) => {
+            const balances = tokensBalances[token.id]
+            const availableBalance = balances ? balances.balance - balances.lockedBalance : undefined
+
+            return { type: 'unlistedFT', availableBalance, balance: balances?.balance, ...token } as UnlistedFTDisplay
+          }),
+          [(t) => t.name.toLowerCase(), 'id'],
+          ['asc', 'asc']
+        ),
+        ...orderBy(
+          NFTs.map((token) => ({ type: 'NFT', ...token }) as NFTDisplay),
+          ['collectionId', (nft) => nft.name.toLowerCase()],
+          ['asc', 'asc']
+        ),
+        ...orderBy(
+          nonStandardTokens.map((tokenId) => {
+            const balances = tokensBalances[tokenId]
+            const availableBalance = balances ? balances.balance - balances.lockedBalance : undefined
+
+            return {
+              type: 'nonStandardToken',
+              id: tokenId,
+              balance: balances?.balance,
+              availableBalance
+            } as NonStandardTokenDisplay
+          }),
+          'id',
+          'asc'
+        )
+      ],
+      [NFTs, listedFTs, nonStandardTokens, tokensBalances, tokensWorth, unlistedFTs]
+    )
+  }
+}
+
+export default useAddressesDisplayTokens
+
+export const getTokenDisplayData = (token: TokenDisplay) => ({
+  image: token.type === 'NFT' ? token.image : token.type === 'listedFT' ? token.logoURI : undefined,
+  name: token.type !== 'nonStandardToken' ? token.name : undefined,
+  symbol: token.type === 'listedFT' || token.type === 'unlistedFT' ? token.symbol : undefined,
+  amount: token.type !== 'NFT' ? token.availableBalance : undefined,
+  decimals: token.type === 'listedFT' || token.type === 'unlistedFT' ? token.decimals : undefined,
+  balance: token.type !== 'NFT' ? token.balance : undefined,
+  availableBalance: token.type !== 'NFT' ? token.availableBalance : undefined,
+  worth: token.type === 'listedFT' ? token.worth : undefined
+})

--- a/apps/desktop-wallet/src/components/Amount.tsx
+++ b/apps/desktop-wallet/src/components/Amount.tsx
@@ -34,7 +34,7 @@ interface AmountProps {
   overrideSuffixColor?: boolean
   tabIndex?: number
   suffix?: string
-  isUnknownToken?: boolean
+  isNonStandardToken?: boolean
   highlight?: boolean
   showPlusMinus?: boolean
   className?: string
@@ -53,7 +53,7 @@ const Amount = ({
   overrideSuffixColor,
   tabIndex,
   highlight,
-  isUnknownToken,
+  isNonStandardToken,
   showPlusMinus = false
 }: AmountProps) => {
   const dispatch = useAppDispatch()
@@ -67,7 +67,7 @@ const Amount = ({
   if (value !== undefined) {
     if (isFiat && typeof value === 'number') {
       amount = formatFiatAmountForDisplay(value)
-    } else if (isUnknownToken) {
+    } else if (isNonStandardToken) {
       amount = value.toString()
     } else {
       isNegative = value < 0
@@ -114,7 +114,7 @@ const Amount = ({
         '-'
       )}
 
-      {!isUnknownToken && <Suffix color={overrideSuffixColor ? color : undefined}>{` ${suffix ?? 'ALPH'}`}</Suffix>}
+      {!isNonStandardToken && <Suffix color={overrideSuffixColor ? color : undefined}>{` ${suffix ?? 'ALPH'}`}</Suffix>}
     </AmountStyled>
   )
 }

--- a/apps/desktop-wallet/src/components/Inputs/SelectOptionToken.tsx
+++ b/apps/desktop-wallet/src/components/Inputs/SelectOptionToken.tsx
@@ -16,47 +16,49 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Asset } from '@alephium/shared'
 import styled from 'styled-components'
 
+import { getTokenDisplayData } from '@/api/useAddressesDisplayTokens'
 import Amount from '@/components/Amount'
 import AssetLogo from '@/components/AssetLogo'
 import HashEllipsed from '@/components/HashEllipsed'
 import SelectOptionItemContent from '@/components/Inputs/SelectOptionItemContent'
 import Truncate from '@/components/Truncate'
+import { TokenDisplay } from '@/types/tokens'
 
-interface SelectOptionAssetProps {
-  asset: Asset
+type SelectOptionTokenProps = TokenDisplay & {
   isSelected?: boolean
-  hideAmount?: boolean
   className?: string
 }
 
-const SelectOptionAsset = ({ asset, hideAmount, ...props }: SelectOptionAssetProps) => (
-  <SelectOptionItemContent
-    MainContent={
-      <AssetName>
-        <AssetLogo assetImageUrl={asset.logoURI} size={20} assetName={asset.name} />
-        <Truncate>
-          {asset.name ? `${asset.name} ${asset.symbol ? `(${asset.symbol})` : ''}` : <HashEllipsed hash={asset.id} />}
-        </Truncate>
-      </AssetName>
-    }
-    SecondaryContent={
-      !hideAmount && (
-        <AmountStyled
-          value={asset.balance}
-          suffix={asset.symbol}
-          decimals={asset.decimals}
-          isUnknownToken={!asset.symbol}
-        />
-      )
-    }
-    {...props}
-  />
-)
+const SelectOptionToken = ({ isSelected, className, ...token }: SelectOptionTokenProps) => {
+  const { image, name, symbol, amount, decimals } = getTokenDisplayData(token)
 
-export default SelectOptionAsset
+  return (
+    <SelectOptionItemContent
+      MainContent={
+        <>
+          <AssetName>
+            <AssetLogo assetImageUrl={image} size={20} assetName={name} isNft={token.type === 'NFT'} />
+            <Truncate>{name ? `${name} ${symbol ? `(${symbol})` : ''}` : <HashEllipsed hash={token.id} />}</Truncate>
+          </AssetName>
+          {amount !== undefined && (
+            <AmountStyled
+              value={amount}
+              suffix={symbol}
+              decimals={decimals}
+              isNonStandardToken={token.type === 'nonStandardToken'}
+            />
+          )}
+        </>
+      }
+      isSelected={isSelected}
+      className={className}
+    />
+  )
+}
+
+export default SelectOptionToken
 
 const AssetName = styled.div`
   display: flex;

--- a/apps/desktop-wallet/src/features/assetsLists/AssetsTabs.tsx
+++ b/apps/desktop-wallet/src/features/assetsLists/AssetsTabs.tsx
@@ -26,8 +26,8 @@ import { ExpandableTable } from '@/components/Table'
 import TableTabBar from '@/components/TableTabBar'
 import FungibleTokensBalancesList from '@/features/assetsLists/FungibleTokensBalancesList'
 import NFTsGrid from '@/features/assetsLists/NFTsGrid'
+import NonStandardTokensBalancesList from '@/features/assetsLists/NonStandardTokensBalancesList'
 import { AssetsTabsProps } from '@/features/assetsLists/types'
-import UnknownTokensBalancesList from '@/features/assetsLists/UnknownTokensBalancesList'
 
 const AssetsTabs = ({
   className,
@@ -78,7 +78,7 @@ const AssetsTabs = ({
               />
             ),
             unknownTokens: (
-              <UnknownTokensBalancesList
+              <NonStandardTokensBalancesList
                 addressHash={addressHash}
                 isExpanded={isExpanded || !maxHeightInPx}
                 onExpand={handleButtonClick}

--- a/apps/desktop-wallet/src/features/assetsLists/NonStandardTokensBalancesList.tsx
+++ b/apps/desktop-wallet/src/features/assetsLists/NonStandardTokensBalancesList.tsx
@@ -24,7 +24,7 @@ import { ExpandRow } from '@/components/Table'
 import TokenBalancesRow from '@/features/assetsLists/TokenBalancesRow'
 import { AssetsTabsProps } from '@/features/assetsLists/types'
 
-const UnknownTokensBalancesList = ({ className, addressHash, isExpanded, onExpand }: AssetsTabsProps) => {
+const NonStandardTokensBalancesList = ({ className, addressHash, isExpanded, onExpand }: AssetsTabsProps) => {
   const { data: addressesNonStandardTokenIds } = useAddressesUnlistedNonStandardTokenIds(addressHash)
 
   return (
@@ -40,4 +40,4 @@ const UnknownTokensBalancesList = ({ className, addressHash, isExpanded, onExpan
   )
 }
 
-export default UnknownTokensBalancesList
+export default NonStandardTokensBalancesList

--- a/apps/desktop-wallet/src/features/assetsLists/useSortedFungibleTokens.tsx
+++ b/apps/desktop-wallet/src/features/assetsLists/useSortedFungibleTokens.tsx
@@ -23,7 +23,9 @@ import { useMemo } from 'react'
 import { useAddressesListedFungibleTokens } from '@/api/addressesListedFungibleTokensDataHooks'
 import { useAddressesTokensWorth } from '@/api/addressesTokensPricesDataHooks'
 import { useAddressesUnlistedFungibleTokens } from '@/api/addressesUnlistedTokensHooks'
+import { ListedFT, UnlistedFT } from '@/types/tokens'
 
+// TODO: Merge with useAddressDisplayTokens?
 const useAddressesSortedFungibleTokens = (addressHash?: AddressHash) => {
   const { data: addressesTokensWorth, isLoading: isLoadingTokensWorth } = useAddressesTokensWorth(addressHash)
   const { data: addressesListedFungibleTokens, isLoading: isLoadingListedFungibleTokens } =
@@ -41,7 +43,7 @@ const useAddressesSortedFungibleTokens = (addressHash?: AddressHash) => {
       ...orderBy(addressesUnlistedFungibleTokens, [(t) => t.name.toLowerCase(), 'id'], ['asc', 'asc'])
     ],
     [addressesListedFungibleTokens, addressesTokensWorth, addressesUnlistedFungibleTokens]
-  )
+  ) as (ListedFT | UnlistedFT)[]
 
   return {
     data: sortedTokens,

--- a/apps/desktop-wallet/src/modals/SendModals/CheckAmountsBox.tsx
+++ b/apps/desktop-wallet/src/modals/SendModals/CheckAmountsBox.tsx
@@ -67,7 +67,7 @@ const CheckAmountsBox = ({ assetAmounts, className }: CheckAmountsBoxProps) => {
                 value={BigInt(asset.amount)}
                 suffix={fungibleToken?.symbol}
                 decimals={fungibleToken?.decimals}
-                isUnknownToken={!fungibleToken?.symbol}
+                isNonStandardToken={!fungibleToken?.symbol}
                 fullPrecision
               />
               {asset.id === ALPH.id && !!extraAlphForDust && (

--- a/apps/desktop-wallet/src/modals/TransactionDetailsModal.tsx
+++ b/apps/desktop-wallet/src/modals/TransactionDetailsModal.tsx
@@ -219,7 +219,7 @@ const TransactionDetailsModal = ({ transaction, onClose }: TransactionDetailsMod
                     fullPrecision
                     decimals={decimals}
                     suffix={symbol}
-                    isUnknownToken={!symbol}
+                    isNonStandardToken={!symbol}
                     highlight={!isMoved}
                     showPlusMinus={!isMoved}
                   />
@@ -242,7 +242,7 @@ const TransactionDetailsModal = ({ transaction, onClose }: TransactionDetailsMod
               <Amounts>
                 {unknownTokens.map(({ id, amount, symbol }) => (
                   <AmountContainer key={id}>
-                    <Amount tabIndex={0} value={amount} isUnknownToken={!symbol} highlight />
+                    <Amount tabIndex={0} value={amount} isNonStandardToken={!symbol} highlight />
                     {!symbol && <TokenHash hash={id} />}
                   </AmountContainer>
                 ))}

--- a/apps/desktop-wallet/src/pages/UnlockedWallet/TransfersPage/index.tsx
+++ b/apps/desktop-wallet/src/pages/UnlockedWallet/TransfersPage/index.tsx
@@ -16,7 +16,6 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Asset } from '@alephium/shared'
 import { colord } from 'colord'
 import { motion } from 'framer-motion'
 import { map } from 'lodash'
@@ -37,6 +36,7 @@ import UnlockedWalletPage from '@/pages/UnlockedWallet/UnlockedWalletPage'
 import { selectAllAddresses, selectDefaultAddress } from '@/storage/addresses/addressesSelectors'
 import { transfersPageInfoMessageClosed } from '@/storage/global/globalActions'
 import { walletSidebarWidthPx } from '@/style/globalStyles'
+import { TokenDisplay } from '@/types/tokens'
 import { links } from '@/utils/links'
 import { directionOptions } from '@/utils/transactions'
 
@@ -55,7 +55,7 @@ const TransfersPage = ({ className }: TransfersPageProps) => {
   const [direction, setDirection] = useState(scrollDirection?.get())
   const [selectedAddresses, setSelectedAddresses] = useState(addresses)
   const [selectedDirections, setSelectedDirections] = useState(directionOptions)
-  const [selectedAssets, setSelectedAssets] = useState<Asset[]>()
+  const [selectedAssets, setSelectedAssets] = useState<TokenDisplay[]>()
   const [isSendModalOpen, setIsSendModalOpen] = useState(false)
   const [isReceiveModalOpen, setIsReceiveModalOpen] = useState(false)
 

--- a/apps/desktop-wallet/src/types/tokens.ts
+++ b/apps/desktop-wallet/src/types/tokens.ts
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 - 2024 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { FungibleTokenBasicMetadata, NFT } from '@alephium/shared'
+import { TokenInfo } from '@alephium/token-list'
+
+// For better code readability
+export interface ListedFT extends TokenInfo {}
+export interface UnlistedFT extends FungibleTokenBasicMetadata {}
+export interface NonStandardToken {
+  id: string
+}
+
+// For stricter typings in our components that handle display of multiple token types
+export type TokenDisplay = ListedFTDisplay | UnlistedFTDisplay | NFTDisplay | NonStandardTokenDisplay
+
+export type ListedFTDisplay = ListedFT & {
+  type: 'listedFT'
+  worth?: number
+  balance?: bigint
+  availableBalance?: bigint
+}
+
+export type UnlistedFTDisplay = UnlistedFT & {
+  type: 'unlistedFT'
+  balance?: bigint
+  availableBalance?: bigint
+}
+
+export type NFTDisplay = NFT & {
+  type: 'NFT'
+}
+
+export type NonStandardTokenDisplay = NonStandardToken & {
+  type: 'nonStandardToken'
+  balance?: bigint
+  availableBalance?: bigint
+}


### PR DESCRIPTION
The main goal of this PR is to delete `makeSelectAddressesTokens` so that components use Tanstack data instead of Redux data.

EDIT:
Audit fails for a package with no patched version, so let's ignore.
```
│ Package             │ micromatch                                             │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <=4.0.7                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ <0.0.0                                                 │
```