### PR TITLE
Navigate to active address scan screen on metadata restore

### DIFF
--- a/apps/mobile-wallet/__tests__/wallet.test.ts
+++ b/apps/mobile-wallet/__tests__/wallet.test.ts
@@ -232,39 +232,39 @@ describe(deleteWallet, () => {
 })
 
 describe(validateAndRepareStoredWalletData, () => {
-  it('should return true if we have a mnemonic and metadata', async () => {
+  it('should be valid if we have a mnemonic and metadata', async () => {
     mockedGetItemAsync.mockResolvedValueOnce(testWalletMnemonicStored)
     await addTestWalletMetadataInStorage()
 
-    const result = await validateAndRepareStoredWalletData(mockCallback)
+    const status = await validateAndRepareStoredWalletData(mockCallback)
 
-    expect(result).toBe(true)
+    expect(status === 'valid').toBe(true)
   })
 
   it('should show correct wallet metadata restore message', async () => {
     mockedGetItemAsync.mockResolvedValueOnce(testWalletMnemonicStored) // mock stored mnemonic
     mockedGetItemAsync.mockResolvedValueOnce('mocked-timestamp') // mock stored app-installed-on-persistent
 
-    let result = await validateAndRepareStoredWalletData(mockCallback)
+    let status = await validateAndRepareStoredWalletData(mockCallback)
 
     expect(mockedGetItemAsync).toHaveBeenCalledTimes(2)
     expect(mockedGetItemAsync.mock.calls[0][0]).toBe('wallet-mnemonic-v2')
     expect(mockedGetItemAsync.mock.calls[1][0]).toBe('app-installed-on-persistent')
 
-    expect(result).toBe(false)
+    expect(status === 'awaiting-user-confirmation').toBe(true)
     expect(spyAlert).toHaveBeenCalled()
     expect(spyAlert.mock.calls[0][1]).toContain('We noticed that you deleted the app')
 
     mockedGetItemAsync.mockResolvedValueOnce(testWalletMnemonicStored) // mock stored mnemonic
     mockedGetItemAsync.mockResolvedValueOnce(null) // mock stored app-installed-on-persistent
 
-    result = await validateAndRepareStoredWalletData(mockCallback)
+    status = await validateAndRepareStoredWalletData(mockCallback)
 
     expect(mockedGetItemAsync).toHaveBeenCalledTimes(4)
     expect(mockedGetItemAsync.mock.calls[2][0]).toBe('wallet-mnemonic-v2')
     expect(mockedGetItemAsync.mock.calls[3][0]).toBe('app-installed-on-persistent')
 
-    expect(result).toBe(false)
+    expect(status === 'awaiting-user-confirmation').toBe(true)
     expect(spyAlert).toHaveBeenCalled()
     expect(spyAlert.mock.calls[1][1]).toContain("some of your app's data are missing")
   })
@@ -273,13 +273,13 @@ describe(validateAndRepareStoredWalletData, () => {
     mockedGetItemAsync.mockResolvedValueOnce(testWalletMnemonicStored) // mock stored mnemonic
     mockedGetItemAsync.mockResolvedValueOnce('mocked-timestamp') // mock stored app-installed-on-persistent
 
-    const result = await validateAndRepareStoredWalletData(mockCallback)
+    const status = await validateAndRepareStoredWalletData(mockCallback)
 
     expect(mockedGetItemAsync).toHaveBeenCalledTimes(2)
     expect(mockedGetItemAsync.mock.calls[0][0]).toBe('wallet-mnemonic-v2')
     expect(mockedGetItemAsync.mock.calls[1][0]).toBe('app-installed-on-persistent')
 
-    expect(result).toBe(false)
+    expect(status === 'awaiting-user-confirmation').toBe(true)
     expect(spyAlert).toHaveBeenCalled()
 
     const alertButtons = spyAlert.mock.calls[0][2]
@@ -320,7 +320,7 @@ describe(validateAndRepareStoredWalletData, () => {
     mockedGetItemAsync.mockResolvedValueOnce('mocked-timestamp') // mock stored app-installed-on-persistent
     mockedGetItemAsync.mockResolvedValueOnce('pinencryptedmnemonic') // mock stored pin encrypted deprecated mnemonic
 
-    const result = await validateAndRepareStoredWalletData(mockCallback)
+    const status = await validateAndRepareStoredWalletData(mockCallback)
 
     expect(mockedGetItemAsync).toHaveBeenCalledTimes(3)
     expect(mockedGetItemAsync.mock.calls[0][0]).toBe('wallet-mnemonic-v2')
@@ -332,7 +332,7 @@ describe(validateAndRepareStoredWalletData, () => {
     expect(recreatedDeprecatedWalletMetadata).toBeTruthy()
     expect(recreatedDeprecatedWalletMetadata?.addresses.length).toBe(1)
     expect(recreatedDeprecatedWalletMetadata?.addresses[0].hash).toBeUndefined() // ensure it's deprecated metadata
-    expect(result).toBe(true)
+    expect(status === 'valid').toBe(true)
   })
 
   it('should delete metadata if no mnemonic and no deprecated mnemonic is found', async () => {
@@ -341,7 +341,7 @@ describe(validateAndRepareStoredWalletData, () => {
     mockedGetItemAsync.mockResolvedValueOnce(null) // mock missing deprecated mnemonic
     await addTestWalletMetadataInStorage()
 
-    const result = await validateAndRepareStoredWalletData(mockCallback)
+    const status = await validateAndRepareStoredWalletData(mockCallback)
 
     expect(mockedGetItemAsync).toHaveBeenCalledTimes(3)
     expect(mockedGetItemAsync.mock.calls[0][0]).toBe('wallet-mnemonic-v2')
@@ -351,21 +351,21 @@ describe(validateAndRepareStoredWalletData, () => {
     const walletMetadata = await getWalletMetadata()
 
     expect(walletMetadata).toBeNull()
-    expect(result).toBe(true)
+    expect(status === 'valid').toBe(true)
   })
 
-  it('should return true if no mnemonics and no metadata are found', async () => {
+  it('should be valid if no mnemonics and no metadata are found', async () => {
     mockedGetItemAsync.mockResolvedValueOnce(null) // mock missing mnemonic
     mockedGetItemAsync.mockResolvedValueOnce(null) // mock stored app-installed-on-persistent
     mockedGetItemAsync.mockResolvedValueOnce(null) // mock missing deprecated mnemonic
 
-    const result = await validateAndRepareStoredWalletData(mockCallback)
+    const status = await validateAndRepareStoredWalletData(mockCallback)
 
     expect(mockedGetItemAsync).toHaveBeenCalledTimes(3)
     expect(mockedGetItemAsync.mock.calls[0][0]).toBe('wallet-mnemonic-v2')
     expect(mockedGetItemAsync.mock.calls[1][0]).toBe('app-installed-on-persistent')
     expect(mockedGetItemAsync.mock.calls[2][0]).toBe('wallet-pin')
 
-    expect(result).toBe(true)
+    expect(status === 'valid').toBe(true)
   })
 })

--- a/apps/mobile-wallet/locales/en-US/translation.json
+++ b/apps/mobile-wallet/locales/en-US/translation.json
@@ -372,5 +372,6 @@
   "We noticed that you deleted the app, would you like to restore your last wallet?": "We noticed that you deleted the app, would you like to restore your last wallet?",
   "Yes": "Yes",
   "No": "No",
-  "You might want to scan for active addresses in the settings.": "You might want to scan for active addresses in the settings."
+  "Welcome back to Alephium!": "Welcome back to Alephium!",
+  "Enjoy your restored wallet!": "Enjoy your restored wallet!"
 }

--- a/apps/mobile-wallet/src/App.tsx
+++ b/apps/mobile-wallet/src/App.tsx
@@ -90,8 +90,8 @@ const App = () => {
 const useShowAppContentAfterValidatingStoredWalletData = () => {
   const [state, setState] = useState({ showAppContent: false, wasMetadataRestored: false })
 
-  const onUserConfirm = useCallback(() => {
-    setState({ showAppContent: true, wasMetadataRestored: true })
+  const onUserConfirm = useCallback((userChoseYes: boolean) => {
+    setState({ showAppContent: true, wasMetadataRestored: userChoseYes })
     store.dispatch(metadataRestored())
   }, [])
 

--- a/apps/mobile-wallet/src/App.tsx
+++ b/apps/mobile-wallet/src/App.tsx
@@ -53,12 +53,13 @@ import {
 import { store } from '~/store/store'
 import { selectTransactionUnknownTokenIds } from '~/store/transactions/transactionSelectors'
 import { appLaunchedWithLastUsedWallet } from '~/store/wallet/walletActions'
+import { metadataRestored } from '~/store/wallet/walletSlice'
 import { themes } from '~/style/themes'
 
 SplashScreen.preventAutoHideAsync()
 
 const App = () => {
-  const showAppContent = useShowAppContentAfterValidatingStoredWalletData()
+  const { showAppContent, wasMetadataRestored } = useShowAppContentAfterValidatingStoredWalletData()
   const [theme, setTheme] = useState<DefaultTheme>(themes.light)
 
   useEffect(
@@ -74,7 +75,11 @@ const App = () => {
       <Main>
         <ThemeProvider theme={theme}>
           <StatusBar animated translucent style="light" />
-          {showAppContent && <RootStackNavigation />}
+          {showAppContent && (
+            <RootStackNavigation
+              initialRouteName={wasMetadataRestored ? 'ImportWalletAddressDiscoveryScreen' : undefined}
+            />
+          )}
           <ToastAnchor />
         </ThemeProvider>
       </Main>
@@ -83,11 +88,14 @@ const App = () => {
 }
 
 const useShowAppContentAfterValidatingStoredWalletData = () => {
-  const [showAppContent, setShowAppContent] = useState(false)
+  const [state, setState] = useState({ showAppContent: false, wasMetadataRestored: false })
 
-  const onUserConfirm = useCallback(() => setShowAppContent(true), [])
+  const onUserConfirm = useCallback(() => {
+    setState({ showAppContent: true, wasMetadataRestored: true })
+    store.dispatch(metadataRestored())
+  }, [])
 
-  const { data: isStoredWalletDataValid, isLoading: isValidatingStoredWalletData } = useAsyncData(
+  const { data: validationStatus, isLoading: isValidatingStoredWalletData } = useAsyncData(
     useCallback(() => validateAndRepareStoredWalletData(onUserConfirm), [onUserConfirm])
   )
 
@@ -96,10 +104,10 @@ const useShowAppContentAfterValidatingStoredWalletData = () => {
   }, [isValidatingStoredWalletData])
 
   useEffect(() => {
-    if (isStoredWalletDataValid !== undefined) setShowAppContent(isStoredWalletDataValid)
-  }, [isStoredWalletDataValid])
+    if (validationStatus === 'valid') setState({ showAppContent: true, wasMetadataRestored: false })
+  }, [validationStatus])
 
-  return showAppContent
+  return state
 }
 
 const Main = ({ children, ...props }: ViewProps) => {

--- a/apps/mobile-wallet/src/navigation/RootStackNavigation.tsx
+++ b/apps/mobile-wallet/src/navigation/RootStackNavigation.tsx
@@ -72,7 +72,11 @@ import { resetNavigation, rootStackNavigationRef } from '~/utils/navigation'
 
 const RootStack = createStackNavigator<RootStackParamList>()
 
-const RootStackNavigation = () => {
+interface RootStackNavigationProps {
+  initialRouteName?: keyof RootStackParamList
+}
+
+const RootStackNavigation = ({ initialRouteName = 'LandingScreen' }: RootStackNavigationProps) => {
   const theme = useTheme()
 
   const themeNavigator = {
@@ -94,7 +98,7 @@ const RootStackNavigation = () => {
         <NavigationContainer ref={rootStackNavigationRef} theme={themeNavigator}>
           <Analytics>
             <WalletConnectContextProvider>
-              <RootStack.Navigator initialRouteName="LandingScreen" screenOptions={{ headerShown: false }}>
+              <RootStack.Navigator initialRouteName={initialRouteName} screenOptions={{ headerShown: false }}>
                 <RootStack.Group screenOptions={{ cardStyleInterpolator: CardStyleInterpolators.forFadeFromCenter }}>
                   <RootStack.Screen name="LandingScreen" component={LandingScreen} />
                   <RootStack.Screen name="LoginWithPinScreen" component={LoginWithPinScreen} />
@@ -128,7 +132,7 @@ const RootStackNavigation = () => {
               </RootStack.Navigator>
             </WalletConnectContextProvider>
           </Analytics>
-          <AppUnlockModal />
+          <AppUnlockModal initialRouteName={initialRouteName} />
         </NavigationContainer>
       </Host>
     </GestureHandlerRootView>
@@ -137,7 +141,7 @@ const RootStackNavigation = () => {
 
 export default RootStackNavigation
 
-const AppUnlockModal = () => {
+const AppUnlockModal = ({ initialRouteName = 'InWalletTabsNavigation' }: RootStackNavigationProps) => {
   const dispatch = useAppDispatch()
   const isWalletUnlocked = useAppSelector((s) => s.wallet.isUnlocked)
   const lastUsedWalletId = useAppSelector((s) => s.wallet.id)
@@ -162,14 +166,14 @@ const AppUnlockModal = () => {
       const lastRoute = rootStackNavigationRef.current?.getCurrentRoute()?.name
 
       if (!lastRoute || ['LandingScreen', 'LoginWithPinScreen'].includes(lastRoute)) {
-        resetNavigation(navigation)
+        resetNavigation(navigation, initialRouteName)
       }
     } catch (error) {
       const message = 'Could not initialize app with stored wallet'
       showExceptionToast(error, message)
       sendAnalytics({ type: 'error', error, message })
     }
-  }, [dispatch, navigation])
+  }, [dispatch, initialRouteName, navigation])
 
   const unlockApp = useCallback(async () => {
     if (isWalletUnlocked) return

--- a/apps/mobile-wallet/src/persistent-storage/wallet.ts
+++ b/apps/mobile-wallet/src/persistent-storage/wallet.ts
@@ -60,7 +60,7 @@ const ADDRESS_PUB_KEY_PREFIX = 'address-pub-key-'
 const ADDRESS_PRIV_KEY_PREFIX = 'address-priv-key-'
 
 export const validateAndRepareStoredWalletData = async (
-  onUserConfirm: () => void
+  onUserConfirm: (userChoseYes: boolean) => void
 ): Promise<'valid' | 'invalid' | 'awaiting-user-confirmation'> => {
   let walletMetadata = await getWalletMetadata(false)
   let mnemonicV2Exists
@@ -94,7 +94,7 @@ export const validateAndRepareStoredWalletData = async (
         [
           {
             text: i18n.t('No'),
-            onPress: onUserConfirm
+            onPress: () => onUserConfirm(false)
           },
           {
             text: i18n.t('Yes'),
@@ -112,7 +112,7 @@ export const validateAndRepareStoredWalletData = async (
                 })
                 sendAnalytics({ event: 'Recreated missing wallet metadata for existing wallet' })
 
-                onUserConfirm()
+                onUserConfirm(true)
               } else {
                 showToast({
                   text1: i18n.t('Could not unlock app'),

--- a/apps/mobile-wallet/src/screens/new-wallet/NewWalletSuccessScreen.tsx
+++ b/apps/mobile-wallet/src/screens/new-wallet/NewWalletSuccessScreen.tsx
@@ -26,8 +26,7 @@ import animationSrc from '~/animations/lottie/success.json'
 import HighlightButton from '~/components/buttons/HighlightButton'
 import { ScreenProps, ScreenSection } from '~/components/layout/Screen'
 import ScrollScreen from '~/components/layout/ScrollScreen'
-import CenteredInstructions, { Instruction } from '~/components/text/CenteredInstructions'
-import i18n from '~/features/localization/i18n'
+import CenteredInstructions from '~/components/text/CenteredInstructions'
 import { useAppSelector } from '~/hooks/redux'
 import AlephiumLogo from '~/images/logos/AlephiumLogo'
 import RootStackParamList from '~/navigation/rootStackRoutes'
@@ -38,13 +37,9 @@ interface NewWalletSuccessScreenProps
   extends StackScreenProps<RootStackParamList, 'NewWalletSuccessScreen'>,
     ScreenProps {}
 
-const instructions: Instruction[] = [
-  { text: `${i18n.t('Welcome to Alephium!')} 🎉`, type: 'primary' },
-  { text: i18n.t('Enjoy your new wallet!'), type: 'secondary' }
-]
-
 const NewWalletSuccessScreen = ({ navigation, ...props }: NewWalletSuccessScreenProps) => {
   const method = useAppSelector((s) => s.walletGeneration.method)
+  const wasWalletMetadataRestored = useAppSelector((s) => s.wallet.metadataRestored)
   const theme = useTheme()
   const { t } = useTranslation()
 
@@ -62,7 +57,20 @@ const NewWalletSuccessScreen = ({ navigation, ...props }: NewWalletSuccessScreen
         <StyledAlephiumLogo color={theme.font.primary} />
         <StyledAnimation source={animationSrc} autoPlay />
       </AnimationContainer>
-      <CenteredInstructions instructions={instructions} stretch fontSize={19} />
+      <CenteredInstructions
+        instructions={[
+          {
+            text: `${t(wasWalletMetadataRestored ? 'Welcome back to Alephium!' : 'Welcome to Alephium!')} 🎉`,
+            type: 'primary'
+          },
+          {
+            text: t(wasWalletMetadataRestored ? 'Enjoy your restored wallet!' : 'Enjoy your new wallet!'),
+            type: 'secondary'
+          }
+        ]}
+        stretch
+        fontSize={19}
+      />
       <ActionsContainer>
         <ScreenSection centered>
           <HighlightButton title={t("Let's go!")} wide onPress={() => resetNavigation(navigation)} />

--- a/apps/mobile-wallet/src/store/wallet/walletSlice.ts
+++ b/apps/mobile-wallet/src/store/wallet/walletSlice.ts
@@ -35,7 +35,8 @@ const initialState: WalletState = {
   id: '',
   name: '',
   isMnemonicBackedUp: undefined,
-  isUnlocked: false
+  isUnlocked: false,
+  metadataRestored: false
 }
 
 const resetState = () => initialState
@@ -46,6 +47,9 @@ const walletSlice = createSlice({
   reducers: {
     mnemonicBackedUp: (state) => {
       state.isMnemonicBackedUp = true
+    },
+    metadataRestored: (state) => {
+      state.metadataRestored = true
     }
   },
   extraReducers: (builder) => {
@@ -72,6 +76,6 @@ const walletSlice = createSlice({
   }
 })
 
-export const { mnemonicBackedUp } = walletSlice.actions
+export const { mnemonicBackedUp, metadataRestored } = walletSlice.actions
 
 export default walletSlice

--- a/apps/mobile-wallet/src/types/wallet.ts
+++ b/apps/mobile-wallet/src/types/wallet.ts
@@ -46,6 +46,7 @@ export interface WalletStoredState {
 
 export interface WalletState extends WalletStoredState {
   isUnlocked: boolean
+  metadataRestored: boolean
 }
 
 export interface DeprecatedWalletState extends WalletState {


### PR DESCRIPTION
Given the troubles that out internal testing team had today with scanning for active addresses after walelt metadata restore I decided to change the flow and reuse part of the wallet generation flow on metadata restore with some nicer, friendlier messages.

## Before

<details><summary>Click to expand screenshot</summary>

<img src="https://github.com/user-attachments/assets/23a49b5f-0dfc-41d1-b485-3ad66ae3d7e5" width="350" />

</details>

## After

| Step 1 | Step 2 | Step 3 | Step 4
| ----- | ----- | ----- | ----- |
| ![image](https://github.com/user-attachments/assets/583cecb0-1eb2-43b9-80a2-1d5d18608611) | ![image](https://github.com/user-attachments/assets/df6f2bc7-8140-466b-bd64-646aadf753e8) | ![image](https://github.com/user-attachments/assets/1c27b1ae-f034-4375-859c-32b67f568f2c) | ![image](https://github.com/user-attachments/assets/87b3bdb9-797c-4651-afc1-32c076ae2512) |

