### PR TITLE
Add clickable NFT name and total worth in Send modal flow

### DIFF
--- a/.changeset/late-squids-smoke.md
+++ b/.changeset/late-squids-smoke.md
@@ -1,0 +1,5 @@
+---
+"alephium-desktop-wallet": patch
+---
+
+Display total transaction worth when sending

--- a/.changeset/selfish-apricots-give.md
+++ b/.changeset/selfish-apricots-give.md
@@ -1,0 +1,5 @@
+---
+"alephium-desktop-wallet": patch
+---
+
+Display address derivation path in developer tools

--- a/.changeset/thick-coins-breathe.md
+++ b/.changeset/thick-coins-breathe.md
@@ -1,0 +1,5 @@
+---
+"alephium-desktop-wallet": patch
+---
+
+Improve NFT sending flow

--- a/apps/desktop-wallet/locales/en-US/translation.json
+++ b/apps/desktop-wallet/locales/en-US/translation.json
@@ -481,5 +481,6 @@
   "If you choose to forget an address with assets, you can always re-add it to your wallet using the \"Discover active addresses\" feature.": "If you choose to forget an address with assets, you can always re-add it to your wallet using the \"Discover active addresses\" feature.",
   "This will remove {{ num }} address(es) from your address list.": "This will remove {{ num }} address(es) from your address list.",
   "Forget selected addresses": "Forget selected addresses",
-  "You only have one address. You cannot forget it.": "You only have one address. You cannot forget it."
+  "You only have one address. You cannot forget it.": "You only have one address. You cannot forget it.",
+  "Total worth": "Total worth"
 }

--- a/apps/desktop-wallet/package.json
+++ b/apps/desktop-wallet/package.json
@@ -63,6 +63,7 @@
     "@alephium/typescript-config": "workspace:*",
     "@alephium/walletconnect-provider": "1.5.1",
     "@alephium/web3": "1.5.1",
+    "@alephium/web3-wallet": "1.5.1",
     "@electron/notarize": "^1.2.3",
     "@json-rpc-tools/utils": "^1.7.6",
     "@reduxjs/toolkit": "^1.9.1",

--- a/apps/desktop-wallet/src/components/AddressRow.tsx
+++ b/apps/desktop-wallet/src/components/AddressRow.tsx
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { AddressHash } from '@alephium/shared'
+import { ReactNode } from 'react'
 import styled from 'styled-components'
 
 import AddressBadge from '@/components/AddressBadge'
@@ -27,9 +28,11 @@ interface AddressRowProps {
   addressHash: AddressHash
   onClick?: (addressHash: AddressHash) => void
   className?: string
+  subtitle?: string
+  children?: ReactNode
 }
 
-const AddressRow: FC<AddressRowProps> = ({ addressHash, onClick, children, className }) => (
+const AddressRow = ({ addressHash, onClick, children, className, subtitle }: AddressRowProps) => (
   <TableRow
     key={addressHash}
     role="row"
@@ -42,6 +45,7 @@ const AddressRow: FC<AddressRowProps> = ({ addressHash, onClick, children, class
       <AddressColorIndicatorStyled addressHash={addressHash} />
       <Label>
         <AddressBadge addressHash={addressHash} hideColorIndication truncate appendHash displayHashUnder />
+        <AddressSubtitle>{subtitle}</AddressSubtitle>
       </Label>
       {children}
     </Row>
@@ -64,4 +68,10 @@ const Label = styled.div`
   font-size: 14px;
   font-weight: var(--fontWeight-medium);
   max-width: 120px;
+`
+
+const AddressSubtitle = styled.span`
+  font-family: 'Roboto Mono';
+  font-size: 12px;
+  color: ${({ theme }) => theme.font.tertiary};
 `

--- a/apps/desktop-wallet/src/features/send/CheckAmountsBox.tsx
+++ b/apps/desktop-wallet/src/features/send/CheckAmountsBox.tsx
@@ -121,7 +121,8 @@ const FiatAmount = ({ symbol, amount, decimals }: FiatAmountProps) => {
 }
 
 const FiatAmountStyled = styled(Amount)`
-  color: ${({ theme }) => theme.font.highlight};
+  color: ${({ theme }) => theme.font.secondary};
+  font-weight: var(--font-weight-medium);
 `
 
 const AssetAmountRowStyled = styled.div`

--- a/apps/desktop-wallet/src/features/send/CheckAmountsBox.tsx
+++ b/apps/desktop-wallet/src/features/send/CheckAmountsBox.tsx
@@ -29,7 +29,9 @@ import Amount from '@/components/Amount'
 import AssetLogo from '@/components/AssetLogo'
 import Box from '@/components/Box'
 import HorizontalDivider from '@/components/Dividers/HorizontalDivider'
+import { openModal } from '@/features/modals/modalActions'
 import { getTransactionAssetAmounts } from '@/features/send/sendUtils'
+import { useAppDispatch } from '@/hooks/redux'
 import { links } from '@/utils/links'
 import { openInWebBrowser } from '@/utils/misc'
 
@@ -50,7 +52,7 @@ const CheckAmountsBox = ({ assetAmounts, className }: CheckAmountsBoxProps) => {
       {assets.map((asset, index) => (
         <Fragment key={asset.id}>
           {index > 0 && <HorizontalDivider />}
-          <AssetAmountRowComponent tokenId={asset.id} amount={asset.amount} extraAlphForDust={extraAlphForDust} />
+          <AssetAmountRow tokenId={asset.id} amount={asset.amount} extraAlphForDust={extraAlphForDust} />
         </Fragment>
       ))}
     </Box>
@@ -59,23 +61,29 @@ const CheckAmountsBox = ({ assetAmounts, className }: CheckAmountsBoxProps) => {
 
 export default CheckAmountsBox
 
-interface AssetAmountRowComponentProps {
+interface AssetAmountRowProps {
   tokenId: string
   amount: string
   extraAlphForDust: bigint
 }
 
-const AssetAmountRowComponent = ({ tokenId, amount, extraAlphForDust }: AssetAmountRowComponentProps) => {
+const AssetAmountRow = ({ tokenId, amount, extraAlphForDust }: AssetAmountRowProps) => {
   const { t } = useTranslation()
   const { data: token } = useFetchToken(tokenId)
+  const dispatch = useAppDispatch()
+
+  const handleRowClick = () => {
+    if (isNFT(token)) dispatch(openModal({ name: 'NFTDetailsModal', props: { nftId: tokenId } }))
+  }
 
   return (
-    <AssetAmountRow>
+    <AssetAmountRowStyled onClick={isNFT(token) ? handleRowClick : undefined}>
       <AssetLogo tokenId={tokenId} size={30} />
 
       <TokenText>
         {isNFT(token) ? token.name : <Amount tokenId={tokenId} value={BigInt(amount)} fullPrecision />}
       </TokenText>
+
       {tokenId === ALPH.id && !!extraAlphForDust && (
         <ActionLink
           onClick={() => openInWebBrowser(links.utxoDust)}
@@ -86,16 +94,18 @@ const AssetAmountRowComponent = ({ tokenId, amount, extraAlphForDust }: AssetAmo
           <Info size={20} />
         </ActionLink>
       )}
-    </AssetAmountRow>
+    </AssetAmountRowStyled>
   )
 }
 
-const AssetAmountRow = styled.div`
+const AssetAmountRowStyled = styled.div`
   display: flex;
   padding: 23px 0;
   justify-content: center;
   align-items: center;
   gap: 15px;
+
+  cursor: ${({ onClick }) => (onClick ? 'pointer' : 'default')};
 `
 
 const TokenText = styled.span`

--- a/apps/desktop-wallet/src/features/send/CheckAmountsBox.tsx
+++ b/apps/desktop-wallet/src/features/send/CheckAmountsBox.tsx
@@ -16,14 +16,15 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AssetAmount, toHumanReadableAmount } from '@alephium/shared'
+import { AssetAmount, calculateAmountWorth, toHumanReadableAmount } from '@alephium/shared'
 import { ALPH } from '@alephium/token-list'
 import { Info } from 'lucide-react'
 import { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
-import useFetchToken, { isNFT } from '@/api/apiDataHooks/token/useFetchToken'
+import { useFetchTokenPrice } from '@/api/apiDataHooks/market/useFetchTokenPrices'
+import useFetchToken, { isFT, isNFT } from '@/api/apiDataHooks/token/useFetchToken'
 import ActionLink from '@/components/ActionLink'
 import Amount from '@/components/Amount'
 import AssetLogo from '@/components/AssetLogo'
@@ -78,37 +79,74 @@ const AssetAmountRow = ({ tokenId, amount, extraAlphForDust }: AssetAmountRowPro
 
   return (
     <AssetAmountRowStyled onClick={isNFT(token) ? handleRowClick : undefined}>
-      <AssetLogo tokenId={tokenId} size={30} />
+      <LogoAndName>
+        <AssetLogo tokenId={tokenId} size={30} />
 
-      <TokenText>
-        {isNFT(token) ? token.name : <Amount tokenId={tokenId} value={BigInt(amount)} fullPrecision />}
-      </TokenText>
+        {(isFT(token) || isNFT(token)) && <TokenName>{token.name}</TokenName>}
 
-      {tokenId === ALPH.id && !!extraAlphForDust && (
-        <ActionLink
-          onClick={() => openInWebBrowser(links.utxoDust)}
-          tooltip={t('{{ amount }} ALPH are added for UTXO spam prevention. Click here to know more.', {
-            amount: toHumanReadableAmount(extraAlphForDust)
-          })}
-        >
-          <Info size={20} />
-        </ActionLink>
+        {tokenId === ALPH.id && !!extraAlphForDust && (
+          <ActionLink
+            onClick={() => openInWebBrowser(links.utxoDust)}
+            tooltip={t('{{ amount }} ALPH are added for UTXO spam prevention. Click here to know more.', {
+              amount: toHumanReadableAmount(extraAlphForDust)
+            })}
+          >
+            <Info size={16} />
+          </ActionLink>
+        )}
+      </LogoAndName>
+
+      {!isNFT(token) && (
+        <TokenAmount>
+          <Amount tokenId={tokenId} value={BigInt(amount)} fullPrecision />
+          {isFT(token) && <FiatAmount symbol={token.symbol} amount={BigInt(amount)} decimals={token.decimals} />}
+        </TokenAmount>
       )}
     </AssetAmountRowStyled>
   )
 }
 
+interface FiatAmountProps {
+  symbol: string
+  amount: bigint
+  decimals: number
+}
+
+const FiatAmount = ({ symbol, amount, decimals }: FiatAmountProps) => {
+  const { data: tokenPrice, isLoading: isLoadingTokenPrice } = useFetchTokenPrice(symbol)
+
+  const worth = tokenPrice?.price !== undefined ? calculateAmountWorth(amount, tokenPrice.price, decimals) : undefined
+
+  return <FiatAmountStyled value={worth} isFiat isLoading={isLoadingTokenPrice} />
+}
+
+const FiatAmountStyled = styled(Amount)`
+  color: ${({ theme }) => theme.font.highlight};
+`
+
 const AssetAmountRowStyled = styled.div`
   display: flex;
-  padding: 23px 0;
-  justify-content: center;
+  padding: 18px 15px;
   align-items: center;
+  justify-content: space-between;
   gap: 15px;
 
   cursor: ${({ onClick }) => (onClick ? 'pointer' : 'default')};
 `
 
-const TokenText = styled.span`
-  font-weight: var(--fontWeight-semiBold);
-  font-size: 26px;
+const TokenName = styled.span`
+  font-size: 16px;
+`
+
+const LogoAndName = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+`
+
+const TokenAmount = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--spacing-1);
 `

--- a/apps/desktop-wallet/src/features/send/CheckAmountsBox.tsx
+++ b/apps/desktop-wallet/src/features/send/CheckAmountsBox.tsx
@@ -136,7 +136,8 @@ const AssetAmountRowStyled = styled.div`
 `
 
 const TokenName = styled.span`
-  font-size: 16px;
+  font-size: 14px;
+  font-weight: var(--fontWeight-medium);
 `
 
 const LogoAndName = styled.div`

--- a/apps/desktop-wallet/src/features/send/CheckWorthBox.tsx
+++ b/apps/desktop-wallet/src/features/send/CheckWorthBox.tsx
@@ -69,5 +69,5 @@ const CheckWorthBox = ({ assetAmounts }: CheckWorthBoxProps) => {
 export default CheckWorthBox
 
 const AmountStyled = styled(Amount)`
-  color: ${({ theme }) => theme.font.highlight};
+  color: ${({ theme }) => theme.font.primary};
 `

--- a/apps/desktop-wallet/src/features/send/CheckWorthBox.tsx
+++ b/apps/desktop-wallet/src/features/send/CheckWorthBox.tsx
@@ -19,6 +19,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { AssetAmount, calculateAmountWorth } from '@alephium/shared'
 import { ALPH } from '@alephium/token-list'
 import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
 
 import useFetchTokenPrices from '@/api/apiDataHooks/market/useFetchTokenPrices'
 import useFetchTokensSeparatedByType from '@/api/apiDataHooks/utils/useFetchTokensSeparatedByType'
@@ -54,10 +55,19 @@ const CheckWorthBox = ({ assetAmounts }: CheckWorthBoxProps) => {
   return (
     <Box>
       <InfoRow label={t('Total worth')}>
-        <Amount tokenId={ALPH.id} value={totalWorth} isFiat isLoading={isLoadingTokensByType || isLoadingTokenPrices} />
+        <AmountStyled
+          tokenId={ALPH.id}
+          value={totalWorth}
+          isFiat
+          isLoading={isLoadingTokensByType || isLoadingTokenPrices}
+        />
       </InfoRow>
     </Box>
   )
 }
 
 export default CheckWorthBox
+
+const AmountStyled = styled(Amount)`
+  color: ${({ theme }) => theme.font.highlight};
+`

--- a/apps/desktop-wallet/src/features/send/CheckWorthBox.tsx
+++ b/apps/desktop-wallet/src/features/send/CheckWorthBox.tsx
@@ -1,0 +1,63 @@
+/*
+Copyright 2018 - 2024 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { AssetAmount, calculateAmountWorth } from '@alephium/shared'
+import { ALPH } from '@alephium/token-list'
+import { useTranslation } from 'react-i18next'
+
+import useFetchTokenPrices from '@/api/apiDataHooks/market/useFetchTokenPrices'
+import useFetchTokensSeparatedByType from '@/api/apiDataHooks/utils/useFetchTokensSeparatedByType'
+import Amount from '@/components/Amount'
+import Box from '@/components/Box'
+import InfoRow from '@/features/send/InfoRow'
+
+interface CheckWorthBoxProps {
+  assetAmounts: AssetAmount[]
+}
+
+const CheckWorthBox = ({ assetAmounts }: CheckWorthBoxProps) => {
+  const { t } = useTranslation()
+
+  const {
+    data: { listedFts },
+    isLoading: isLoadingTokensByType
+  } = useFetchTokensSeparatedByType(assetAmounts)
+
+  const { data: tokenPrices, isLoading: isLoadingTokenPrices } = useFetchTokenPrices()
+
+  const totalWorth = listedFts.reduce((totalWorth, token) => {
+    const tokenPrice = tokenPrices?.find(({ symbol }) => symbol === token.symbol)?.price
+    const tokenAmount = assetAmounts.find((asset) => asset.id === token.id)?.amount
+    const tokenWorth =
+      tokenPrice !== undefined && tokenAmount !== undefined
+        ? calculateAmountWorth(tokenAmount, tokenPrice, token.decimals)
+        : 0
+
+    return totalWorth + tokenWorth
+  }, 0)
+
+  return (
+    <Box>
+      <InfoRow label={t('Total worth')}>
+        <Amount tokenId={ALPH.id} value={totalWorth} isFiat isLoading={isLoadingTokensByType || isLoadingTokenPrices} />
+      </InfoRow>
+    </Box>
+  )
+}
+
+export default CheckWorthBox

--- a/apps/desktop-wallet/src/features/send/sendModals/callContract/CheckTxModalContent.tsx
+++ b/apps/desktop-wallet/src/features/send/sendModals/callContract/CheckTxModalContent.tsx
@@ -24,6 +24,7 @@ import CheckAddressesBox from '@/features/send/CheckAddressesBox'
 import CheckAmountsBox from '@/features/send/CheckAmountsBox'
 import CheckFeeLockTimeBox from '@/features/send/CheckFeeLockTimeBox'
 import CheckModalContent from '@/features/send/CheckModalContent'
+import CheckWorthBox from '@/features/send/CheckWorthBox'
 import { CallContractTxData, CheckTxProps } from '@/features/send/sendTypes'
 import { useAppSelector } from '@/hooks/redux'
 
@@ -35,6 +36,7 @@ const CallContractCheckTxModalContent = ({ data, fees, onSubmit }: CheckTxProps<
     <>
       <CheckModalContent>
         {data.assetAmounts && <CheckAmountsBox assetAmounts={data.assetAmounts} />}
+        {data.assetAmounts && <CheckWorthBox assetAmounts={data.assetAmounts} />}
         <CheckAddressesBox fromAddress={data.fromAddress} />
         <CheckFeeLockTimeBox fee={fees} />
         <InfoBox label={t('Bytecode')} text={data.bytecode} wordBreak />

--- a/apps/desktop-wallet/src/features/send/sendModals/deployContract/CheckTxModalContent.tsx
+++ b/apps/desktop-wallet/src/features/send/sendModals/deployContract/CheckTxModalContent.tsx
@@ -25,6 +25,7 @@ import CheckAddressesBox from '@/features/send/CheckAddressesBox'
 import CheckAmountsBox from '@/features/send/CheckAmountsBox'
 import CheckFeeLockTimeBox from '@/features/send/CheckFeeLockTimeBox'
 import CheckModalContent from '@/features/send/CheckModalContent'
+import CheckWorthBox from '@/features/send/CheckWorthBox'
 import InfoRow from '@/features/send/InfoRow'
 import { CheckTxProps, DeployContractTxData } from '@/features/send/sendTypes'
 import { useAppSelector } from '@/hooks/redux'
@@ -36,7 +37,12 @@ const DeployContractCheckTxModalContent = ({ data, fees, onSubmit }: CheckTxProp
   return (
     <>
       <CheckModalContent>
-        {data.initialAlphAmount && <CheckAmountsBox assetAmounts={[data.initialAlphAmount]} />}
+        {data.initialAlphAmount && (
+          <>
+            <CheckAmountsBox assetAmounts={[data.initialAlphAmount]} />
+            <CheckWorthBox assetAmounts={[data.initialAlphAmount]} />
+          </>
+        )}
         <CheckAddressesBox fromAddress={data.fromAddress} />
         {data.issueTokenAmount && (
           <Box>

--- a/apps/desktop-wallet/src/features/send/sendModals/transfer/CheckTxModalContent.tsx
+++ b/apps/desktop-wallet/src/features/send/sendModals/transfer/CheckTxModalContent.tsx
@@ -24,6 +24,7 @@ import CheckAddressesBox from '@/features/send/CheckAddressesBox'
 import CheckAmountsBox from '@/features/send/CheckAmountsBox'
 import CheckFeeLocktimeBox from '@/features/send/CheckFeeLockTimeBox'
 import CheckModalContent from '@/features/send/CheckModalContent'
+import CheckWorthBox from '@/features/send/CheckWorthBox'
 import { CheckTxProps, TransferTxData } from '@/features/send/sendTypes'
 import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 
@@ -42,6 +43,7 @@ const TransferCheckTxModalContent = ({ data, fees, onSubmit }: CheckTxProps<Tran
     <>
       <CheckModalContent>
         <CheckAmountsBox assetAmounts={data.assetAmounts} />
+        <CheckWorthBox assetAmounts={data.assetAmounts} />
         <CheckAddressesBox fromAddress={data.fromAddress} toAddressHash={data.toAddress} />
         <CheckFeeLocktimeBox fee={fees} lockTime={data.lockTime} />
       </CheckModalContent>

--- a/apps/desktop-wallet/src/modals/SettingsModal/DevToolsSettingsSection.tsx
+++ b/apps/desktop-wallet/src/modals/SettingsModal/DevToolsSettingsSection.tsx
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { AddressHash, getHumanReadableError } from '@alephium/shared'
+import { getSecp259K1Path } from '@alephium/web3-wallet'
 import { AlertOctagon, Download, FileCode, TerminalSquare } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -132,7 +133,7 @@ const DevToolsSettingsSection = () => {
             <Paragraph>{t('Copy the keys of an address.')}</Paragraph>
             <Table>
               {addresses.map((address) => (
-                <AddressRow addressHash={address.hash} key={address.hash}>
+                <AddressRow addressHash={address.hash} key={address.hash} subtitle={getSecp259K1Path(address.index)}>
                   <Buttons>
                     <ButtonStyled role="secondary" short onClick={() => copyPublicKey(address)}>
                       {t('Public key')}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       '@alephium/web3':
         specifier: 1.5.1
         version: 1.5.1
+      '@alephium/web3-wallet':
+        specifier: 1.5.1
+        version: 1.5.1
       '@electron/notarize':
         specifier: ^1.2.3
         version: 1.2.4


### PR DESCRIPTION
In the context of closing #77 which is partially implemented in `next-tanstack` I would like to merge these small changes:

| before | after |
| ----- | ----- |
| <img width="635" alt="image" src="https://github.com/user-attachments/assets/9be27e1e-8de9-4c72-916c-702d240fbd00"> | <img width="636" alt="image" src="https://github.com/user-attachments/assets/05d24b69-1206-48b9-807b-4dcec44a4366"> |


EDIT: I also added this feature that will make our users who asked for it happy:
- #630
- https://github.com/alephium/alephium-frontend/discussions/432

| before | after |
| ----- | ----- |
| <img width="644" alt="image" src="https://github.com/user-attachments/assets/af0e7264-8f3d-40a6-ae43-df7d46daa215"> | <img width="629" alt="image" src="https://github.com/user-attachments/assets/e49bb84f-6594-40fb-b1fc-3aa9d4b23b39"> |

Closes #630