### PR TITLE
fix:  desktop wallet on Windows while 'About' window is still open leads to a white screen

### DIFF
--- a/apps/desktop-wallet/public/electron.js
+++ b/apps/desktop-wallet/public/electron.js
@@ -129,7 +129,19 @@ const template = [
       ...(isMac
         ? []
         : isWindows
-          ? [{ role: 'about' }, { type: 'separator' }]
+          ? [
+              {
+                label: `About ${app.getName()}`,
+                click: async () => {
+                  dialog.showMessageBoxSync(mainWindow, {
+                    message: `Version ${CURRENT_VERSION}`,
+                    title: app.getName(),
+                    type: 'info'
+                  })
+                }
+              },
+              { type: 'separator' }
+            ]
           : [
               {
                 label: 'About',


### PR DESCRIPTION
ref #964