### PR TITLE
Add `outputs` field for Explorer turbo config

### DIFF
--- a/apps/explorer/turbo.json
+++ b/apps/explorer/turbo.json
@@ -2,7 +2,8 @@
   "extends": ["//"],
   "pipeline": {
     "build": {
-      "env": ["VITE_NETWORK_TYPE", "VITE_BACKEND_URL", "VITE_NODE_URL", "BASE_URL"]
+      "env": ["VITE_NETWORK_TYPE", "VITE_BACKEND_URL", "VITE_NODE_URL", "BASE_URL"],
+      "outputs": ["build/**"]
     },
     "start:app": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
CI pipeline for deploying Explorer is consistently failing, the reason seems to be that the `build` directory is not generated after running `pnpm ci:build`. 

I am not sure when/where this has become an issue, adding the `outputs` fields in turbo config fixes this.
