### PR TITLE
Remove app reload and update gcTime

### DIFF
--- a/apps/desktop-wallet/public/electron.js
+++ b/apps/desktop-wallet/public/electron.js
@@ -326,10 +326,6 @@ app.on('ready', async function () {
     deepLinkUri = null
   })
 
-  ipcMain.handle('app:reload', () => {
-    mainWindow.reload()
-  })
-
   createWindow()
 })
 

--- a/apps/desktop-wallet/public/preload.js
+++ b/apps/desktop-wallet/public/preload.js
@@ -66,7 +66,6 @@ contextBridge.exposeInMainWorld('electron', {
     show: () => ipcRenderer.invoke('app:show'),
     getSystemLanguage: () => ipcRenderer.invoke('app:getSystemLanguage'),
     setProxySettings: (proxySettings) => ipcRenderer.invoke('app:setProxySettings', proxySettings),
-    restart: () => ipcRenderer.invoke('app:restart'),
-    reload: () => ipcRenderer.invoke('app:reload')
+    restart: () => ipcRenderer.invoke('app:restart')
   }
 })

--- a/apps/desktop-wallet/src/api/apiDataHooks/utils/useFetchFtList.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/utils/useFetchFtList.ts
@@ -23,8 +23,6 @@ import axios from 'axios'
 
 import { useAppSelector } from '@/hooks/redux'
 
-const TOKEN_LIST_QUERY_KEY = 'tokenList'
-
 export interface FTList {
   data: TokenList['tokens'] | undefined
   isLoading: boolean
@@ -39,13 +37,14 @@ const useFetchFtList = (props?: FTListProps): FTList => {
   const network = networkId === 0 ? 'mainnet' : networkId === 1 ? 'testnet' : undefined
 
   const { data, isLoading } = useQuery({
-    queryKey: [TOKEN_LIST_QUERY_KEY, network],
+    queryKey: ['tokenList', network],
+    staleTime: ONE_DAY_MS,
+    gcTime: Infinity,
     queryFn:
       !network || props?.skip
         ? skipToken
         : () => axios.get(getTokensURL(network)).then(({ data }) => (data as TokenList)?.tokens),
-    placeholderData: network === 'mainnet' ? mainnet.tokens : network === 'testnet' ? testnet.tokens : [],
-    staleTime: ONE_DAY_MS
+    placeholderData: network === 'mainnet' ? mainnet.tokens : network === 'testnet' ? testnet.tokens : []
   })
 
   // TODO: Maybe return an object instead of an array for faster search?

--- a/apps/desktop-wallet/src/api/queries/addressQueries.ts
+++ b/apps/desktop-wallet/src/api/queries/addressQueries.ts
@@ -33,6 +33,8 @@ export type AddressAlphBalancesQueryFnData = {
 export const addressAlphBalancesQuery = ({ addressHash, networkId, skip }: AddressLatestTransactionQueryProps) =>
   queryOptions({
     queryKey: ['address', addressHash, 'balance', 'ALPH', { networkId }],
+    staleTime: Infinity,
+    gcTime: Infinity,
     queryFn: !skip
       ? async () => {
           const balances = await throttledClient.explorer.addresses.getAddressesAddressBalance(addressHash)
@@ -46,8 +48,7 @@ export const addressAlphBalancesQuery = ({ addressHash, networkId, skip }: Addre
             }
           }
         }
-      : skipToken,
-    staleTime: Infinity
+      : skipToken
   })
 
 export type AddressTokensBalancesQueryFnData = {
@@ -58,6 +59,8 @@ export type AddressTokensBalancesQueryFnData = {
 export const addressTokensBalancesQuery = ({ addressHash, networkId, skip }: AddressLatestTransactionQueryProps) =>
   queryOptions({
     queryKey: ['address', addressHash, 'balance', 'tokens', { networkId }],
+    staleTime: Infinity,
+    gcTime: Infinity,
     queryFn: !skip
       ? async () => {
           const tokenBalances = [] as TokenDisplayBalances[]
@@ -89,7 +92,5 @@ export const addressTokensBalancesQuery = ({ addressHash, networkId, skip }: Add
             balances: tokenBalances
           }
         }
-      : skipToken,
-
-    staleTime: Infinity
+      : skipToken
   })

--- a/apps/desktop-wallet/src/api/queries/priceQueries.ts
+++ b/apps/desktop-wallet/src/api/queries/priceQueries.ts
@@ -16,39 +16,26 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { ONE_MINUTE_MS, throttledClient } from '@alephium/shared'
-import { ALPH } from '@alephium/token-list'
+import { FIVE_MINUTES_MS, ONE_MINUTE_MS, throttledClient } from '@alephium/shared'
 import { queryOptions, skipToken } from '@tanstack/react-query'
 
 import { SkipProp } from '@/api/apiDataHooks/apiDataHooksTypes'
-import queryClient from '@/api/queryClient'
 
 interface TokensPriceQueryProps extends SkipProp {
   symbols: string[]
   currency: string
 }
 
-const TOKEN_PRICES_KEY = 'tokenPrices'
+export const tokensPriceQuery = ({ symbols, currency, skip }: TokensPriceQueryProps) =>
+  queryOptions({
+    queryKey: ['tokenPrices', 'currentPrice', symbols, { currency }],
+    refetchInterval: ONE_MINUTE_MS,
+    gcTime: FIVE_MINUTES_MS,
+    queryFn: !skip
+      ? async () => {
+          const prices = await throttledClient.explorer.market.postMarketPrices({ currency }, symbols)
 
-export const tokensPriceQuery = ({ symbols, currency, skip }: TokensPriceQueryProps) => {
-  const getQueryOptions = (_symbols: TokensPriceQueryProps['symbols']) =>
-    queryOptions({
-      queryKey: [TOKEN_PRICES_KEY, 'currentPrice', _symbols, { currency }],
-      queryFn: !skip
-        ? async () => {
-            const prices = await throttledClient.explorer.market.postMarketPrices({ currency }, _symbols)
-
-            return prices.map((price, i) => ({ price, symbol: _symbols[i] }))
-          }
-        : skipToken,
-      refetchInterval: ONE_MINUTE_MS
-    })
-
-  const previousQueryKey = getQueryOptions([ALPH.symbol]).queryKey
-  const latestQueryOptions = getQueryOptions(symbols)
-
-  return queryOptions({
-    ...latestQueryOptions,
-    placeholderData: queryClient.getQueryData(previousQueryKey)
+          return prices.map((price, i) => ({ price, symbol: symbols[i] }))
+        }
+      : skipToken
   })
-}

--- a/apps/desktop-wallet/src/api/queries/tokenQueries.ts
+++ b/apps/desktop-wallet/src/api/queries/tokenQueries.ts
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { batchers, ONE_DAY_MS, throttledClient } from '@alephium/shared'
+import { batchers, ONE_DAY_MS } from '@alephium/shared'
 import { explorer, NFTMetaData, NFTTokenUriMetaData } from '@alephium/web3'
 import { TokenInfo, TokenStdInterfaceId } from '@alephium/web3/dist/src/api/api-explorer'
 import { queryOptions, skipToken, UseQueryResult } from '@tanstack/react-query'
@@ -42,6 +42,8 @@ interface NFTQueryProps extends TokenQueryProps {
 export const tokenTypeQuery = ({ id, skip }: TokenQueryProps) =>
   queryOptions({
     queryKey: ['token', 'type', id],
+    staleTime: Infinity,
+    gcTime: Infinity,
     queryFn: !skip
       ? async () => {
           const tokenInfo = await batchers.tokenTypeBatcher.fetch(id)
@@ -50,8 +52,7 @@ export const tokenTypeQuery = ({ id, skip }: TokenQueryProps) =>
             ? { ...tokenInfo, stdInterfaceId: tokenInfo.stdInterfaceId as TokenStdInterfaceId }
             : null
         }
-      : skipToken,
-    staleTime: Infinity
+      : skipToken
   })
 
 export const combineTokenTypeQueryResults = (results: UseQueryResult<TokenInfo | null>[]) => ({
@@ -81,26 +82,30 @@ export const combineTokenTypeQueryResults = (results: UseQueryResult<TokenInfo |
 export const fungibleTokenMetadataQuery = ({ id, skip }: TokenQueryProps) =>
   queryOptions({
     queryKey: ['token', 'fungible', 'metadata', id],
+    staleTime: Infinity,
+    gcTime: Infinity,
     queryFn: !skip
       ? async () => {
           const tokenMetadata = await batchers.ftMetadataBatcher.fetch(id)
 
           return tokenMetadata ? convertTokenDecimalsToNumber(tokenMetadata) : null
         }
-      : skipToken,
-    staleTime: Infinity
+      : skipToken
   })
 
 export const nftMetadataQuery = ({ id, skip }: TokenQueryProps) =>
   queryOptions({
     queryKey: ['token', 'non-fungible', 'metadata', id],
-    queryFn: !skip ? async () => (await batchers.nftMetadataBatcher.fetch(id)) ?? null : skipToken,
-    staleTime: Infinity
+    staleTime: Infinity,
+    gcTime: Infinity,
+    queryFn: !skip ? async () => (await batchers.nftMetadataBatcher.fetch(id)) ?? null : skipToken
   })
 
 export const nftDataQuery = ({ id, tokenUri, skip }: NFTQueryProps) =>
   queryOptions({
     queryKey: ['token', 'non-fungible', 'data', id],
+    staleTime: ONE_DAY_MS,
+    gcTime: Infinity,
     queryFn:
       !skip && !!tokenUri
         ? async () => {
@@ -114,36 +119,5 @@ export const nftDataQuery = ({ id, tokenUri, skip }: NFTQueryProps) =>
                   image: nftData?.image.toString() || ''
                 }
           }
-        : skipToken,
-    staleTime: ONE_DAY_MS
-  })
-
-export const tokenTypesQuery = (ids: TokenId[]) =>
-  queryOptions({
-    queryKey: ['tokens', 'type', ids],
-    queryFn: async (): Promise<TokenTypesQueryFnData> => {
-      const tokensInfo = await throttledClient.explorer.tokens.postTokens(ids)
-
-      return tokensInfo.reduce(
-        (tokenIdsByType, tokenInfo) => {
-          if (!tokenInfo) return tokenIdsByType
-          const stdInterfaceId = tokenInfo.stdInterfaceId as explorer.TokenStdInterfaceId
-
-          if (StdInterfaceIds.includes(stdInterfaceId)) {
-            tokenIdsByType[stdInterfaceId].push(tokenInfo.token)
-          } else {
-            // Except from NonStandard, the interface might be any string or undefined. We merge all that together.
-            tokenIdsByType[explorer.TokenStdInterfaceId.NonStandard].push(tokenInfo.token)
-          }
-
-          return tokenIdsByType
-        },
-        {
-          [explorer.TokenStdInterfaceId.Fungible]: [],
-          [explorer.TokenStdInterfaceId.NonFungible]: [],
-          [explorer.TokenStdInterfaceId.NonStandard]: []
-        } as TokenTypesQueryFnData
-      )
-    },
-    staleTime: Infinity
+        : skipToken
   })

--- a/apps/desktop-wallet/src/api/queries/transactionQueries.ts
+++ b/apps/desktop-wallet/src/api/queries/transactionQueries.ts
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AddressHash, throttledClient } from '@alephium/shared'
+import { AddressHash, FIVE_MINUTES_MS, throttledClient } from '@alephium/shared'
 import { Transaction } from '@alephium/web3/dist/src/api/api-explorer'
 import { infiniteQueryOptions, queryOptions, skipToken } from '@tanstack/react-query'
 
@@ -37,6 +37,7 @@ export interface AddressLatestTransactionQueryFnData {
 export const addressLatestTransactionQuery = ({ addressHash, networkId, skip }: AddressLatestTransactionQueryProps) =>
   queryOptions({
     queryKey: ['address', addressHash, 'transaction', 'latest', { networkId }],
+    gcTime: Infinity,
     queryFn: !skip
       ? async ({ queryKey }) => {
           const transactions = await throttledClient.explorer.addresses.getAddressesAddressTransactions(addressHash, {
@@ -81,13 +82,14 @@ export const addressTransactionsInfiniteQuery = ({
 }: AddressTransactionsInfiniteQueryProps) =>
   infiniteQueryOptions({
     queryKey: ['address', addressHash, 'transactions', { timestamp, networkId }],
+    staleTime: Infinity,
+    gcTime: FIVE_MINUTES_MS,
     queryFn: !skip
       ? ({ pageParam }) =>
           throttledClient.explorer.addresses.getAddressesAddressTransactions(addressHash, { page: pageParam })
       : skipToken,
     initialPageParam: 1,
-    getNextPageParam: (lastPage, _, lastPageParam) => (lastPage.length > 0 ? (lastPageParam += 1) : null),
-    staleTime: Infinity
+    getNextPageParam: (lastPage, _, lastPageParam) => (lastPage.length > 0 ? (lastPageParam += 1) : null)
   })
 
 interface WalletTransactionsInfiniteQueryProps extends TransactionsInfiniteQueryBaseProps {
@@ -102,13 +104,14 @@ export const walletTransactionsInfiniteQuery = ({
 }: WalletTransactionsInfiniteQueryProps) =>
   infiniteQueryOptions({
     queryKey: ['wallet', 'transactions', { timestamp, networkId, addressHashes }],
+    staleTime: Infinity,
+    gcTime: FIVE_MINUTES_MS,
     queryFn: !skip
       ? ({ pageParam }) =>
           throttledClient.explorer.addresses.postAddressesTransactions({ page: pageParam }, addressHashes)
       : skipToken,
     initialPageParam: 1,
-    getNextPageParam: (lastPage, _, lastPageParam) => (lastPage.length > 0 ? (lastPageParam += 1) : null),
-    staleTime: Infinity
+    getNextPageParam: (lastPage, _, lastPageParam) => (lastPage.length > 0 ? (lastPageParam += 1) : null)
   })
 
 interface WalletLatestTransactionsQueryProps {
@@ -119,8 +122,9 @@ interface WalletLatestTransactionsQueryProps {
 export const walletLatestTransactionsQuery = ({ addressHashes, networkId }: WalletLatestTransactionsQueryProps) =>
   queryOptions({
     queryKey: ['wallet', 'transactions', 'latest', { networkId, addressHashes }],
-    queryFn: () => throttledClient.explorer.addresses.postAddressesTransactions({ page: 1, limit: 5 }, addressHashes),
-    staleTime: Infinity
+    staleTime: Infinity,
+    gcTime: FIVE_MINUTES_MS,
+    queryFn: () => throttledClient.explorer.addresses.postAddressesTransactions({ page: 1, limit: 5 }, addressHashes)
   })
 
 interface TransactionQueryProps extends SkipProp {
@@ -130,13 +134,15 @@ interface TransactionQueryProps extends SkipProp {
 export const confirmedTransactionQuery = ({ txHash, skip }: TransactionQueryProps) =>
   queryOptions({
     queryKey: ['transaction', 'confirmed', txHash],
-    queryFn: !skip ? () => throttledClient.explorer.transactions.getTransactionsTransactionHash(txHash) : skipToken,
-    staleTime: Infinity
+    staleTime: Infinity,
+    gcTime: FIVE_MINUTES_MS,
+    queryFn: !skip ? () => throttledClient.explorer.transactions.getTransactionsTransactionHash(txHash) : skipToken
   })
 
 export const pendingTransactionQuery = ({ txHash, skip }: TransactionQueryProps) =>
   queryOptions({
     queryKey: ['transaction', 'pending', txHash],
-    queryFn: !skip ? () => throttledClient.explorer.transactions.getTransactionsTransactionHash(txHash) : skipToken,
-    refetchInterval: 3000
+    gcTime: FIVE_MINUTES_MS,
+    refetchInterval: 3000,
+    queryFn: !skip ? () => throttledClient.explorer.transactions.getTransactionsTransactionHash(txHash) : skipToken
   })

--- a/apps/desktop-wallet/src/api/queryClient.ts
+++ b/apps/desktop-wallet/src/api/queryClient.ts
@@ -16,17 +16,15 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { FIVE_MINUTES_MS, MAX_API_RETRIES, ONE_MINUTE_MS } from '@alephium/shared'
+import { MAX_API_RETRIES, ONE_MINUTE_MS } from '@alephium/shared'
 import { QueryClient } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
-
-export const DELETE_INACTIVE_QUERY_DATA_AFTER = FIVE_MINUTES_MS
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: ONE_MINUTE_MS,
-      gcTime: DELETE_INACTIVE_QUERY_DATA_AFTER,
+      gcTime: Infinity, // Will prevent data of locked wallets from being deleted from persisted storage
       retry: (failureCount, error) => {
         if (
           (error instanceof AxiosError && error.response?.status !== 429) ||

--- a/apps/desktop-wallet/src/features/addressDeletion/useDeleteAddress.ts
+++ b/apps/desktop-wallet/src/features/addressDeletion/useDeleteAddress.ts
@@ -18,6 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { AddressHash } from '@alephium/shared'
 
+import queryClient from '@/api/queryClient'
 import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import { addressDeleted } from '@/storage/addresses/addressesActions'
 import { addressMetadataStorage } from '@/storage/addresses/addressMetadataPersistentStorage'
@@ -34,6 +35,7 @@ const useDeleteAddress = () => {
 
     try {
       addressMetadataStorage.deleteOne(activeWalletId, address.index)
+      queryClient.removeQueries({ queryKey: ['address', addressHash] })
       dispatch(addressDeleted(address.hash))
     } catch (error) {
       console.error(error)

--- a/apps/desktop-wallet/src/features/historicChart/useHistoricData.tsx
+++ b/apps/desktop-wallet/src/features/historicChart/useHistoricData.tsx
@@ -26,7 +26,6 @@ import dayjs from 'dayjs'
 import { combineIsLoading } from '@/api/apiDataHooks/apiDataHooksUtils'
 import { useAppSelector } from '@/hooks/redux'
 
-const HISTORY_QUERY_KEY = 'history'
 const DAILY = explorer.IntervalType.Daily
 
 type Timestamp = string
@@ -38,8 +37,9 @@ const useHistoricData = () => {
   const networkId = useAppSelector((s) => s.network.settings.networkId)
 
   const { data: alphPriceHistory, isLoading: isLoadingAlphPriceHistory } = useQuery({
-    queryKey: [HISTORY_QUERY_KEY, 'price', ALPH.symbol, { currency }],
+    queryKey: ['history', 'price', ALPH.symbol, { currency }],
     staleTime: ONE_DAY_MS,
+    gcTime: Infinity,
     queryFn: () =>
       throttledClient.explorer.market.getMarketPricesSymbolCharts(ALPH.symbol, { currency }).then((rawHistory) => {
         const today = dayjs().format(CHART_DATE_FORMAT)
@@ -73,8 +73,9 @@ const useHistoricData = () => {
     hasHistoricBalances
   } = useQueries({
     queries: allAddressHashes.map((hash) => ({
-      queryKey: [HISTORY_QUERY_KEY, 'addressBalance', DAILY, ALPH.symbol, { hash, networkId }],
+      queryKey: ['address', hash, 'history', 'addressBalance', DAILY, ALPH.symbol, { networkId }],
       staleTime: ONE_DAY_MS,
+      gcTime: Infinity,
       queryFn: async () => {
         const now = dayjs()
         const thisMoment = now.valueOf()

--- a/apps/desktop-wallet/src/modals/NFTDetailsModal.tsx
+++ b/apps/desktop-wallet/src/modals/NFTDetailsModal.tsx
@@ -97,18 +97,21 @@ const NFTCollectionDetails = ({ collectionId }: Pick<NFT, 'collectionId'>) => {
 
   const { data: nftCollectionMetadata } = useQuery({
     queryKey: ['nfts', 'nftCollection', 'nftCollectionMetadata', collectionId],
+    staleTime: Infinity,
+    gcTime: Infinity,
     queryFn: !collectionId
       ? skipToken
       : async () =>
           (
             await throttledClient.explorer.tokens.postTokensNftCollectionMetadata([addressFromContractId(collectionId)])
-          )[0] ?? null,
-    staleTime: Infinity
+          )[0] ?? null
   })
 
   const collectionUri = nftCollectionMetadata?.collectionUri
   const { data: nftCollectionData } = useQuery({
     queryKey: ['nfts', 'nftCollection', 'nftCollectionData', collectionId],
+    staleTime: Infinity,
+    gcTime: Infinity,
     queryFn: !collectionUri
       ? skipToken
       : async () => {
@@ -121,8 +124,7 @@ const NFTCollectionDetails = ({ collectionId }: Pick<NFT, 'collectionId'>) => {
               `Response does not match the NFT collection metadata schema. NFT collection URI: ${collectionUri}`
             )
           }
-        },
-    staleTime: Infinity
+        }
   })
 
   if (!nftCollectionData) return null

--- a/apps/desktop-wallet/src/modals/WalletRemovalModal.tsx
+++ b/apps/desktop-wallet/src/modals/WalletRemovalModal.tsx
@@ -21,6 +21,7 @@ import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from 'styled-components'
 
+import queryClient from '@/api/queryClient'
 import Button from '@/components/Button'
 import InfoBox from '@/components/InfoBox'
 import { Section } from '@/components/PageComponents/PageContainers'
@@ -29,6 +30,7 @@ import useAnalytics from '@/features/analytics/useAnalytics'
 import { closeModal } from '@/features/modals/modalActions'
 import { ModalBaseProp } from '@/features/modals/modalTypes'
 import { useAppDispatch, useAppSelector } from '@/hooks/redux'
+import { useUnsortedAddressesHashes } from '@/hooks/useAddresses'
 import CenteredModal from '@/modals/CenteredModal'
 import { addressMetadataStorage } from '@/storage/addresses/addressMetadataPersistentStorage'
 import { activeWalletDeleted, walletDeleted } from '@/storage/wallets/walletActions'
@@ -45,10 +47,15 @@ const WalletRemovalModal = memo(({ id, walletId, walletName }: ModalBaseProp & W
   const dispatch = useAppDispatch()
   const { sendAnalytics } = useAnalytics()
   const activeWalletId = useAppSelector((s) => s.activeWallet.id)
+  const allAddressHashes = useUnsortedAddressesHashes()
 
   const removeWallet = () => {
     walletStorage.delete(walletId)
     addressMetadataStorage.delete(walletId)
+
+    allAddressHashes.forEach((addressHash) => {
+      queryClient.removeQueries({ queryKey: ['address', addressHash] })
+    })
 
     dispatch(walletId === activeWalletId ? activeWalletDeleted() : walletDeleted(walletId))
     dispatch(closeModal({ id }))

--- a/apps/desktop-wallet/src/pages/HomePage/index.tsx
+++ b/apps/desktop-wallet/src/pages/HomePage/index.tsx
@@ -16,13 +16,10 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { ONE_MINUTE_MS } from '@alephium/shared'
-import { useInterval } from '@alephium/shared-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { fadeInSlowly } from '@/animations'
-import { DELETE_INACTIVE_QUERY_DATA_AFTER } from '@/api/queryClient'
 import AppHeader from '@/components/AppHeader'
 import { FloatingPanel } from '@/components/PageComponents/PageContainers'
 import PanelTitle from '@/components/PageComponents/PanelTitle'
@@ -30,15 +27,12 @@ import { useAppSelector } from '@/hooks/redux'
 import NewWalletActions from '@/pages/HomePage/NewWalletActions'
 import UnlockPanel from '@/pages/HomePage/UnlockPanel'
 import LockedWalletLayout from '@/pages/LockedWalletLayout'
-import { electron } from '@/utils/misc'
 
 const HomePage = () => {
   const { t } = useTranslation()
   const hasAtLeastOneWallet = useAppSelector((state) => state.global.wallets.length > 0)
 
   const [showNewWalletActions, setShowNewWalletActions] = useState(false)
-
-  useInterval(() => electron?.app.reload(), DELETE_INACTIVE_QUERY_DATA_AFTER - ONE_MINUTE_MS)
 
   return (
     <LockedWalletLayout {...fadeInSlowly} animateSideBar>

--- a/apps/desktop-wallet/src/types/window.d.ts
+++ b/apps/desktop-wallet/src/types/window.d.ts
@@ -52,7 +52,6 @@ export interface AlephiumWindow extends Window {
       getSystemLanguage: () => Promise<string | undefined>
       setProxySettings: (proxySettings: ProxySettings) => Promise<void>
       restart: () => void
-      reload: () => void
     }
   }
 }


### PR DESCRIPTION
I have a compromise to propose:
1. We set **default** `gcTime: Infinity` so that we prevent data of locked wallets from being deleted from persisted storage
2. We set `gcTime: FIVE_MINUTES` to all queries whose `queryKey` can change
3. We call `queryClient.removeQueries` for the address-queries with `gcTime: Infinity` when a wallet or address gets deleted

What we end up with this approach is:
1. The balance queries will be preserved until wallet/address is deleted and will not be affected by gcTime when app is locked
2. Transaction queries will be cleared by gcTime when app is locked
3. Token metadata queries will be preserved indefinitely (or until user clears cache manually)

I think all the above is a good compromise.