### PR TITLE
First step on modals optimization refactoring

### DIFF
--- a/apps/desktop-wallet/src/App.tsx
+++ b/apps/desktop-wallet/src/App.tsx
@@ -37,6 +37,7 @@ import SplashScreen from '@/components/SplashScreen'
 import { WalletConnectContextProvider } from '@/contexts/walletconnect'
 import useAnalytics from '@/features/analytics/useAnalytics'
 import AutoUpdateSnackbar from '@/features/autoUpdate/AutoUpdateSnackbar'
+import AppModals from '@/features/modals/AppModals'
 import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import useAutoLock from '@/hooks/useAutoLock'
 import Router from '@/routes'
@@ -253,6 +254,8 @@ const App = () => {
           </CenteredSection>
         </AppContainer>
       </WalletConnectContextProvider>
+
+      <AppModals />
 
       <SnackbarManager />
       <AutoUpdateSnackbar />

--- a/apps/desktop-wallet/src/components/IOList.tsx
+++ b/apps/desktop-wallet/src/components/IOList.tsx
@@ -19,16 +19,14 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { AddressHash, GENESIS_TIMESTAMP } from '@alephium/shared'
 import { explorer } from '@alephium/web3'
 import _ from 'lodash'
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import ActionLink from '@/components/ActionLink'
 import AddressBadge from '@/components/AddressBadge'
 import Badge from '@/components/Badge'
-import { useAppSelector } from '@/hooks/redux'
-import AddressDetailsModal from '@/modals/AddressDetailsModal'
-import ModalPortal from '@/modals/ModalPortal'
+import { openModal } from '@/features/modals/modalActions'
+import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import { selectAddressIds } from '@/storage/addresses/addressesSelectors'
 import { openInWebBrowser } from '@/utils/misc'
 
@@ -56,14 +54,13 @@ const IOList = ({
   const { t } = useTranslation()
   const internalAddressHashes = useAppSelector(selectAddressIds) as AddressHash[]
   const explorerUrl = useAppSelector((state) => state.network.settings.explorerUrl)
-
-  const [selectedAddressHash, setSelectedAddressHash] = useState<AddressHash>()
+  const dispatch = useAppDispatch()
 
   const io = (isOut ? outputs : inputs) as Array<explorer.Output | explorer.Input> | undefined
 
   const handleShowAddress = (addressHash: AddressHash) =>
     internalAddressHashes.includes(addressHash)
-      ? setSelectedAddressHash(addressHash)
+      ? dispatch(openModal({ name: 'AddressDetailsModal', props: { addressHash } }))
       : openInWebBrowser(`${explorerUrl}/addresses/${addressHash}`)
 
   if (io && io.length > 0) {
@@ -102,11 +99,6 @@ const IOList = ({
             addressComponent
           )
         })}
-        <ModalPortal>
-          {selectedAddressHash && (
-            <AddressDetailsModal addressHash={selectedAddressHash} onClose={() => setSelectedAddressHash(undefined)} />
-          )}
-        </ModalPortal>
       </Addresses>
     )
   } else if (timestamp === GENESIS_TIMESTAMP) {

--- a/apps/desktop-wallet/src/features/modals/AppModals.tsx
+++ b/apps/desktop-wallet/src/features/modals/AppModals.tsx
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 - 2024 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import LazyModalRenderer from '@/features/modals/LazyModalRenderer'
+import AddressDetailsModalWrapper from '@/modals/AddressDetailsModal'
+import CSVExportModalWrapper from '@/modals/CSVExportModal'
+
+const AppModals = () => (
+  <>
+    <LazyModalRenderer name="AddressDetailsModal">
+      <AddressDetailsModalWrapper />
+    </LazyModalRenderer>
+    <LazyModalRenderer name="CSVExportModal">
+      <CSVExportModalWrapper />
+    </LazyModalRenderer>
+  </>
+)
+
+export default AppModals

--- a/apps/desktop-wallet/src/features/modals/LazyModalRenderer.tsx
+++ b/apps/desktop-wallet/src/features/modals/LazyModalRenderer.tsx
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 - 2024 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { AnimatePresence } from 'framer-motion'
+import { ReactNode } from 'react'
+
+import { selectModalState } from '@/features/modals/modalSelectors'
+import { ModalName } from '@/features/modals/modalTypes'
+import { useAppSelector } from '@/hooks/redux'
+
+interface LazyModalRendererProps {
+  name: ModalName
+  children: JSX.Element
+}
+
+const LazyModalRenderer = ({ name, children }: LazyModalRendererProps): ReactNode => {
+  const modalState = useAppSelector((s) => selectModalState(s, name))
+
+  // Avoid doing any work until the modal needs to be open
+  return <AnimatePresence>{modalState.isOpen ? children : false}</AnimatePresence>
+}
+
+export default LazyModalRenderer

--- a/apps/desktop-wallet/src/features/modals/modalActions.ts
+++ b/apps/desktop-wallet/src/features/modals/modalActions.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 - 2024 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { createAction } from '@reduxjs/toolkit'
+
+import { CloseModalParams, OpenModalParams } from '@/features/modals/modalTypes'
+
+export const openModal = createAction<OpenModalParams>('modal/openModal')
+export const closeModal = createAction<CloseModalParams>('modal/closeModal')

--- a/apps/desktop-wallet/src/features/modals/modalNames.ts
+++ b/apps/desktop-wallet/src/features/modals/modalNames.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 - 2024 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+const ModalNames = {
+  AddressDetailsModal: 'AddressDetailsModal',
+  CSVExportModal: 'CSVExportModal'
+} as const
+
+export default ModalNames

--- a/apps/desktop-wallet/src/features/modals/modalSelectors.ts
+++ b/apps/desktop-wallet/src/features/modals/modalSelectors.ts
@@ -1,0 +1,27 @@
+/*
+Copyright 2018 - 2024 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { createSelector } from '@reduxjs/toolkit'
+
+import { ModalName } from '@/features/modals/modalTypes'
+import { RootState } from '@/storage/store'
+
+export const selectModalState = createSelector(
+  [(state: RootState) => state.modals, (_, name: ModalName) => name],
+  (modals, name) => modals[name]
+)

--- a/apps/desktop-wallet/src/features/modals/modalSlice.ts
+++ b/apps/desktop-wallet/src/features/modals/modalSlice.ts
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 - 2024 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { createSlice } from '@reduxjs/toolkit'
+
+import { closeModal, openModal } from '@/features/modals/modalActions'
+import ModalNames from '@/features/modals/modalNames'
+import { ModalsState } from '@/features/modals/modalTypes'
+
+const createInitialModalState = (): ModalsState =>
+  Object.values(ModalNames).reduce(
+    (state, key) => ({
+      ...state,
+      [key]: {
+        isOpen: false,
+        props: undefined
+      }
+    }),
+    {} as ModalsState
+  )
+
+const initialModalsState: ModalsState = createInitialModalState()
+
+const modalSlice = createSlice({
+  name: 'modals',
+  initialState: initialModalsState,
+  reducers: {},
+  extraReducers(builder) {
+    builder
+      .addCase(openModal, (state, action) => {
+        const { name, props } = action.payload
+
+        state[name].isOpen = true
+        state[name].props = props
+      })
+      .addCase(closeModal, (state, action) => {
+        const { name } = action.payload
+
+        state[name].isOpen = false
+        // state[name].props = undefined // To preserve fade out animation
+      })
+  }
+})
+
+export default modalSlice

--- a/apps/desktop-wallet/src/features/modals/modalTypes.ts
+++ b/apps/desktop-wallet/src/features/modals/modalTypes.ts
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 - 2024 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import ModalNames from '@/features/modals/modalNames'
+import { AddressDetailsModalProps } from '@/modals/AddressDetailsModal'
+import { CSVExportModalProps } from '@/modals/CSVExportModal'
+
+export interface ModalsState {
+  [ModalNames.AddressDetailsModal]: AppModalState<AddressDetailsModalProps>
+  [ModalNames.CSVExportModal]: AppModalState<CSVExportModalProps>
+}
+
+export type OpenModalParams =
+  | {
+      name: typeof ModalNames.AddressDetailsModal
+      props: AddressDetailsModalProps
+    }
+  | {
+      name: typeof ModalNames.CSVExportModal
+      props: CSVExportModalProps
+    }
+
+export type ModalName = keyof ModalsState
+
+export type CloseModalParams = { name: ModalName }
+
+interface AppModalState<T> {
+  isOpen: boolean
+  props?: T
+}

--- a/apps/desktop-wallet/src/modals/CSVExportModal.tsx
+++ b/apps/desktop-wallet/src/modals/CSVExportModal.tsx
@@ -25,19 +25,29 @@ import FooterButton from '@/components/Buttons/FooterButton'
 import Select from '@/components/Inputs/Select'
 import Paragraph from '@/components/Paragraph'
 import useAnalytics from '@/features/analytics/useAnalytics'
+import { closeModal } from '@/features/modals/modalActions'
+import { selectModalState } from '@/features/modals/modalSelectors'
 import { useAppDispatch, useAppSelector } from '@/hooks/redux'
-import CenteredModal, { CenteredModalProps } from '@/modals/CenteredModal'
+import CenteredModal from '@/modals/CenteredModal'
 import { selectAddressByHash } from '@/storage/addresses/addressesSelectors'
 import { csvFileGenerationFinished, fetchTransactionsCsv } from '@/storage/transactions/transactionsActions'
 import { TransactionTimePeriod } from '@/types/transactions'
 import { generateCsvFile, getCsvExportTimeRangeQueryParams } from '@/utils/csvExport'
 import { timePeriodsOptions } from '@/utils/transactions'
 
-interface CSVExportModalProps extends CenteredModalProps {
+export interface CSVExportModalProps {
   addressHash: AddressHash
 }
 
-const CSVExportModal = ({ addressHash, ...props }: CSVExportModalProps) => {
+const CSVExportModalWrapper = () => {
+  const { props } = useAppSelector((s) => selectModalState(s, 'CSVExportModal'))
+
+  return props ? <CSVExportModal addressHash={props.addressHash} /> : null
+}
+
+export default CSVExportModalWrapper
+
+const CSVExportModal = ({ addressHash }: CSVExportModalProps) => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const { sendAnalytics } = useAnalytics()
@@ -48,8 +58,10 @@ const CSVExportModal = ({ addressHash, ...props }: CSVExportModalProps) => {
 
   if (!address) return null
 
+  const onClose = () => dispatch(closeModal({ name: 'CSVExportModal' }))
+
   const handleExportClick = () => {
-    props.onClose()
+    onClose()
     getCSVFile()
 
     sendAnalytics({ event: 'Exported CSV', props: { time_period: selectedTimePeriod } })
@@ -67,7 +79,7 @@ const CSVExportModal = ({ addressHash, ...props }: CSVExportModalProps) => {
   }
 
   return (
-    <CenteredModal title={t('Export address transactions')} subtitle={address.label || address.hash} {...props}>
+    <CenteredModal title={t('Export address transactions')} subtitle={address.label || address.hash} onClose={onClose}>
       <Paragraph>
         {t(
           'You can download the address transaction history for a selected time period. This can be useful for tax reporting.'
@@ -84,5 +96,3 @@ const CSVExportModal = ({ addressHash, ...props }: CSVExportModalProps) => {
     </CenteredModal>
   )
 }
-
-export default CSVExportModal

--- a/apps/desktop-wallet/src/modals/TransactionDetailsModal.tsx
+++ b/apps/desktop-wallet/src/modals/TransactionDetailsModal.tsx
@@ -32,9 +32,9 @@ import HashEllipsed from '@/components/HashEllipsed'
 import IOList from '@/components/IOList'
 import NFTThumbnail from '@/components/NFTThumbnail'
 import Tooltip from '@/components/Tooltip'
-import { useAppSelector } from '@/hooks/redux'
+import { openModal } from '@/features/modals/modalActions'
+import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import { useTransactionUI } from '@/hooks/useTransactionUI'
-import AddressDetailsModal from '@/modals/AddressDetailsModal'
 import ModalPortal from '@/modals/ModalPortal'
 import NFTDetailsModal from '@/modals/NFTDetailsModal'
 import SideModal from '@/modals/SideModal'
@@ -51,7 +51,6 @@ interface TransactionDetailsModalProps {
 const TransactionDetailsModal = ({ transaction, onClose }: TransactionDetailsModalProps) => {
   const { t } = useTranslation()
   const theme = useTheme()
-  const [selectedAddressHash, setSelectedAddressHash] = useState<AddressHash>()
   const [selectedNFTId, setSelectedNFTId] = useState<NFT['id']>()
   const explorerUrl = useAppSelector((state) => state.network.settings.explorerUrl)
   const allNFTs = useAppSelector((s) => s.nfts.entities)
@@ -61,6 +60,7 @@ const TransactionDetailsModal = ({ transaction, onClose }: TransactionDetailsMod
     infoType,
     isFailedScriptTx: !transaction.scriptExecutionOk
   })
+  const dispatch = useAppDispatch()
 
   const isMoved = infoType === 'move'
 
@@ -68,7 +68,7 @@ const TransactionDetailsModal = ({ transaction, onClose }: TransactionDetailsMod
 
   const handleShowAddress = (addressHash: AddressHash) =>
     internalAddressHashes.includes(addressHash)
-      ? setSelectedAddressHash(addressHash)
+      ? dispatch(openModal({ name: 'AddressDetailsModal', props: { addressHash } }))
       : openInWebBrowser(`${explorerUrl}/addresses/${addressHash}`)
 
   const [tokensWithSymbol, tokensWithoutSymbol] = partition(assets, (asset) => !!asset.symbol)
@@ -287,9 +287,6 @@ const TransactionDetailsModal = ({ transaction, onClose }: TransactionDetailsMod
       </Details>
       <Tooltip />
       <ModalPortal>
-        {selectedAddressHash && (
-          <AddressDetailsModal addressHash={selectedAddressHash} onClose={() => setSelectedAddressHash(undefined)} />
-        )}
         {selectedNFTId && <NFTDetailsModal nftId={selectedNFTId} onClose={() => setSelectedNFTId(undefined)} />}
       </ModalPortal>
     </SideModal>

--- a/apps/desktop-wallet/src/pages/UnlockedWallet/AddressesPage/AddressGridRow.tsx
+++ b/apps/desktop-wallet/src/pages/UnlockedWallet/AddressesPage/AddressGridRow.tsx
@@ -18,7 +18,6 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { AddressHash, CURRENCIES } from '@alephium/shared'
 import dayjs from 'dayjs'
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -28,9 +27,8 @@ import AddressColorIndicator from '@/components/AddressColorIndicator'
 import Amount from '@/components/Amount'
 import SkeletonLoader from '@/components/SkeletonLoader'
 import AssetsBadgesList from '@/features/assetsLists/AssetsBadgesList'
-import { useAppSelector } from '@/hooks/redux'
-import AddressDetailsModal from '@/modals/AddressDetailsModal'
-import ModalPortal from '@/modals/ModalPortal'
+import { openModal } from '@/features/modals/modalActions'
+import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import { selectAddressByHash, selectIsStateUninitialized } from '@/storage/addresses/addressesSelectors'
 import { onEnterOrSpace } from '@/utils/misc'
 
@@ -45,60 +43,52 @@ const AddressGridRow = ({ addressHash, className }: AddressGridRowProps) => {
   const stateUninitialized = useAppSelector(selectIsStateUninitialized)
   const fiatCurrency = useAppSelector((s) => s.settings.fiatCurrency)
   const { data: totalWorth, isLoading: isLoadingTotalWorth } = useAddressesTokensWorthTotal(addressHash)
-
-  const [isAddressDetailsModalOpen, setIsAddressDetailsModalOpen] = useState(false)
+  const dispatch = useAppDispatch()
 
   if (!address) return null
 
-  const openAddressDetailsModal = () => setIsAddressDetailsModalOpen(true)
+  const openAddressDetailsModal = () => dispatch(openModal({ name: 'AddressDetailsModal', props: { addressHash } }))
 
   return (
-    <>
-      <GridRow
-        key={addressHash}
-        onClick={openAddressDetailsModal}
-        onKeyDown={(e) => onEnterOrSpace(e, openAddressDetailsModal)}
-        className={className}
-        role="row"
-        tabIndex={0}
-      >
-        <AddressNameCell>
-          <AddressColorIndicator addressHash={addressHash} size={16} />
-          <Column>
-            <Label>
-              <AddressBadge addressHash={addressHash} hideColorIndication truncate disableA11y />
-            </Label>
-            {stateUninitialized ? (
-              <SkeletonLoader height="15.5px" />
-            ) : (
-              <SecondaryText>
-                {address.lastUsed ? `${t('Last activity')} ${dayjs(address.lastUsed).fromNow()}` : t('Never used')}
-              </SecondaryText>
-            )}
-          </Column>
-        </AddressNameCell>
-        <Cell>
-          <SecondaryText>
-            {t('Group')} {address.group}
-          </SecondaryText>
-        </Cell>
-        <Cell>
-          <AssetsBadgesListStyled addressHash={addressHash} simple />
-        </Cell>
-        <FiatAmountCell>
-          {stateUninitialized || isLoadingTotalWorth ? (
-            <SkeletonLoader height="18.5px" />
+    <GridRow
+      key={addressHash}
+      onClick={openAddressDetailsModal}
+      onKeyDown={(e) => onEnterOrSpace(e, openAddressDetailsModal)}
+      className={className}
+      role="row"
+      tabIndex={0}
+    >
+      <AddressNameCell>
+        <AddressColorIndicator addressHash={addressHash} size={16} />
+        <Column>
+          <Label>
+            <AddressBadge addressHash={addressHash} hideColorIndication truncate disableA11y />
+          </Label>
+          {stateUninitialized ? (
+            <SkeletonLoader height="15.5px" />
           ) : (
-            <Amount value={totalWorth} isFiat suffix={CURRENCIES[fiatCurrency].symbol} />
+            <SecondaryText>
+              {address.lastUsed ? `${t('Last activity')} ${dayjs(address.lastUsed).fromNow()}` : t('Never used')}
+            </SecondaryText>
           )}
-        </FiatAmountCell>
-      </GridRow>
-      <ModalPortal>
-        {isAddressDetailsModalOpen && (
-          <AddressDetailsModal addressHash={addressHash} onClose={() => setIsAddressDetailsModalOpen(false)} />
+        </Column>
+      </AddressNameCell>
+      <Cell>
+        <SecondaryText>
+          {t('Group')} {address.group}
+        </SecondaryText>
+      </Cell>
+      <Cell>
+        <AssetsBadgesListStyled addressHash={addressHash} simple />
+      </Cell>
+      <FiatAmountCell>
+        {stateUninitialized || isLoadingTotalWorth ? (
+          <SkeletonLoader height="18.5px" />
+        ) : (
+          <Amount value={totalWorth} isFiat suffix={CURRENCIES[fiatCurrency].symbol} />
         )}
-      </ModalPortal>
-    </>
+      </FiatAmountCell>
+    </GridRow>
   )
 }
 

--- a/apps/desktop-wallet/src/pages/UnlockedWallet/OverviewPage/AddressesList.tsx
+++ b/apps/desktop-wallet/src/pages/UnlockedWallet/OverviewPage/AddressesList.tsx
@@ -33,9 +33,8 @@ import FocusableContent from '@/components/FocusableContent'
 import SkeletonLoader from '@/components/SkeletonLoader'
 import { ExpandableTable, ExpandRow, TableHeader } from '@/components/Table'
 import TableCellAmount from '@/components/TableCellAmount'
-import { useAppSelector } from '@/hooks/redux'
-import AddressDetailsModal from '@/modals/AddressDetailsModal'
-import ModalPortal from '@/modals/ModalPortal'
+import { openModal } from '@/features/modals/modalActions'
+import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import { selectAllAddressHashes } from '@/storage/addresses/addressesSelectors'
 
 interface AddressesListProps {
@@ -75,12 +74,11 @@ const AddressesList = ({ className, maxHeightInPx }: AddressesListProps) => {
 
 const AddressesRows = ({ className, isExpanded, onExpand, onAddressClick }: AddressListProps) => {
   const addressHashes = useAppSelector(selectAllAddressHashes)
-
-  const [selectedAddress, setSelectedAddress] = useState<AddressHash>()
+  const dispatch = useAppDispatch()
 
   const handleRowClick = (addressHash: AddressHash) => {
     onAddressClick()
-    setSelectedAddress(addressHash)
+    dispatch(openModal({ name: 'AddressDetailsModal', props: { addressHash } }))
   }
 
   return (
@@ -96,12 +94,6 @@ const AddressesRows = ({ className, isExpanded, onExpand, onAddressClick }: Addr
       </motion.div>
 
       {!isExpanded && addressHashes.length > 5 && onExpand && <ExpandRow onClick={onExpand} />}
-
-      <ModalPortal>
-        {selectedAddress && (
-          <AddressDetailsModal addressHash={selectedAddress} onClose={() => setSelectedAddress(undefined)} />
-        )}
-      </ModalPortal>
     </>
   )
 }

--- a/apps/desktop-wallet/src/storage/store.ts
+++ b/apps/desktop-wallet/src/storage/store.ts
@@ -20,6 +20,7 @@ import { sharedReducer } from '@alephium/shared'
 import { configureStore } from '@reduxjs/toolkit'
 import { setupListeners } from '@reduxjs/toolkit/dist/query'
 
+import modalSlice from '@/features/modals/modalSlice'
 import addressesSlice from '@/storage/addresses/addressesSlice'
 import contactsSlice from '@/storage/addresses/contactsSlice'
 import globalSlice from '@/storage/global/globalSlice'
@@ -40,7 +41,8 @@ export const store = configureStore({
     [addressesSlice.name]: addressesSlice.reducer,
     [confirmedTransactionsSlice.name]: confirmedTransactionsSlice.reducer,
     [pendingTransactionsSlice.name]: pendingTransactionsSlice.reducer,
-    [snackbarSlice.name]: snackbarSlice.reducer
+    [snackbarSlice.name]: snackbarSlice.reducer,
+    [modalSlice.name]: modalSlice.reducer
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(settingsListenerMiddleware.middleware).concat(networkListenerMiddleware.middleware)


### PR DESCRIPTION
This is an experiment on optimizing our modals architecture. It is directly inspired by Uniswap mobile: https://github.com/Uniswap/interface/tree/main/apps/mobile/src/features/modals

The first step refactors 2 modals: 
- AddressDetailsModal
- CSVExportModal

## Pros
By moving the open/close state of a modal into Redux we decrease the number of rerenders of unrelated components that live close to the modal

## Cons
Our app allows several modals of the same type to be open at the same time. However, Uniswap's architecture does not allow rendering a modal more than onse at the same time.

An example flow that illustrates the cons is:
   1. Overview page
   2. Address list row click (opens AddressDetailsModal)
   3. Transaction list row click (opens TransactionDetailsModal)
   4. Address badge/hash click (opens AddressDetailsModal)

The above flow will cause 2 problems:
1. the AddressDetailsModal of step 2 to rendered at step 4, losing the state of step 2
2. the TransactionDetailsModal will remain on top of the rerendered AddressDetailsModal of step 4

## Ideas for future work

We could try using an array in the Redux state to represent the modals that are currently open.