### PR TITLE
Custom Tanstack persister for each wallet

### DIFF
--- a/apps/desktop-wallet/public/electron.js
+++ b/apps/desktop-wallet/public/electron.js
@@ -326,10 +326,6 @@ app.on('ready', async function () {
     deepLinkUri = null
   })
 
-  ipcMain.handle('app:reload', () => {
-    mainWindow.reload()
-  })
-
   createWindow()
 })
 

--- a/apps/desktop-wallet/public/preload.js
+++ b/apps/desktop-wallet/public/preload.js
@@ -66,7 +66,6 @@ contextBridge.exposeInMainWorld('electron', {
     show: () => ipcRenderer.invoke('app:show'),
     getSystemLanguage: () => ipcRenderer.invoke('app:getSystemLanguage'),
     setProxySettings: (proxySettings) => ipcRenderer.invoke('app:setProxySettings', proxySettings),
-    restart: () => ipcRenderer.invoke('app:restart'),
-    reload: () => ipcRenderer.invoke('app:reload')
+    restart: () => ipcRenderer.invoke('app:restart')
   }
 })

--- a/apps/desktop-wallet/src/api/apiDataHooks/address/useFetchAddressBalancesTokens.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/address/useFetchAddressBalancesTokens.ts
@@ -21,9 +21,10 @@ import { useQuery } from '@tanstack/react-query'
 import { UseFetchAddressProps } from '@/api/apiDataHooks/address/addressApiDataHooksTypes'
 import { addressTokensBalancesQuery } from '@/api/queries/addressQueries'
 import { useAppSelector } from '@/hooks/redux'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 
 const useFetchAddressBalancesTokens = ({ addressHash, skip }: UseFetchAddressProps) => {
-  const networkId = useAppSelector((s) => s.network.settings.networkId)
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
 
   return useQuery(addressTokensBalancesQuery({ addressHash, networkId, skip }))
 }

--- a/apps/desktop-wallet/src/api/apiDataHooks/address/useFetchAddressLatestTransaction.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/address/useFetchAddressLatestTransaction.ts
@@ -21,9 +21,10 @@ import { useQuery } from '@tanstack/react-query'
 import { UseFetchAddressProps } from '@/api/apiDataHooks/address/addressApiDataHooksTypes'
 import { addressLatestTransactionQuery } from '@/api/queries/transactionQueries'
 import { useAppSelector } from '@/hooks/redux'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 
 const useFetchAddressLatestTransaction = ({ addressHash, skip }: UseFetchAddressProps) => {
-  const networkId = useAppSelector((s) => s.network.settings.networkId)
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
 
   return useQuery(addressLatestTransactionQuery({ addressHash, networkId, skip }))
 }

--- a/apps/desktop-wallet/src/api/apiDataHooks/token/useFetchNft.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/token/useFetchNft.ts
@@ -21,6 +21,8 @@ import { useMemo } from 'react'
 
 import { SkipProp } from '@/api/apiDataHooks/apiDataHooksTypes'
 import { nftDataQuery, nftMetadataQuery } from '@/api/queries/tokenQueries'
+import { useAppSelector } from '@/hooks/redux'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 import { TokenId } from '@/types/tokens'
 
 interface UseNFTProps extends SkipProp {
@@ -28,13 +30,14 @@ interface UseNFTProps extends SkipProp {
 }
 
 const useFetchNft = ({ id, skip }: UseNFTProps) => {
-  const { data: nftMetadata, isLoading: isLoadingNftMetadata } = useQuery(nftMetadataQuery({ id, skip }))
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
+  const { data: nftMetadata, isLoading: isLoadingNftMetadata } = useQuery(nftMetadataQuery({ id, networkId, skip }))
 
   const {
     data: nftData,
     isLoading: isLoadingNftData,
     error
-  } = useQuery(nftDataQuery({ id, tokenUri: nftMetadata?.tokenUri, skip: skip || isLoadingNftMetadata }))
+  } = useQuery(nftDataQuery({ id, tokenUri: nftMetadata?.tokenUri, networkId, skip: skip || isLoadingNftMetadata }))
 
   return {
     data: useMemo(

--- a/apps/desktop-wallet/src/api/apiDataHooks/token/useFetchToken.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/token/useFetchToken.ts
@@ -24,22 +24,26 @@ import { DataHook } from '@/api/apiDataHooks/apiDataHooksTypes'
 import useFetchNft from '@/api/apiDataHooks/token/useFetchNft'
 import useFetchFtList from '@/api/apiDataHooks/utils/useFetchFtList'
 import { fungibleTokenMetadataQuery, tokenTypeQuery } from '@/api/queries/tokenQueries'
+import { useAppSelector } from '@/hooks/redux'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 import { ListedFT, NonStandardToken, TokenId, UnlistedFT } from '@/types/tokens'
 
 type UseFetchTokenResponse = DataHook<ListedFT | UnlistedFT | NFT | NonStandardToken>
 
 const useFetchToken = (id: TokenId): UseFetchTokenResponse => {
   const { data: fTList, isLoading: isLoadingFtList } = useFetchFtList()
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
 
   const listedFT = fTList?.find((t) => t.id === id)
 
   const { data: tokenType, isLoading: isLoadingTokenType } = useQuery(
-    tokenTypeQuery({ id, skip: isLoadingFtList || !!listedFT })
+    tokenTypeQuery({ id, networkId, skip: isLoadingFtList || !!listedFT })
   )
 
   const { data: unlistedFT, isLoading: isLoadingUnlistedFT } = useQuery(
     fungibleTokenMetadataQuery({
       id,
+      networkId,
       skip: isLoadingTokenType || tokenType?.stdInterfaceId !== explorer.TokenStdInterfaceId.Fungible
     })
   )

--- a/apps/desktop-wallet/src/api/apiDataHooks/transaction/useFetchPendingTransaction.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/transaction/useFetchPendingTransaction.ts
@@ -20,7 +20,13 @@ import { useQuery } from '@tanstack/react-query'
 
 import { UseFetchTransactionProps } from '@/api/apiDataHooks/transaction/transactionTypes'
 import { pendingTransactionQuery } from '@/api/queries/transactionQueries'
+import { useAppSelector } from '@/hooks/redux'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 
-const useFetchPendingTransaction = (props: UseFetchTransactionProps) => useQuery(pendingTransactionQuery(props))
+const useFetchPendingTransaction = (props: UseFetchTransactionProps) => {
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
+
+  return useQuery(pendingTransactionQuery({ ...props, networkId }))
+}
 
 export default useFetchPendingTransaction

--- a/apps/desktop-wallet/src/api/apiDataHooks/transaction/useFetchTransaction.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/transaction/useFetchTransaction.ts
@@ -23,14 +23,16 @@ import useFetchPendingTransaction from '@/api/apiDataHooks/transaction/useFetchP
 import { confirmedTransactionQuery } from '@/api/queries/transactionQueries'
 import { selectSentTransactionByHash } from '@/features/send/sentTransactions/sentTransactionsSelectors'
 import { useAppSelector } from '@/hooks/redux'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 
 const useFetchTransaction = ({ txHash, skip }: UseFetchTransactionProps) => {
   const sentTx = useAppSelector((s) => selectSentTransactionByHash(s, txHash))
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
 
   const isPendingTx = sentTx && sentTx.status !== 'confirmed'
 
   const { data: confirmedTx, isLoading: isLoadingConfirmedTx } = useQuery(
-    confirmedTransactionQuery({ txHash, skip: skip || isPendingTx })
+    confirmedTransactionQuery({ txHash, networkId, skip: skip || isPendingTx })
   )
   const { data: pendingTx } = useFetchPendingTransaction({ txHash, skip: skip || !isPendingTx })
 

--- a/apps/desktop-wallet/src/api/apiDataHooks/utils/useFetchFtList.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/utils/useFetchFtList.ts
@@ -22,6 +22,7 @@ import { skipToken, useQuery } from '@tanstack/react-query'
 import axios from 'axios'
 
 import { useAppSelector } from '@/hooks/redux'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 
 export interface FTList {
   data: TokenList['tokens'] | undefined
@@ -33,7 +34,7 @@ type FTListProps = {
 }
 
 const useFetchFtList = (props?: FTListProps): FTList => {
-  const networkId = useAppSelector((s) => s.network.settings.networkId)
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
   const network = networkId === 0 ? 'mainnet' : networkId === 1 ? 'testnet' : undefined
 
   const { data, isLoading } = useQuery({

--- a/apps/desktop-wallet/src/api/apiDataHooks/utils/useFetchFtList.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/utils/useFetchFtList.ts
@@ -23,8 +23,6 @@ import axios from 'axios'
 
 import { useAppSelector } from '@/hooks/redux'
 
-const TOKEN_LIST_QUERY_KEY = 'tokenList'
-
 export interface FTList {
   data: TokenList['tokens'] | undefined
   isLoading: boolean
@@ -39,13 +37,16 @@ const useFetchFtList = (props?: FTListProps): FTList => {
   const network = networkId === 0 ? 'mainnet' : networkId === 1 ? 'testnet' : undefined
 
   const { data, isLoading } = useQuery({
-    queryKey: [TOKEN_LIST_QUERY_KEY, network],
+    queryKey: ['tokenList', network],
+    staleTime: ONE_DAY_MS,
+    // The token list is essential for the whole app so we don't want to ever delete it. Even if we set a lower gcTime,
+    // it will never become inactive (since it's always used by a mount component).
+    gcTime: Infinity,
     queryFn:
       !network || props?.skip
         ? skipToken
         : () => axios.get(getTokensURL(network)).then(({ data }) => (data as TokenList)?.tokens),
-    placeholderData: network === 'mainnet' ? mainnet.tokens : network === 'testnet' ? testnet.tokens : [],
-    staleTime: ONE_DAY_MS
+    placeholderData: network === 'mainnet' ? mainnet.tokens : network === 'testnet' ? testnet.tokens : []
   })
 
   // TODO: Maybe return an object instead of an array for faster search?

--- a/apps/desktop-wallet/src/api/apiDataHooks/utils/useFetchFtList.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/utils/useFetchFtList.ts
@@ -43,6 +43,7 @@ const useFetchFtList = (props?: FTListProps): FTList => {
     // The token list is essential for the whole app so we don't want to ever delete it. Even if we set a lower gcTime,
     // it will never become inactive (since it's always used by a mount component).
     gcTime: Infinity,
+    meta: { isMainnet: networkId === 0 },
     queryFn:
       !network || props?.skip
         ? skipToken

--- a/apps/desktop-wallet/src/api/apiDataHooks/utils/useFetchSortedFts.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/utils/useFetchSortedFts.ts
@@ -25,6 +25,8 @@ import { SkipProp } from '@/api/apiDataHooks/apiDataHooksTypes'
 import { combineDefined } from '@/api/apiDataHooks/apiDataHooksUtils'
 import useFetchTokenPrices from '@/api/apiDataHooks/market/useFetchTokenPrices'
 import { fungibleTokenMetadataQuery } from '@/api/queries/tokenQueries'
+import { useAppSelector } from '@/hooks/redux'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 import { DisplayBalances, ListedFT, TokenId } from '@/types/tokens'
 
 interface UseSortFTsProps extends SkipProp {
@@ -33,8 +35,10 @@ interface UseSortFTsProps extends SkipProp {
 }
 
 const useFetchSortedFts = ({ listedFts, unlistedFtIds, skip }: UseSortFTsProps) => {
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
+
   const { data: unlistedFts, isLoading: isLoadingUnlistedFTs } = useQueries({
-    queries: unlistedFtIds.map((id) => fungibleTokenMetadataQuery({ id })),
+    queries: unlistedFtIds.map((id) => fungibleTokenMetadataQuery({ id, networkId })),
     combine: combineDefined
   })
 

--- a/apps/desktop-wallet/src/api/apiDataHooks/utils/useFetchTokensSeparatedByType.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/utils/useFetchTokensSeparatedByType.ts
@@ -20,6 +20,8 @@ import { useQueries } from '@tanstack/react-query'
 
 import useFetchTokensSeparatedByListing from '@/api/apiDataHooks/utils/useFetchTokensSeparatedByListing'
 import { combineTokenTypeQueryResults, tokenTypeQuery } from '@/api/queries/tokenQueries'
+import { useAppSelector } from '@/hooks/redux'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 import { ListedFT, TokenId, UnlistedToken } from '@/types/tokens'
 
 interface TokensByType<T> {
@@ -34,6 +36,8 @@ interface TokensByType<T> {
 }
 
 const useFetchTokensSeparatedByType = <T extends UnlistedToken>(tokens: T[] = []): TokensByType<T> => {
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
+
   const {
     data: { listedFts, unlistedTokens },
     isLoading: isLoadingTokensByListing
@@ -43,7 +47,7 @@ const useFetchTokensSeparatedByType = <T extends UnlistedToken>(tokens: T[] = []
     data: { fungible: unlistedFtIds, 'non-fungible': nftIds, 'non-standard': nstIds },
     isLoading: isLoadingTokensByType
   } = useQueries({
-    queries: unlistedTokens.map(({ id }) => tokenTypeQuery({ id })),
+    queries: unlistedTokens.map(({ id }) => tokenTypeQuery({ id, networkId })),
     combine: combineTokenTypeQueryResults
   })
 

--- a/apps/desktop-wallet/src/api/apiDataHooks/wallet/useFetchLatestTransactionOfEachAddress.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/wallet/useFetchLatestTransactionOfEachAddress.ts
@@ -23,9 +23,10 @@ import { flatMapCombine } from '@/api/apiDataHooks/apiDataHooksUtils'
 import { addressLatestTransactionQuery } from '@/api/queries/transactionQueries'
 import { useAppSelector } from '@/hooks/redux'
 import { useUnsortedAddressesHashes } from '@/hooks/useAddresses'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 
 const useFetchLatestTransactionOfEachAddress = (props?: SkipProp) => {
-  const networkId = useAppSelector((s) => s.network.settings.networkId)
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
   const allAddressHashes = useUnsortedAddressesHashes()
 
   return useQueries({

--- a/apps/desktop-wallet/src/api/apiDataHooks/wallet/useFetchWalletBalancesAlph.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/wallet/useFetchWalletBalancesAlph.ts
@@ -24,6 +24,7 @@ import { combineIsLoading } from '@/api/apiDataHooks/apiDataHooksUtils'
 import { addressAlphBalancesQuery, AddressAlphBalancesQueryFnData } from '@/api/queries/addressQueries'
 import { useAppSelector } from '@/hooks/redux'
 import { useUnsortedAddressesHashes } from '@/hooks/useAddresses'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 import { DisplayBalances } from '@/types/tokens'
 
 // Using undefined to avoid adding noUncheckedIndexedAccess in tsconfig while maintaining strong typing when accessing
@@ -44,7 +45,7 @@ interface UseFetchWalletBalancesAlphProps<T> extends SkipProp {
 }
 
 const useFetchWalletBalancesAlph = <T>({ combine, skip }: UseFetchWalletBalancesAlphProps<T>) => {
-  const networkId = useAppSelector((s) => s.network.settings.networkId)
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
   const allAddressHashes = useUnsortedAddressesHashes()
 
   return useQueries({

--- a/apps/desktop-wallet/src/api/apiDataHooks/wallet/useFetchWalletBalancesTokens.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/wallet/useFetchWalletBalancesTokens.ts
@@ -23,6 +23,7 @@ import { combineIsLoading } from '@/api/apiDataHooks/apiDataHooksUtils'
 import { addressTokensBalancesQuery, AddressTokensBalancesQueryFnData } from '@/api/queries/addressQueries'
 import { useAppSelector } from '@/hooks/redux'
 import { useUnsortedAddressesHashes } from '@/hooks/useAddresses'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 import { DisplayBalances, TokenDisplayBalances, TokenId } from '@/types/tokens'
 
 export const useFetchWalletBalancesTokensArray = () => useFetchWalletBalancesTokens(combineBalancesToArray)
@@ -34,7 +35,7 @@ export const useFetchWalletBalancesTokensByAddress = () => useFetchWalletBalance
 const useFetchWalletBalancesTokens = <T>(
   combine: (results: UseQueryResult<AddressTokensBalancesQueryFnData>[]) => { data: T; isLoading: boolean }
 ) => {
-  const networkId = useAppSelector((s) => s.network.settings.networkId)
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
   const allAddressHashes = useUnsortedAddressesHashes()
 
   return useQueries({

--- a/apps/desktop-wallet/src/api/apiDataHooks/wallet/useFetchWalletSingleTokenBalances.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/wallet/useFetchWalletSingleTokenBalances.ts
@@ -26,6 +26,7 @@ import { useFetchWalletBalancesAlphArray } from '@/api/apiDataHooks/wallet/useFe
 import { addressTokensBalancesQuery, AddressTokensBalancesQueryFnData } from '@/api/queries/addressQueries'
 import { useAppSelector } from '@/hooks/redux'
 import { useUnsortedAddressesHashes } from '@/hooks/useAddresses'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 import { DisplayBalances, TokenId } from '@/types/tokens'
 
 interface UseFetchWalletSingleTokenBalancesProps extends SkipProp {
@@ -33,7 +34,7 @@ interface UseFetchWalletSingleTokenBalancesProps extends SkipProp {
 }
 
 const useFetchWalletSingleTokenBalances = ({ tokenId, skip }: UseFetchWalletSingleTokenBalancesProps) => {
-  const networkId = useAppSelector((s) => s.network.settings.networkId)
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
   const allAddressHashes = useUnsortedAddressesHashes()
 
   const isALPH = tokenId === ALPH.id

--- a/apps/desktop-wallet/src/api/apiDataHooks/wallet/useFetchWalletTransactionsLimited.tsx
+++ b/apps/desktop-wallet/src/api/apiDataHooks/wallet/useFetchWalletTransactionsLimited.tsx
@@ -21,9 +21,10 @@ import { useQuery } from '@tanstack/react-query'
 import { walletLatestTransactionsQuery } from '@/api/queries/transactionQueries'
 import { useAppSelector } from '@/hooks/redux'
 import { useCappedAddressesHashes } from '@/hooks/useAddresses'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 
 const useFetchWalletTransactionsLimited = () => {
-  const networkId = useAppSelector((s) => s.network.settings.networkId)
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
   const { addressHashes, isCapped } = useCappedAddressesHashes()
 
   const { data: confirmedTxs, isLoading } = useQuery(walletLatestTransactionsQuery({ addressHashes, networkId }))

--- a/apps/desktop-wallet/src/api/persistQueryClientContext.tsx
+++ b/apps/desktop-wallet/src/api/persistQueryClientContext.tsx
@@ -1,0 +1,84 @@
+/*
+Copyright 2018 - 2024 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import {
+  PersistQueryClientOptions,
+  persistQueryClientRestore,
+  persistQueryClientSubscribe
+} from '@tanstack/query-persist-client-core'
+import { IsRestoringProvider, OmitKeyof, QueryClientProvider, QueryClientProviderProps } from '@tanstack/react-query'
+import { createContext, ReactNode, useCallback, useContext, useState } from 'react'
+
+import queryClient from '@/api/queryClient'
+import { createTanstackIndexedDBPersister } from '@/storage/tanstackIndexedDBPersister'
+
+export type PersistQueryClientProviderProps = QueryClientProviderProps & {
+  persistOptions: OmitKeyof<PersistQueryClientOptions, 'queryClient'>
+}
+
+export interface PersistQueryClientContextType {
+  restoreQueryCache: (walletId: string) => Promise<void>
+  clearQueryCache: () => void
+}
+
+export const initialPersistQueryClientContext: PersistQueryClientContextType = {
+  restoreQueryCache: () => Promise.resolve(),
+  clearQueryCache: () => {}
+}
+
+export const PersistQueryClientContext = createContext<PersistQueryClientContextType>(initialPersistQueryClientContext)
+
+// Inspired by https://github.com/TanStack/query/blob/1adaf3ff86fa2bf720dbc958714c60553c4aae08/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
+export const PersistQueryClientContextProvider = ({ children }: { children: ReactNode | ReactNode[] }) => {
+  const [isRestoring, setIsRestoring] = useState(true)
+  const [unsubscribeFromQueryClientFn, setUnsubscribeFromQueryClientFn] = useState(() => () => {})
+
+  const clearQueryCache = useCallback(() => {
+    unsubscribeFromQueryClientFn()
+
+    queryClient.clear()
+  }, [unsubscribeFromQueryClientFn])
+
+  const restoreQueryCache = useCallback(async (walletId: string) => {
+    const options = {
+      queryClient,
+      maxAge: Infinity,
+      persister: createTanstackIndexedDBPersister('tanstack-cache-for-wallet-' + walletId)
+    }
+
+    setIsRestoring(true)
+
+    await persistQueryClientRestore(options)
+
+    const newUnsubscribeFromQueryClientFn = persistQueryClientSubscribe(options)
+
+    setUnsubscribeFromQueryClientFn(() => newUnsubscribeFromQueryClientFn)
+
+    setIsRestoring(false)
+  }, [])
+
+  return (
+    <PersistQueryClientContext.Provider value={{ restoreQueryCache, clearQueryCache }}>
+      <QueryClientProvider client={queryClient}>
+        <IsRestoringProvider value={isRestoring}>{children}</IsRestoringProvider>
+      </QueryClientProvider>
+    </PersistQueryClientContext.Provider>
+  )
+}
+
+export const usePersistQueryClientContext = () => useContext(PersistQueryClientContext)

--- a/apps/desktop-wallet/src/api/persistQueryClientContext.tsx
+++ b/apps/desktop-wallet/src/api/persistQueryClientContext.tsx
@@ -21,7 +21,13 @@ import {
   persistQueryClientRestore,
   persistQueryClientSubscribe
 } from '@tanstack/query-persist-client-core'
-import { IsRestoringProvider, OmitKeyof, QueryClientProvider, QueryClientProviderProps } from '@tanstack/react-query'
+import {
+  defaultShouldDehydrateQuery,
+  IsRestoringProvider,
+  OmitKeyof,
+  QueryClientProvider,
+  QueryClientProviderProps
+} from '@tanstack/react-query'
 import { createContext, ReactNode, useCallback, useContext, useState } from 'react'
 
 import queryClient from '@/api/queryClient'
@@ -55,10 +61,14 @@ export const PersistQueryClientContextProvider = ({ children }: { children: Reac
   }, [unsubscribeFromQueryClientFn])
 
   const restoreQueryCache = useCallback(async (walletId: string) => {
-    const options = {
+    const options: PersistQueryClientOptions = {
       queryClient,
       maxAge: Infinity,
-      persister: createTanstackIndexedDBPersister('tanstack-cache-for-wallet-' + walletId)
+      persister: createTanstackIndexedDBPersister('tanstack-cache-for-wallet-' + walletId),
+      dehydrateOptions: {
+        shouldDehydrateQuery: (query) =>
+          query.meta?.['isMainnet'] === false ? false : defaultShouldDehydrateQuery(query)
+      }
     }
 
     setIsRestoring(true)

--- a/apps/desktop-wallet/src/api/queries/addressQueries.ts
+++ b/apps/desktop-wallet/src/api/queries/addressQueries.ts
@@ -33,6 +33,11 @@ export type AddressAlphBalancesQueryFnData = {
 export const addressAlphBalancesQuery = ({ addressHash, networkId, skip }: AddressLatestTransactionQueryProps) =>
   queryOptions({
     queryKey: ['address', addressHash, 'balance', 'ALPH', { networkId }],
+    staleTime: Infinity,
+    // We don't want address data to be deleted when the user navigates away from components that need them since these
+    // data are essential for the major parts of the app. We manually remove cached data when the user deletes an
+    // address.
+    gcTime: Infinity,
     queryFn: !skip
       ? async () => {
           const balances = await throttledClient.explorer.addresses.getAddressesAddressBalance(addressHash)
@@ -46,8 +51,7 @@ export const addressAlphBalancesQuery = ({ addressHash, networkId, skip }: Addre
             }
           }
         }
-      : skipToken,
-    staleTime: Infinity
+      : skipToken
   })
 
 export type AddressTokensBalancesQueryFnData = {
@@ -58,6 +62,11 @@ export type AddressTokensBalancesQueryFnData = {
 export const addressTokensBalancesQuery = ({ addressHash, networkId, skip }: AddressLatestTransactionQueryProps) =>
   queryOptions({
     queryKey: ['address', addressHash, 'balance', 'tokens', { networkId }],
+    staleTime: Infinity,
+    // We don't want address data to be deleted when the user navigates away from components that need them since these
+    // data are essential for the major parts of the app. We manually remove cached data when the user deletes an
+    // address.
+    gcTime: Infinity,
     queryFn: !skip
       ? async () => {
           const tokenBalances = [] as TokenDisplayBalances[]
@@ -89,7 +98,5 @@ export const addressTokensBalancesQuery = ({ addressHash, networkId, skip }: Add
             balances: tokenBalances
           }
         }
-      : skipToken,
-
-    staleTime: Infinity
+      : skipToken
   })

--- a/apps/desktop-wallet/src/api/queries/addressQueries.ts
+++ b/apps/desktop-wallet/src/api/queries/addressQueries.ts
@@ -38,6 +38,7 @@ export const addressAlphBalancesQuery = ({ addressHash, networkId, skip }: Addre
     // data are essential for the major parts of the app. We manually remove cached data when the user deletes an
     // address.
     gcTime: Infinity,
+    meta: { isMainnet: networkId === 0 },
     queryFn: !skip
       ? async () => {
           const balances = await throttledClient.explorer.addresses.getAddressesAddressBalance(addressHash)
@@ -67,6 +68,7 @@ export const addressTokensBalancesQuery = ({ addressHash, networkId, skip }: Add
     // data are essential for the major parts of the app. We manually remove cached data when the user deletes an
     // address.
     gcTime: Infinity,
+    meta: { isMainnet: networkId === 0 },
     queryFn: !skip
       ? async () => {
           const tokenBalances = [] as TokenDisplayBalances[]

--- a/apps/desktop-wallet/src/api/queries/addressQueries.ts
+++ b/apps/desktop-wallet/src/api/queries/addressQueries.ts
@@ -39,20 +39,21 @@ export const addressAlphBalancesQuery = ({ addressHash, networkId, skip }: Addre
     // address.
     gcTime: Infinity,
     meta: { isMainnet: networkId === 0 },
-    queryFn: !skip
-      ? async () => {
-          const balances = await throttledClient.explorer.addresses.getAddressesAddressBalance(addressHash)
+    queryFn:
+      !skip && networkId !== undefined
+        ? async () => {
+            const balances = await throttledClient.explorer.addresses.getAddressesAddressBalance(addressHash)
 
-          return {
-            addressHash,
-            balances: {
-              totalBalance: BigInt(balances.balance),
-              lockedBalance: BigInt(balances.lockedBalance),
-              availableBalance: BigInt(balances.balance) - BigInt(balances.lockedBalance)
+            return {
+              addressHash,
+              balances: {
+                totalBalance: BigInt(balances.balance),
+                lockedBalance: BigInt(balances.lockedBalance),
+                availableBalance: BigInt(balances.balance) - BigInt(balances.lockedBalance)
+              }
             }
           }
-        }
-      : skipToken
+        : skipToken
   })
 
 export type AddressTokensBalancesQueryFnData = {
@@ -69,36 +70,37 @@ export const addressTokensBalancesQuery = ({ addressHash, networkId, skip }: Add
     // address.
     gcTime: Infinity,
     meta: { isMainnet: networkId === 0 },
-    queryFn: !skip
-      ? async () => {
-          const tokenBalances = [] as TokenDisplayBalances[]
-          let tokenBalancesInPage = [] as AddressTokenBalance[]
-          let page = 1
+    queryFn:
+      !skip && networkId !== undefined
+        ? async () => {
+            const tokenBalances = [] as TokenDisplayBalances[]
+            let tokenBalancesInPage = [] as AddressTokenBalance[]
+            let page = 1
 
-          while (page === 1 || tokenBalancesInPage.length === PAGINATION_PAGE_LIMIT) {
-            tokenBalancesInPage = await throttledClient.explorer.addresses.getAddressesAddressTokensBalance(
+            while (page === 1 || tokenBalancesInPage.length === PAGINATION_PAGE_LIMIT) {
+              tokenBalancesInPage = await throttledClient.explorer.addresses.getAddressesAddressTokensBalance(
+                addressHash,
+                {
+                  limit: PAGINATION_PAGE_LIMIT,
+                  page
+                }
+              )
+
+              tokenBalances.push(
+                ...tokenBalancesInPage.map((tokenBalances) => ({
+                  id: tokenBalances.tokenId,
+                  totalBalance: BigInt(tokenBalances.balance),
+                  lockedBalance: BigInt(tokenBalances.lockedBalance),
+                  availableBalance: BigInt(tokenBalances.balance) - BigInt(tokenBalances.lockedBalance)
+                }))
+              )
+              page += 1
+            }
+
+            return {
               addressHash,
-              {
-                limit: PAGINATION_PAGE_LIMIT,
-                page
-              }
-            )
-
-            tokenBalances.push(
-              ...tokenBalancesInPage.map((tokenBalances) => ({
-                id: tokenBalances.tokenId,
-                totalBalance: BigInt(tokenBalances.balance),
-                lockedBalance: BigInt(tokenBalances.lockedBalance),
-                availableBalance: BigInt(tokenBalances.balance) - BigInt(tokenBalances.lockedBalance)
-              }))
-            )
-            page += 1
+              balances: tokenBalances
+            }
           }
-
-          return {
-            addressHash,
-            balances: tokenBalances
-          }
-        }
-      : skipToken
+        : skipToken
   })

--- a/apps/desktop-wallet/src/api/queries/tokenQueries.ts
+++ b/apps/desktop-wallet/src/api/queries/tokenQueries.ts
@@ -33,19 +33,21 @@ export const StdInterfaceIds = Object.values(explorer.TokenStdInterfaceId)
 
 interface TokenQueryProps extends SkipProp {
   id: TokenId
+  networkId?: number
 }
 
 interface NFTQueryProps extends TokenQueryProps {
   tokenUri?: NFTMetaData['tokenUri']
 }
 
-export const tokenTypeQuery = ({ id, skip }: TokenQueryProps) =>
+export const tokenTypeQuery = ({ id, networkId, skip }: TokenQueryProps) =>
   queryOptions({
     queryKey: ['token', 'type', id],
     staleTime: Infinity,
     // We always want to remember the type of a token, even when user navigates for too long from components that use
     // tokens.
     gcTime: Infinity,
+    meta: { isMainnet: networkId === 0 },
     queryFn: !skip
       ? async () => {
           const tokenInfo = await batchers.tokenTypeBatcher.fetch(id)
@@ -81,12 +83,13 @@ export const combineTokenTypeQueryResults = (results: UseQueryResult<TokenInfo |
   ...combineIsLoading(results)
 })
 
-export const fungibleTokenMetadataQuery = ({ id, skip }: TokenQueryProps) =>
+export const fungibleTokenMetadataQuery = ({ id, networkId, skip }: TokenQueryProps) =>
   queryOptions({
     queryKey: ['token', 'fungible', 'metadata', id],
     staleTime: Infinity,
     // We don't want to delete the fungible token metadata when the user navigates away components that need them.
     gcTime: Infinity,
+    meta: { isMainnet: networkId === 0 },
     queryFn: !skip
       ? async () => {
           const tokenMetadata = await batchers.ftMetadataBatcher.fetch(id)
@@ -96,19 +99,21 @@ export const fungibleTokenMetadataQuery = ({ id, skip }: TokenQueryProps) =>
       : skipToken
   })
 
-export const nftMetadataQuery = ({ id, skip }: TokenQueryProps) =>
+export const nftMetadataQuery = ({ id, networkId, skip }: TokenQueryProps) =>
   queryOptions({
     queryKey: ['token', 'non-fungible', 'metadata', id],
     staleTime: Infinity,
     gcTime: Infinity, // We don't want to delete the NFT metadata when the user navigates away from NFT components.
+    meta: { isMainnet: networkId === 0 },
     queryFn: !skip ? async () => (await batchers.nftMetadataBatcher.fetch(id)) ?? null : skipToken
   })
 
-export const nftDataQuery = ({ id, tokenUri, skip }: NFTQueryProps) =>
+export const nftDataQuery = ({ id, tokenUri, networkId, skip }: NFTQueryProps) =>
   queryOptions({
     queryKey: ['token', 'non-fungible', 'data', id],
     staleTime: ONE_DAY_MS,
     gcTime: Infinity, // We don't want to delete the NFT data when the user navigates away from NFT components.
+    meta: { isMainnet: networkId === 0 },
     queryFn:
       !skip && !!tokenUri
         ? async () => {

--- a/apps/desktop-wallet/src/api/queries/transactionQueries.ts
+++ b/apps/desktop-wallet/src/api/queries/transactionQueries.ts
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AddressHash, throttledClient } from '@alephium/shared'
+import { AddressHash, FIVE_MINUTES_MS, throttledClient } from '@alephium/shared'
 import { Transaction } from '@alephium/web3/dist/src/api/api-explorer'
 import { infiniteQueryOptions, queryOptions, skipToken } from '@tanstack/react-query'
 
@@ -37,6 +37,7 @@ export interface AddressLatestTransactionQueryFnData {
 export const addressLatestTransactionQuery = ({ addressHash, networkId, skip }: AddressLatestTransactionQueryProps) =>
   queryOptions({
     queryKey: ['address', addressHash, 'transaction', 'latest', { networkId }],
+    gcTime: FIVE_MINUTES_MS,
     queryFn: !skip
       ? async ({ queryKey }) => {
           const transactions = await throttledClient.explorer.addresses.getAddressesAddressTransactions(addressHash, {
@@ -81,13 +82,15 @@ export const addressTransactionsInfiniteQuery = ({
 }: AddressTransactionsInfiniteQueryProps) =>
   infiniteQueryOptions({
     queryKey: ['address', addressHash, 'transactions', { timestamp, networkId }],
+    staleTime: Infinity,
+    // 5 minutes after the user navigates away from the address details modal, the cached data will be deleted.
+    gcTime: FIVE_MINUTES_MS,
     queryFn: !skip
       ? ({ pageParam }) =>
           throttledClient.explorer.addresses.getAddressesAddressTransactions(addressHash, { page: pageParam })
       : skipToken,
     initialPageParam: 1,
-    getNextPageParam: (lastPage, _, lastPageParam) => (lastPage.length > 0 ? (lastPageParam += 1) : null),
-    staleTime: Infinity
+    getNextPageParam: (lastPage, _, lastPageParam) => (lastPage.length > 0 ? (lastPageParam += 1) : null)
   })
 
 interface WalletTransactionsInfiniteQueryProps extends TransactionsInfiniteQueryBaseProps {
@@ -102,13 +105,16 @@ export const walletTransactionsInfiniteQuery = ({
 }: WalletTransactionsInfiniteQueryProps) =>
   infiniteQueryOptions({
     queryKey: ['wallet', 'transactions', { timestamp, networkId, addressHashes }],
+    staleTime: Infinity,
+    // When the user navigates away from the Transfers page for 5 minutes or when addresses are generated/removed the
+    // cached data will be deleted.
+    gcTime: FIVE_MINUTES_MS,
     queryFn: !skip
       ? ({ pageParam }) =>
           throttledClient.explorer.addresses.postAddressesTransactions({ page: pageParam }, addressHashes)
       : skipToken,
     initialPageParam: 1,
-    getNextPageParam: (lastPage, _, lastPageParam) => (lastPage.length > 0 ? (lastPageParam += 1) : null),
-    staleTime: Infinity
+    getNextPageParam: (lastPage, _, lastPageParam) => (lastPage.length > 0 ? (lastPageParam += 1) : null)
   })
 
 interface WalletLatestTransactionsQueryProps {
@@ -119,8 +125,11 @@ interface WalletLatestTransactionsQueryProps {
 export const walletLatestTransactionsQuery = ({ addressHashes, networkId }: WalletLatestTransactionsQueryProps) =>
   queryOptions({
     queryKey: ['wallet', 'transactions', 'latest', { networkId, addressHashes }],
-    queryFn: () => throttledClient.explorer.addresses.postAddressesTransactions({ page: 1, limit: 5 }, addressHashes),
-    staleTime: Infinity
+    staleTime: Infinity,
+    // When the user navigates away from the Overview page for 5 minutes or when addresses are generated/removed the
+    // cached data will be deleted.
+    gcTime: FIVE_MINUTES_MS,
+    queryFn: () => throttledClient.explorer.addresses.postAddressesTransactions({ page: 1, limit: 5 }, addressHashes)
   })
 
 interface TransactionQueryProps extends SkipProp {
@@ -130,13 +139,20 @@ interface TransactionQueryProps extends SkipProp {
 export const confirmedTransactionQuery = ({ txHash, skip }: TransactionQueryProps) =>
   queryOptions({
     queryKey: ['transaction', 'confirmed', txHash],
-    queryFn: !skip ? () => throttledClient.explorer.transactions.getTransactionsTransactionHash(txHash) : skipToken,
-    staleTime: Infinity
+    staleTime: Infinity,
+    // When the user navigates away from the transaction details modal for 5 minutes or when a sent tx confirms the
+    // cached data will be deleted.
+    gcTime: FIVE_MINUTES_MS,
+    queryFn: !skip ? () => throttledClient.explorer.transactions.getTransactionsTransactionHash(txHash) : skipToken
   })
 
 export const pendingTransactionQuery = ({ txHash, skip }: TransactionQueryProps) =>
   queryOptions({
     queryKey: ['transaction', 'pending', txHash],
-    queryFn: !skip ? () => throttledClient.explorer.transactions.getTransactionsTransactionHash(txHash) : skipToken,
-    refetchInterval: 3000
+    // 5 minutes after a sent tx is confirmed, the cached data will be deleted. We cannot set it to a lower value than
+    // the default one because the highest gcTime is always in effect. We would need to set the default to a lower one
+    // just for this one, but is it worth it?
+    gcTime: FIVE_MINUTES_MS,
+    refetchInterval: 3000,
+    queryFn: !skip ? () => throttledClient.explorer.transactions.getTransactionsTransactionHash(txHash) : skipToken
   })

--- a/apps/desktop-wallet/src/api/queries/transactionQueries.ts
+++ b/apps/desktop-wallet/src/api/queries/transactionQueries.ts
@@ -85,7 +85,7 @@ export const addressTransactionsInfiniteQuery = ({
     staleTime: Infinity,
     // 5 minutes after the user navigates away from the address details modal, the cached data will be deleted.
     gcTime: FIVE_MINUTES_MS,
-    meta: { isInfinite: true, isMainnet: networkId === 0 },
+    meta: { isMainnet: networkId === 0 },
     queryFn:
       !skip && networkId !== undefined
         ? ({ pageParam }) =>
@@ -110,7 +110,7 @@ export const walletTransactionsInfiniteQuery = ({
     // When the user navigates away from the Transfers page for 5 minutes or when addresses are generated/removed the
     // cached data will be deleted.
     gcTime: FIVE_MINUTES_MS,
-    meta: { isInfinite: true, isMainnet: networkId === 0 },
+    meta: { isMainnet: networkId === 0 },
     queryFn:
       !skip && networkId !== undefined
         ? ({ pageParam }) =>
@@ -141,25 +141,28 @@ export const walletLatestTransactionsQuery = ({ addressHashes, networkId }: Wall
 
 interface TransactionQueryProps extends SkipProp {
   txHash: string
+  networkId?: number
 }
 
-export const confirmedTransactionQuery = ({ txHash, skip }: TransactionQueryProps) =>
+export const confirmedTransactionQuery = ({ txHash, networkId, skip }: TransactionQueryProps) =>
   queryOptions({
     queryKey: ['transaction', 'confirmed', txHash],
     staleTime: Infinity,
     // When the user navigates away from the transaction details modal for 5 minutes or when a sent tx confirms the
     // cached data will be deleted.
     gcTime: FIVE_MINUTES_MS,
+    meta: { isMainnet: networkId === 0 },
     queryFn: !skip ? () => throttledClient.explorer.transactions.getTransactionsTransactionHash(txHash) : skipToken
   })
 
-export const pendingTransactionQuery = ({ txHash, skip }: TransactionQueryProps) =>
+export const pendingTransactionQuery = ({ txHash, networkId, skip }: TransactionQueryProps) =>
   queryOptions({
     queryKey: ['transaction', 'pending', txHash],
     // 5 minutes after a sent tx is confirmed, the cached data will be deleted. We cannot set it to a lower value than
     // the default one because the highest gcTime is always in effect. We would need to set the default to a lower one
     // just for this one, but is it worth it?
     gcTime: FIVE_MINUTES_MS,
+    meta: { isMainnet: networkId === 0 },
     refetchInterval: 3000,
     queryFn: !skip ? () => throttledClient.explorer.transactions.getTransactionsTransactionHash(txHash) : skipToken
   })

--- a/apps/desktop-wallet/src/api/queries/transactionQueries.ts
+++ b/apps/desktop-wallet/src/api/queries/transactionQueries.ts
@@ -38,6 +38,7 @@ export const addressLatestTransactionQuery = ({ addressHash, networkId, skip }: 
   queryOptions({
     queryKey: ['address', addressHash, 'transaction', 'latest', { networkId }],
     gcTime: FIVE_MINUTES_MS,
+    meta: { isMainnet: networkId === 0 },
     queryFn: !skip
       ? async ({ queryKey }) => {
           const transactions = await throttledClient.explorer.addresses.getAddressesAddressTransactions(addressHash, {
@@ -66,7 +67,6 @@ export const addressLatestTransactionQuery = ({ addressHash, networkId, skip }: 
 
 interface TransactionsInfiniteQueryBaseProps {
   networkId: number
-  timestamp: number
   skip?: boolean
 }
 
@@ -76,15 +76,15 @@ interface AddressTransactionsInfiniteQueryProps extends TransactionsInfiniteQuer
 
 export const addressTransactionsInfiniteQuery = ({
   addressHash,
-  timestamp,
   networkId,
   skip
 }: AddressTransactionsInfiniteQueryProps) =>
   infiniteQueryOptions({
-    queryKey: ['address', addressHash, 'transactions', { timestamp, networkId }],
+    queryKey: ['address', addressHash, 'transactions', { networkId }],
     staleTime: Infinity,
     // 5 minutes after the user navigates away from the address details modal, the cached data will be deleted.
     gcTime: FIVE_MINUTES_MS,
+    meta: { isInfinite: true, isMainnet: networkId === 0 },
     queryFn: !skip
       ? ({ pageParam }) =>
           throttledClient.explorer.addresses.getAddressesAddressTransactions(addressHash, { page: pageParam })
@@ -99,16 +99,16 @@ interface WalletTransactionsInfiniteQueryProps extends TransactionsInfiniteQuery
 
 export const walletTransactionsInfiniteQuery = ({
   addressHashes,
-  timestamp,
   networkId,
   skip
 }: WalletTransactionsInfiniteQueryProps) =>
   infiniteQueryOptions({
-    queryKey: ['wallet', 'transactions', { timestamp, networkId, addressHashes }],
+    queryKey: ['wallet', 'transactions', { networkId, addressHashes }],
     staleTime: Infinity,
     // When the user navigates away from the Transfers page for 5 minutes or when addresses are generated/removed the
     // cached data will be deleted.
     gcTime: FIVE_MINUTES_MS,
+    meta: { isInfinite: true, isMainnet: networkId === 0 },
     queryFn: !skip
       ? ({ pageParam }) =>
           throttledClient.explorer.addresses.postAddressesTransactions({ page: pageParam }, addressHashes)
@@ -129,6 +129,7 @@ export const walletLatestTransactionsQuery = ({ addressHashes, networkId }: Wall
     // When the user navigates away from the Overview page for 5 minutes or when addresses are generated/removed the
     // cached data will be deleted.
     gcTime: FIVE_MINUTES_MS,
+    meta: { isMainnet: networkId === 0 },
     queryFn: () => throttledClient.explorer.addresses.postAddressesTransactions({ page: 1, limit: 5 }, addressHashes)
   })
 

--- a/apps/desktop-wallet/src/api/queries/transactionQueries.ts
+++ b/apps/desktop-wallet/src/api/queries/transactionQueries.ts
@@ -25,7 +25,7 @@ import queryClient from '@/api/queryClient'
 
 export interface AddressLatestTransactionQueryProps {
   addressHash: AddressHash
-  networkId: number
+  networkId?: number
   skip?: boolean
 }
 
@@ -39,30 +39,31 @@ export const addressLatestTransactionQuery = ({ addressHash, networkId, skip }: 
     queryKey: ['address', addressHash, 'transaction', 'latest', { networkId }],
     gcTime: FIVE_MINUTES_MS,
     meta: { isMainnet: networkId === 0 },
-    queryFn: !skip
-      ? async ({ queryKey }) => {
-          const transactions = await throttledClient.explorer.addresses.getAddressesAddressTransactions(addressHash, {
-            page: 1,
-            limit: 1
-          })
+    queryFn:
+      !skip && networkId !== undefined
+        ? async ({ queryKey }) => {
+            const transactions = await throttledClient.explorer.addresses.getAddressesAddressTransactions(addressHash, {
+              page: 1,
+              limit: 1
+            })
 
-          const latestTx = transactions.length > 0 ? transactions[0] : undefined
-          const cachedData = queryClient.getQueryData(queryKey) as AddressLatestTransactionQueryFnData | undefined
-          const cachedLatestTx = cachedData?.latestTx
+            const latestTx = transactions.length > 0 ? transactions[0] : undefined
+            const cachedData = queryClient.getQueryData(queryKey) as AddressLatestTransactionQueryFnData | undefined
+            const cachedLatestTx = cachedData?.latestTx
 
-          // The following block invalidates queries that need to refetch data if a new transaction hash has been
-          // detected. This way, we don't need to use the latest tx hash in the queryKey of each of those queries.
-          if (latestTx !== undefined && latestTx.hash !== cachedLatestTx?.hash) {
-            queryClient.invalidateQueries({ queryKey: ['address', addressHash, 'balance'] })
-            queryClient.invalidateQueries({ queryKey: ['wallet', 'transactions', 'latest'] })
+            // The following block invalidates queries that need to refetch data if a new transaction hash has been
+            // detected. This way, we don't need to use the latest tx hash in the queryKey of each of those queries.
+            if (latestTx !== undefined && latestTx.hash !== cachedLatestTx?.hash) {
+              queryClient.invalidateQueries({ queryKey: ['address', addressHash, 'balance'] })
+              queryClient.invalidateQueries({ queryKey: ['wallet', 'transactions', 'latest'] })
+            }
+
+            return {
+              addressHash, // Needed in combine functions to identify which address the latestTx refers to
+              latestTx
+            }
           }
-
-          return {
-            addressHash, // Needed in combine functions to identify which address the latestTx refers to
-            latestTx
-          }
-        }
-      : skipToken
+        : skipToken
   })
 
 interface TransactionsInfiniteQueryBaseProps {
@@ -85,10 +86,11 @@ export const addressTransactionsInfiniteQuery = ({
     // 5 minutes after the user navigates away from the address details modal, the cached data will be deleted.
     gcTime: FIVE_MINUTES_MS,
     meta: { isInfinite: true, isMainnet: networkId === 0 },
-    queryFn: !skip
-      ? ({ pageParam }) =>
-          throttledClient.explorer.addresses.getAddressesAddressTransactions(addressHash, { page: pageParam })
-      : skipToken,
+    queryFn:
+      !skip && networkId !== undefined
+        ? ({ pageParam }) =>
+            throttledClient.explorer.addresses.getAddressesAddressTransactions(addressHash, { page: pageParam })
+        : skipToken,
     initialPageParam: 1,
     getNextPageParam: (lastPage, _, lastPageParam) => (lastPage.length > 0 ? (lastPageParam += 1) : null)
   })
@@ -109,16 +111,17 @@ export const walletTransactionsInfiniteQuery = ({
     // cached data will be deleted.
     gcTime: FIVE_MINUTES_MS,
     meta: { isInfinite: true, isMainnet: networkId === 0 },
-    queryFn: !skip
-      ? ({ pageParam }) =>
-          throttledClient.explorer.addresses.postAddressesTransactions({ page: pageParam }, addressHashes)
-      : skipToken,
+    queryFn:
+      !skip && networkId !== undefined
+        ? ({ pageParam }) =>
+            throttledClient.explorer.addresses.postAddressesTransactions({ page: pageParam }, addressHashes)
+        : skipToken,
     initialPageParam: 1,
     getNextPageParam: (lastPage, _, lastPageParam) => (lastPage.length > 0 ? (lastPageParam += 1) : null)
   })
 
 interface WalletLatestTransactionsQueryProps {
-  networkId: number
+  networkId?: number
   addressHashes: AddressHash[]
 }
 
@@ -130,7 +133,10 @@ export const walletLatestTransactionsQuery = ({ addressHashes, networkId }: Wall
     // cached data will be deleted.
     gcTime: FIVE_MINUTES_MS,
     meta: { isMainnet: networkId === 0 },
-    queryFn: () => throttledClient.explorer.addresses.postAddressesTransactions({ page: 1, limit: 5 }, addressHashes)
+    queryFn:
+      networkId !== undefined
+        ? () => throttledClient.explorer.addresses.postAddressesTransactions({ page: 1, limit: 5 }, addressHashes)
+        : skipToken
   })
 
 interface TransactionQueryProps extends SkipProp {

--- a/apps/desktop-wallet/src/api/queryClient.ts
+++ b/apps/desktop-wallet/src/api/queryClient.ts
@@ -20,13 +20,11 @@ import { FIVE_MINUTES_MS, MAX_API_RETRIES, ONE_MINUTE_MS } from '@alephium/share
 import { QueryClient } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 
-export const DELETE_INACTIVE_QUERY_DATA_AFTER = FIVE_MINUTES_MS
-
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: ONE_MINUTE_MS,
-      gcTime: DELETE_INACTIVE_QUERY_DATA_AFTER,
+      gcTime: FIVE_MINUTES_MS,
       retry: (failureCount, error) => {
         if (
           (error instanceof AxiosError && error.response?.status !== 429) ||

--- a/apps/desktop-wallet/src/features/addressDeletion/useDeleteAddress.ts
+++ b/apps/desktop-wallet/src/features/addressDeletion/useDeleteAddress.ts
@@ -18,6 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { AddressHash } from '@alephium/shared'
 
+import queryClient from '@/api/queryClient'
 import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import { addressDeleted } from '@/storage/addresses/addressesActions'
 import { addressMetadataStorage } from '@/storage/addresses/addressMetadataPersistentStorage'
@@ -34,6 +35,7 @@ const useDeleteAddress = () => {
 
     try {
       addressMetadataStorage.deleteOne(activeWalletId, address.index)
+      queryClient.removeQueries({ queryKey: ['address', addressHash] })
       dispatch(addressDeleted(address.hash))
     } catch (error) {
       console.error(error)

--- a/apps/desktop-wallet/src/features/dataPolling/useAddressesDataPolling.ts
+++ b/apps/desktop-wallet/src/features/dataPolling/useAddressesDataPolling.ts
@@ -22,10 +22,11 @@ import { useQueries } from '@tanstack/react-query'
 import { addressLatestTransactionQuery } from '@/api/queries/transactionQueries'
 import { useAppSelector } from '@/hooks/redux'
 import { useUnsortedAddressesHashes } from '@/hooks/useAddresses'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 
 const useAddressesDataPolling = () => {
   const allAddressHashes = useUnsortedAddressesHashes()
-  const networkId = useAppSelector((s) => s.network.settings.networkId)
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
 
   useQueries({
     queries: allAddressHashes.map((addressHash) => ({

--- a/apps/desktop-wallet/src/features/historicChart/useHistoricData.tsx
+++ b/apps/desktop-wallet/src/features/historicChart/useHistoricData.tsx
@@ -76,6 +76,7 @@ const useHistoricData = () => {
       queryKey: ['address', hash, 'history', 'addressBalance', DAILY, ALPH.symbol, { networkId }],
       staleTime: ONE_DAY_MS,
       gcTime: Infinity, // We don't want to delete the balance history if the user stays on a page without a chart for too long
+      meta: { isMainnet: networkId === 0 },
       queryFn: async () => {
         const now = dayjs()
         const thisMoment = now.valueOf()

--- a/apps/desktop-wallet/src/features/historicChart/useHistoricData.tsx
+++ b/apps/desktop-wallet/src/features/historicChart/useHistoricData.tsx
@@ -26,7 +26,6 @@ import dayjs from 'dayjs'
 import { combineIsLoading } from '@/api/apiDataHooks/apiDataHooksUtils'
 import { useAppSelector } from '@/hooks/redux'
 
-const HISTORY_QUERY_KEY = 'history'
 const DAILY = explorer.IntervalType.Daily
 
 type Timestamp = string
@@ -38,8 +37,9 @@ const useHistoricData = () => {
   const networkId = useAppSelector((s) => s.network.settings.networkId)
 
   const { data: alphPriceHistory, isLoading: isLoadingAlphPriceHistory } = useQuery({
-    queryKey: [HISTORY_QUERY_KEY, 'price', ALPH.symbol, { currency }],
+    queryKey: ['history', 'price', ALPH.symbol, { currency }],
     staleTime: ONE_DAY_MS,
+    gcTime: Infinity, // We don't want to delete the price history if the user stays on a page without a chart for too long
     queryFn: () =>
       throttledClient.explorer.market.getMarketPricesSymbolCharts(ALPH.symbol, { currency }).then((rawHistory) => {
         const today = dayjs().format(CHART_DATE_FORMAT)
@@ -73,8 +73,9 @@ const useHistoricData = () => {
     hasHistoricBalances
   } = useQueries({
     queries: allAddressHashes.map((hash) => ({
-      queryKey: [HISTORY_QUERY_KEY, 'addressBalance', DAILY, ALPH.symbol, { hash, networkId }],
+      queryKey: ['address', hash, 'history', 'addressBalance', DAILY, ALPH.symbol, { networkId }],
       staleTime: ONE_DAY_MS,
+      gcTime: Infinity, // We don't want to delete the balance history if the user stays on a page without a chart for too long
       queryFn: async () => {
         const now = dayjs()
         const thisMoment = now.valueOf()

--- a/apps/desktop-wallet/src/features/historicChart/useHistoricData.tsx
+++ b/apps/desktop-wallet/src/features/historicChart/useHistoricData.tsx
@@ -25,6 +25,7 @@ import dayjs from 'dayjs'
 
 import { combineIsLoading } from '@/api/apiDataHooks/apiDataHooksUtils'
 import { useAppSelector } from '@/hooks/redux'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 
 const DAILY = explorer.IntervalType.Daily
 
@@ -34,7 +35,7 @@ type Amount = string
 const useHistoricData = () => {
   const allAddressHashes = useAppSelector((s) => s.addresses.ids as AddressHash[])
   const currency = useAppSelector((s) => s.settings.fiatCurrency).toLowerCase()
-  const networkId = useAppSelector((s) => s.network.settings.networkId)
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
 
   const { data: alphPriceHistory, isLoading: isLoadingAlphPriceHistory } = useQuery({
     queryKey: ['history', 'price', ALPH.symbol, { currency }],
@@ -72,28 +73,34 @@ const useHistoricData = () => {
     isLoading: isLoadingHistoricalAlphBalances,
     hasHistoricBalances
   } = useQueries({
-    queries: allAddressHashes.map((hash) => ({
-      queryKey: ['address', hash, 'history', 'addressBalance', DAILY, ALPH.symbol, { networkId }],
-      staleTime: ONE_DAY_MS,
-      gcTime: Infinity, // We don't want to delete the balance history if the user stays on a page without a chart for too long
-      meta: { isMainnet: networkId === 0 },
-      queryFn: async () => {
-        const now = dayjs()
-        const thisMoment = now.valueOf()
-        const oneYearAgo = now.subtract(365, 'days').valueOf()
+    queries:
+      networkId !== undefined
+        ? allAddressHashes.map((hash) => ({
+            queryKey: ['address', hash, 'history', 'addressBalance', DAILY, ALPH.symbol, { networkId }],
+            staleTime: ONE_DAY_MS,
+            gcTime: Infinity, // We don't want to delete the balance history if the user stays on a page without a chart for too long
+            meta: { isMainnet: networkId === 0 },
+            queryFn: async () => {
+              const now = dayjs()
+              const thisMoment = now.valueOf()
+              const oneYearAgo = now.subtract(365, 'days').valueOf()
 
-        const { amountHistory } = await throttledClient.explorer.addresses.getAddressesAddressAmountHistory(hash, {
-          fromTs: oneYearAgo,
-          toTs: thisMoment,
-          'interval-type': DAILY
-        })
+              const { amountHistory } = await throttledClient.explorer.addresses.getAddressesAddressAmountHistory(
+                hash,
+                {
+                  fromTs: oneYearAgo,
+                  toTs: thisMoment,
+                  'interval-type': DAILY
+                }
+              )
 
-        return {
-          address: hash,
-          amountHistory
-        }
-      }
-    })),
+              return {
+                address: hash,
+                amountHistory
+              }
+            }
+          }))
+        : [],
     combine
   })
 

--- a/apps/desktop-wallet/src/features/switch-wallet/WalletUnlockModal.tsx
+++ b/apps/desktop-wallet/src/features/switch-wallet/WalletUnlockModal.tsx
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { memo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
 import WalletPassphrase from '@/components/Inputs/WalletPassphrase'
@@ -36,7 +36,6 @@ export interface WalletUnlockModalProps {
 const WalletUnlockModal = memo(({ id, walletId }: ModalBaseProp & WalletUnlockModalProps) => {
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
-  const location = useLocation()
   const { unlockWallet } = useWalletLock()
   const { t } = useTranslation()
   const wallets = useAppSelector((s) => s.global.wallets)
@@ -47,15 +46,15 @@ const WalletUnlockModal = memo(({ id, walletId }: ModalBaseProp & WalletUnlockMo
 
   const onUnlockClick = (password: string) => {
     dispatch(closeModal({ id }))
+
+    navigate('/')
+
     unlockWallet({
       event: 'switch',
       walletId,
       password,
       passphrase,
-      afterUnlock: () => {
-        const nextPageLocation = '/wallet/overview'
-        if (location.pathname !== nextPageLocation) navigate(nextPageLocation)
-      }
+      afterUnlock: () => navigate('/wallet/overview')
     })
 
     setPassphrase('')

--- a/apps/desktop-wallet/src/features/transactionsDisplay/useFetchTransactionTokens.ts
+++ b/apps/desktop-wallet/src/features/transactionsDisplay/useFetchTransactionTokens.ts
@@ -26,6 +26,8 @@ import { combineDefined } from '@/api/apiDataHooks/apiDataHooksUtils'
 import useFetchTokensSeparatedByType from '@/api/apiDataHooks/utils/useFetchTokensSeparatedByType'
 import { fungibleTokenMetadataQuery, nftDataQuery, nftMetadataQuery } from '@/api/queries/tokenQueries'
 import useTransactionAmountDeltas from '@/features/transactionsDisplay/useTransactionAmountDeltas'
+import { useAppSelector } from '@/hooks/redux'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 import { ListedFT, NonStandardToken, UnlistedFT } from '@/types/tokens'
 
 type AmountDelta = { amount: bigint }
@@ -48,6 +50,7 @@ const useFetchTransactionTokens = (
   tx: Transaction | PendingTransaction,
   addressHash: AddressHash
 ): TransactionTokens => {
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
   const { alphAmount, tokenAmounts } = useTransactionAmountDeltas(tx, addressHash)
 
   const {
@@ -56,17 +59,17 @@ const useFetchTransactionTokens = (
   } = useFetchTokensSeparatedByType(tokenAmounts)
 
   const { data: unlistedFts, isLoading: isLoadingUnlistedFTs } = useQueries({
-    queries: unlistedFtIds.map((id) => fungibleTokenMetadataQuery({ id })),
+    queries: unlistedFtIds.map((id) => fungibleTokenMetadataQuery({ id, networkId })),
     combine: combineDefined
   })
 
   const { data: nftsMetadata, isLoading: isLoadingNFTsMetadata } = useQueries({
-    queries: nftIds.map((id) => nftMetadataQuery({ id })),
+    queries: nftIds.map((id) => nftMetadataQuery({ id, networkId })),
     combine: combineDefined
   })
 
   const { data: nftsData, isLoading: isLoadingNFTsData } = useQueries({
-    queries: nftsMetadata.map(({ id, tokenUri }) => nftDataQuery({ id, tokenUri })),
+    queries: nftsMetadata.map(({ id, tokenUri }) => nftDataQuery({ id, tokenUri, networkId })),
     combine: combineDefined
   })
 

--- a/apps/desktop-wallet/src/hooks/useWalletLock.ts
+++ b/apps/desktop-wallet/src/hooks/useWalletLock.ts
@@ -19,13 +19,14 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { EncryptedMnemonicVersion, keyring, NonSensitiveAddressData } from '@alephium/keyring'
 import { useCallback } from 'react'
 
+import { usePersistQueryClientContext } from '@/api/persistQueryClientContext'
 import useAnalytics from '@/features/analytics/useAnalytics'
 import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import useAddressGeneration from '@/hooks/useAddressGeneration'
 import { addressMetadataStorage } from '@/storage/addresses/addressMetadataPersistentStorage'
 import { contactsStorage } from '@/storage/addresses/contactsPersistentStorage'
 import { passwordValidationFailed } from '@/storage/auth/authActions'
-import { userDataMigrationFailed } from '@/storage/global/globalActions'
+import { toggleAppLoading, userDataMigrationFailed } from '@/storage/global/globalActions'
 import { walletLocked, walletSwitched, walletUnlocked } from '@/storage/wallets/walletActions'
 import { walletStorage } from '@/storage/wallets/walletPersistentStorage'
 import { StoredEncryptedWallet } from '@/types/wallet'
@@ -44,15 +45,19 @@ const useWalletLock = () => {
   const { restoreAddressesFromMetadata } = useAddressGeneration()
   const dispatch = useAppDispatch()
   const { sendAnalytics } = useAnalytics()
+  const { restoreQueryCache, clearQueryCache } = usePersistQueryClientContext()
 
   const lockWallet = useCallback(
     (lockedFrom?: string) => {
       keyring.clear()
+
+      clearQueryCache()
+
       dispatch(walletLocked())
 
       if (lockedFrom) sendAnalytics({ event: 'Locked wallet', props: { origin: lockedFrom } })
     },
-    [dispatch, sendAnalytics]
+    [dispatch, sendAnalytics, clearQueryCache]
   )
 
   const unlockWallet = async (props: UnlockWalletProps | null) => {
@@ -73,6 +78,8 @@ const useWalletLock = () => {
       dispatch(passwordValidationFailed())
       return
     }
+
+    dispatch(toggleAppLoading(true))
 
     try {
       await migrateUserData(encryptedWallet.id, password, version)
@@ -97,6 +104,9 @@ const useWalletLock = () => {
       initialAddress
     }
 
+    clearQueryCache()
+    await restoreQueryCache(encryptedWallet.id)
+
     if (!isPassphraseUsed) {
       await restoreAddressesFromMetadata(encryptedWallet.id, isPassphraseUsed)
 
@@ -113,6 +123,8 @@ const useWalletLock = () => {
     }
 
     dispatch(event === 'unlock' ? walletUnlocked(payload) : walletSwitched(payload))
+
+    dispatch(toggleAppLoading(false))
 
     afterUnlock()
 

--- a/apps/desktop-wallet/src/index.tsx
+++ b/apps/desktop-wallet/src/index.tsx
@@ -22,20 +22,18 @@ import '@yaireo/tagify/dist/tagify.css' // Tagify CSS: important to import after
 
 import isPropValid from '@emotion/is-prop-valid'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
-import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
 import { StrictMode, Suspense } from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 import { HashRouter as Router } from 'react-router-dom'
 import { StyleSheetManager } from 'styled-components'
 
-import queryClient from '@/api/queryClient'
+import { PersistQueryClientContextProvider } from '@/api/persistQueryClientContext'
 import App from '@/App'
 import Tooltips from '@/components/Tooltips'
 import AnalyticsProvider from '@/features/analytics/AnalyticsProvider'
 import * as serviceWorker from '@/serviceWorker'
 import { store } from '@/storage/store'
-import tanstackIndexedDBPersister from '@/storage/tanstackIndexedDBPersister'
 
 // The app still behaves as if React 17 is used. This is because
 // `react-custom-scrollbars` is not working with React 18 yet.
@@ -49,13 +47,10 @@ ReactDOM.render(
         <Router>
           <Suspense fallback="loading">
             <StyleSheetManager shouldForwardProp={shouldForwardProp}>
-              <PersistQueryClientProvider
-                client={queryClient}
-                persistOptions={{ persister: tanstackIndexedDBPersister, maxAge: Infinity }}
-              >
+              <PersistQueryClientContextProvider>
                 <App />
                 <ReactQueryDevtools initialIsOpen={false} />
-              </PersistQueryClientProvider>
+              </PersistQueryClientContextProvider>
               <Tooltips />
             </StyleSheetManager>
           </Suspense>

--- a/apps/desktop-wallet/src/modals/NFTDetailsModal.tsx
+++ b/apps/desktop-wallet/src/modals/NFTDetailsModal.tsx
@@ -97,18 +97,21 @@ const NFTCollectionDetails = ({ collectionId }: Pick<NFT, 'collectionId'>) => {
 
   const { data: nftCollectionMetadata } = useQuery({
     queryKey: ['nfts', 'nftCollection', 'nftCollectionMetadata', collectionId],
+    staleTime: Infinity,
+    gcTime: Infinity, // We don't want to delete the collection metadata when the user navigates away from the NFT details modal
     queryFn: !collectionId
       ? skipToken
       : async () =>
           (
             await throttledClient.explorer.tokens.postTokensNftCollectionMetadata([addressFromContractId(collectionId)])
-          )[0] ?? null,
-    staleTime: Infinity
+          )[0] ?? null
   })
 
   const collectionUri = nftCollectionMetadata?.collectionUri
   const { data: nftCollectionData } = useQuery({
     queryKey: ['nfts', 'nftCollection', 'nftCollectionData', collectionId],
+    staleTime: Infinity,
+    gcTime: Infinity, // We don't want to delete the collection data when the user navigates away from the NFT details modal
     queryFn: !collectionUri
       ? skipToken
       : async () => {
@@ -121,8 +124,7 @@ const NFTCollectionDetails = ({ collectionId }: Pick<NFT, 'collectionId'>) => {
               `Response does not match the NFT collection metadata schema. NFT collection URI: ${collectionUri}`
             )
           }
-        },
-    staleTime: Infinity
+        }
   })
 
   if (!nftCollectionData) return null

--- a/apps/desktop-wallet/src/modals/NFTDetailsModal.tsx
+++ b/apps/desktop-wallet/src/modals/NFTDetailsModal.tsx
@@ -33,7 +33,9 @@ import InfoBox from '@/components/InfoBox'
 import NFTThumbnail from '@/components/NFTThumbnail'
 import Truncate from '@/components/Truncate'
 import { ModalBaseProp } from '@/features/modals/modalTypes'
+import { useAppSelector } from '@/hooks/redux'
 import SideModal from '@/modals/SideModal'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
 import { openInWebBrowser } from '@/utils/misc'
 
 export interface NFTDetailsModalProps {
@@ -94,11 +96,13 @@ const NFTDataList = ({ nftId }: NFTDetailsModalProps) => {
 
 const NFTCollectionDetails = ({ collectionId }: Pick<NFT, 'collectionId'>) => {
   const { t } = useTranslation()
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
 
   const { data: nftCollectionMetadata } = useQuery({
     queryKey: ['nfts', 'nftCollection', 'nftCollectionMetadata', collectionId],
     staleTime: Infinity,
     gcTime: Infinity, // We don't want to delete the collection metadata when the user navigates away from the NFT details modal
+    meta: { isMainnet: networkId === 0 },
     queryFn: !collectionId
       ? skipToken
       : async () =>
@@ -112,6 +116,7 @@ const NFTCollectionDetails = ({ collectionId }: Pick<NFT, 'collectionId'>) => {
     queryKey: ['nfts', 'nftCollection', 'nftCollectionData', collectionId],
     staleTime: Infinity,
     gcTime: Infinity, // We don't want to delete the collection data when the user navigates away from the NFT details modal
+    meta: { isMainnet: networkId === 0 },
     queryFn: !collectionUri
       ? skipToken
       : async () => {

--- a/apps/desktop-wallet/src/modals/WalletRemovalModal.tsx
+++ b/apps/desktop-wallet/src/modals/WalletRemovalModal.tsx
@@ -21,6 +21,7 @@ import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from 'styled-components'
 
+import queryClient from '@/api/queryClient'
 import Button from '@/components/Button'
 import InfoBox from '@/components/InfoBox'
 import { Section } from '@/components/PageComponents/PageContainers'
@@ -29,6 +30,7 @@ import useAnalytics from '@/features/analytics/useAnalytics'
 import { closeModal } from '@/features/modals/modalActions'
 import { ModalBaseProp } from '@/features/modals/modalTypes'
 import { useAppDispatch, useAppSelector } from '@/hooks/redux'
+import { useUnsortedAddressesHashes } from '@/hooks/useAddresses'
 import CenteredModal from '@/modals/CenteredModal'
 import { addressMetadataStorage } from '@/storage/addresses/addressMetadataPersistentStorage'
 import { activeWalletDeleted, walletDeleted } from '@/storage/wallets/walletActions'
@@ -45,10 +47,15 @@ const WalletRemovalModal = memo(({ id, walletId, walletName }: ModalBaseProp & W
   const dispatch = useAppDispatch()
   const { sendAnalytics } = useAnalytics()
   const activeWalletId = useAppSelector((s) => s.activeWallet.id)
+  const allAddressHashes = useUnsortedAddressesHashes()
 
   const removeWallet = () => {
     walletStorage.delete(walletId)
     addressMetadataStorage.delete(walletId)
+
+    allAddressHashes.forEach((addressHash) => {
+      queryClient.removeQueries({ queryKey: ['address', addressHash] })
+    })
 
     dispatch(walletId === activeWalletId ? activeWalletDeleted() : walletDeleted(walletId))
     dispatch(closeModal({ id }))

--- a/apps/desktop-wallet/src/pages/HomePage/index.tsx
+++ b/apps/desktop-wallet/src/pages/HomePage/index.tsx
@@ -16,13 +16,10 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { ONE_MINUTE_MS } from '@alephium/shared'
-import { useInterval } from '@alephium/shared-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { fadeInSlowly } from '@/animations'
-import { DELETE_INACTIVE_QUERY_DATA_AFTER } from '@/api/queryClient'
 import AppHeader from '@/components/AppHeader'
 import { FloatingPanel } from '@/components/PageComponents/PageContainers'
 import PanelTitle from '@/components/PageComponents/PanelTitle'
@@ -30,15 +27,12 @@ import { useAppSelector } from '@/hooks/redux'
 import NewWalletActions from '@/pages/HomePage/NewWalletActions'
 import UnlockPanel from '@/pages/HomePage/UnlockPanel'
 import LockedWalletLayout from '@/pages/LockedWalletLayout'
-import { electron } from '@/utils/misc'
 
 const HomePage = () => {
   const { t } = useTranslation()
   const hasAtLeastOneWallet = useAppSelector((state) => state.global.wallets.length > 0)
 
   const [showNewWalletActions, setShowNewWalletActions] = useState(false)
-
-  useInterval(() => electron?.app.reload(), DELETE_INACTIVE_QUERY_DATA_AFTER - ONE_MINUTE_MS)
 
   return (
     <LockedWalletLayout {...fadeInSlowly} animateSideBar>

--- a/apps/desktop-wallet/src/storage/global/globalSlice.ts
+++ b/apps/desktop-wallet/src/storage/global/globalSlice.ts
@@ -16,8 +16,14 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { localStorageNetworkSettingsMigrated } from '@alephium/shared'
-import { createSelector, createSlice } from '@reduxjs/toolkit'
+import {
+  apiClientInitFailed,
+  apiClientInitSucceeded,
+  customNetworkSettingsSaved,
+  localStorageNetworkSettingsMigrated,
+  networkPresetSwitched
+} from '@alephium/shared'
+import { createSelector, createSlice, isAnyOf } from '@reduxjs/toolkit'
 
 import { addressDiscoveryFinished, addressDiscoveryStarted } from '@/storage/addresses/addressesActions'
 import {
@@ -119,6 +125,14 @@ const globalSlice = createSlice({
       })
       .addCase(receiveTestnetTokens.rejected, (state) => {
         state.faucetCallPending = false
+      })
+
+    builder
+      .addMatcher(isAnyOf(networkPresetSwitched, customNetworkSettingsSaved), (state) => {
+        toggleLoading(state, true)
+      })
+      .addMatcher(isAnyOf(apiClientInitSucceeded, apiClientInitFailed), (state) => {
+        toggleLoading(state, false)
       })
   }
 })

--- a/apps/desktop-wallet/src/storage/settings/networkSelectors.ts
+++ b/apps/desktop-wallet/src/storage/settings/networkSelectors.ts
@@ -16,22 +16,11 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { useQuery } from '@tanstack/react-query'
+import { createSelector } from '@reduxjs/toolkit'
 
-import { UseFetchAddressProps } from '@/api/apiDataHooks/address/addressApiDataHooksTypes'
-import { addressAlphBalancesQuery } from '@/api/queries/addressQueries'
-import { useAppSelector } from '@/hooks/redux'
-import { selectCurrentlyOnlineNetworkId } from '@/storage/settings/networkSelectors'
+import { RootState } from '@/storage/store'
 
-const useFetchAddressBalancesAlph = ({ addressHash, skip }: UseFetchAddressProps) => {
-  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
-
-  const { data, isLoading } = useQuery(addressAlphBalancesQuery({ addressHash, networkId, skip }))
-
-  return {
-    data: data?.balances,
-    isLoading
-  }
-}
-
-export default useFetchAddressBalancesAlph
+export const selectCurrentlyOnlineNetworkId = createSelector(
+  (state: RootState) => state.network,
+  (network) => (network.status === 'online' ? network.settings.networkId : undefined)
+)

--- a/apps/desktop-wallet/src/storage/tanstackIndexedDBPersister.ts
+++ b/apps/desktop-wallet/src/storage/tanstackIndexedDBPersister.ts
@@ -24,7 +24,7 @@ import { del, get, set } from 'idb-keyval'
  * @see https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
  * @see https://tanstack.com/query/latest/docs/framework/react/plugins/persistQueryClient#building-a-persister
  */
-const createTanstackIndexedDBPersister = (idbValidKey: IDBValidKey = 'tanstackQuery') =>
+export const createTanstackIndexedDBPersister = (idbValidKey: IDBValidKey = 'tanstackQuery') =>
   ({
     persistClient: async (client: PersistedClient) => {
       await set(idbValidKey, client)
@@ -34,7 +34,3 @@ const createTanstackIndexedDBPersister = (idbValidKey: IDBValidKey = 'tanstackQu
       await del(idbValidKey)
     }
   }) as Persister
-
-const tanstackIndexedDBPersister = createTanstackIndexedDBPersister()
-
-export default tanstackIndexedDBPersister

--- a/apps/desktop-wallet/src/types/window.d.ts
+++ b/apps/desktop-wallet/src/types/window.d.ts
@@ -52,7 +52,6 @@ export interface AlephiumWindow extends Window {
       getSystemLanguage: () => Promise<string | undefined>
       setProxySettings: (proxySettings: ProxySettings) => Promise<void>
       restart: () => void
-      reload: () => void
     }
   }
 }


### PR DESCRIPTION
Supersedes https://github.com/alephium/alephium-frontend/pull/884

1. Implements 1 persister per wallet and swaps them dynamically on wallet unlock. Only the cache of the currently unlocked wallet stays in memory.
2. No persister when the app is locked, everything is removed from memory
1. Removes app reloading
2. Fixes network switch
3. Persist only mainnet data