### PR TITLE
Show toast when failing to authenticate

### DIFF
--- a/.changeset/clean-rules-greet.md
+++ b/.changeset/clean-rules-greet.md
@@ -1,0 +1,5 @@
+---
+"@alephium/mobile-wallet": patch
+---
+
+Show biometrics auth error to user

--- a/apps/mobile-wallet/src/hooks/useBiometrics.ts
+++ b/apps/mobile-wallet/src/hooks/useBiometrics.ts
@@ -56,7 +56,7 @@ export enum BiometricAuthenticationStatus {
 type TriggerArgs<T> = {
   params?: T
   successCallback?: (params?: T) => void
-  failureCallback?: () => void
+  failureCallback?: (message: string) => void
 }
 
 /**
@@ -91,7 +91,7 @@ type TriggerArgs<T> = {
  */
 export function useBiometricPrompt<T = undefined>(
   successCallback?: (params?: T) => void,
-  failureCallback?: () => void
+  failureCallback?: (message: string) => void
 ): {
   triggerBiometricsPrompt: (args?: TriggerArgs<T>) => Promise<void>
 } {
@@ -104,7 +104,7 @@ export function useBiometricPrompt<T = undefined>(
     if (biometricAuthenticationSuccessful(authStatus) || biometricAuthenticationDisabledByOS(authStatus)) {
       _successCallback?.(args?.params)
     } else {
-      _failureCallback?.()
+      _failureCallback?.(authStatus.toString())
     }
   }
 
@@ -173,7 +173,7 @@ export const useBiometricsAuthGuard = () => {
     }: {
       settingsToCheck: 'appAccess' | 'transactions' | 'appAccessOrTransactions'
       successCallback: () => void
-      failureCallback?: () => void
+      failureCallback?: (message: string) => void
       onPromptDisplayed?: () => void
     }) => {
       const isBiometricsAuthRequired = {

--- a/apps/mobile-wallet/src/navigation/RootStackNavigation.tsx
+++ b/apps/mobile-wallet/src/navigation/RootStackNavigation.tsx
@@ -26,6 +26,7 @@ import { Host } from 'react-native-portalize'
 import { useTheme } from 'styled-components/native'
 
 import { Analytics, sendAnalytics } from '~/analytics'
+import ToastAnchor from '~/components/toasts/ToastAnchor'
 import { WalletConnectContextProvider } from '~/contexts/walletConnect/WalletConnectContext'
 import useAutoLock from '~/features/auto-lock/useAutoLock'
 import FundPasswordScreen from '~/features/fund-password/FundPasswordScreen'
@@ -189,7 +190,9 @@ const AppUnlockModal = ({ initialRouteName }: Required<RootStackNavigationProps>
         try {
           await triggerBiometricsAuthGuard({
             settingsToCheck: 'appAccess',
-            successCallback: initializeAppWithStoredWallet
+            successCallback: initializeAppWithStoredWallet,
+            failureCallback: (message: string) =>
+              showToast({ type: 'error', text1: 'Biometrics authentication failed', text2: message })
           })
 
           if (deprecatedWallet) {
@@ -266,6 +269,7 @@ const AppUnlockModal = ({ initialRouteName }: Required<RootStackNavigationProps>
       <View style={{ backgroundColor: 'black', flex: 1 }}>
         <CoolAlephiumCanvas {...dimensions} onPress={unlockApp} />
       </View>
+      <ToastAnchor />
     </Modal>
   )
 }


### PR DESCRIPTION
People still seem to have problems with infinite auth loops: https://github.com/alephium/alephium-frontend/issues/695

This PR shows a tooltip when the auth fails with a message, hoping that it will help us get better feedback.