### PR TITLE
Improve asset selection

### DIFF
--- a/.changeset/clean-spiders-roll.md
+++ b/.changeset/clean-spiders-roll.md
@@ -1,0 +1,5 @@
+---
+"alephium-desktop-wallet": patch
+---
+
+Enable search in asset selection modal

--- a/.changeset/moody-crabs-add.md
+++ b/.changeset/moody-crabs-add.md
@@ -1,0 +1,5 @@
+---
+"alephium-desktop-wallet": patch
+---
+
+Improve accessibility for "Add asset" button

--- a/apps/desktop-wallet/src/api/apiDataHooks/wallet/useFetchWalletNftsSearchStrings.ts
+++ b/apps/desktop-wallet/src/api/apiDataHooks/wallet/useFetchWalletNftsSearchStrings.ts
@@ -1,0 +1,67 @@
+/*
+Copyright 2018 - 2024 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { useQueries } from '@tanstack/react-query'
+import { useMemo } from 'react'
+
+import { combineDefined } from '@/api/apiDataHooks/apiDataHooksUtils'
+import useFetchWalletTokensByType from '@/api/apiDataHooks/wallet/useFetchWalletTokensByType'
+import { nftDataQuery, nftMetadataQuery } from '@/api/queries/tokenQueries'
+import { useAppSelector } from '@/hooks/redux'
+import { selectCurrentlyOnlineNetworkId } from '@/storage/network/networkSelectors'
+import { TokenId } from '@/types/tokens'
+
+const useFetchWalletNftsSearchStrings = () => {
+  const networkId = useAppSelector(selectCurrentlyOnlineNetworkId)
+  const {
+    data: { nftIds },
+    isLoading: isLoadingTokensByType
+  } = useFetchWalletTokensByType({ includeAlph: true })
+
+  const { data: nftsMetadata, isLoading: isLoadingNftsMetadata } = useQueries({
+    queries: nftIds.map((id) => nftMetadataQuery({ id, networkId })),
+    combine: combineDefined
+  })
+
+  const { data: nftsData, isLoading: isLoadingNftsData } = useQueries({
+    queries: nftsMetadata.map(({ id, tokenUri }) =>
+      nftDataQuery({ id, tokenUri, networkId, skip: isLoadingNftsMetadata })
+    ),
+    combine: combineDefined
+  })
+
+  const nftsSearchStringsByNftId = useMemo(
+    () =>
+      nftsData.reduce(
+        (acc, { id, name }) => {
+          acc[id] = `${id} ${name}`
+
+          return acc
+        },
+        {} as Record<TokenId, string>
+      ),
+    [nftsData]
+  )
+
+  return {
+    data: nftsSearchStringsByNftId,
+    isLoading: isLoadingNftsMetadata || isLoadingNftsData || isLoadingTokensByType
+  }
+}
+
+export default useFetchWalletNftsSearchStrings

--- a/apps/desktop-wallet/src/components/Inputs/Select.tsx
+++ b/apps/desktop-wallet/src/components/Inputs/Select.tsx
@@ -293,13 +293,9 @@ export function SelectOptionsModal<T extends OptionValue>({
   // We hide instead of simply not rendering filtered options to avoid changing the height/width of the modal when
   // filtering. When the size of the modal depends on its contents, its size might change when filtering some options
   // out, unless its size is fixed.
-  const [visibleOptions, invisibleOptions] = showOnly
-    ? partition(options, (option) => showOnly.includes(option.value))
-    : [options, []]
+  const [visibleOptions] = showOnly ? partition(options, (option) => showOnly.includes(option.value)) : [options, []]
   const isEmpty = options.length === 0 && emptyListPlaceholder
   const emptySearchResults = visibleOptions.length === 0 && onSearchInput
-  // To display the message without changing the height, remove one of the invisible options
-  if (emptySearchResults) invisibleOptions.pop()
 
   const handleOptionSelect = useCallback(
     (value: T) => {
@@ -384,14 +380,6 @@ export function SelectOptionsModal<T extends OptionValue>({
           )
         })}
         {ListBottomComponent && <div onClick={onClose}>{ListBottomComponent}</div>}
-        {invisibleOptions.map((option) => {
-          const isSelected = option.value === selectedOption?.value
-          return (
-            <OptionItem key={option.value} selected={isSelected} invisible>
-              {optionRender ? optionRender(option, isSelected) : option.label}
-            </OptionItem>
-          )
-        })}
       </OptionSelect>
     </Popup>
   )

--- a/apps/desktop-wallet/src/components/Inputs/Select.tsx
+++ b/apps/desktop-wallet/src/components/Inputs/Select.tsx
@@ -17,7 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { colord } from 'colord'
-import { isEqual, partition } from 'lodash'
+import { isEqual } from 'lodash'
 import { MoreVertical, SearchIcon } from 'lucide-react'
 import {
   KeyboardEvent as ReactKeyboardEvent,
@@ -57,6 +57,7 @@ export type OptionValue = Writable<OptionHTMLAttributes<HTMLOptionElement>['valu
 export interface SelectOption<T extends OptionValue> {
   value: T
   label: string
+  searchString?: string
 }
 
 interface SelectProps<T extends OptionValue> {
@@ -109,10 +110,6 @@ function Select<T extends OptionValue>({
   const [showPopup, setShowPopup] = useState(false)
   const [hookCoordinates, setHookCoordinates] = useState<Coordinates | undefined>(undefined)
 
-  const [searchInput, setSearchInput] = useState('')
-  const filteredOptions =
-    searchInput.length > 2 ? options.filter((o) => o.label.toLocaleLowerCase().includes(searchInput)) : options
-
   const multipleAvailableOptions = options.length > 1
 
   const getContainerCenter = (): Coordinates | undefined => {
@@ -160,7 +157,6 @@ function Select<T extends OptionValue>({
   const handlePopupClose = () => {
     setShowPopup(false)
     selectedValueRef.current?.focus()
-    setSearchInput('')
   }
 
   useEffect(() => {
@@ -241,8 +237,7 @@ function Select<T extends OptionValue>({
             onClose={handlePopupClose}
             parentSelectRef={selectedValueRef}
             ListBottomComponent={ListBottomComponent}
-            showOnly={searchInput.length > 2 ? filteredOptions.map((o) => o.value) : undefined}
-            onSearchInput={isSearchable ? (text) => setSearchInput(text.toLocaleLowerCase()) : undefined}
+            isSearchable={isSearchable}
           />
         )}
       </ModalPortal>
@@ -258,14 +253,13 @@ interface SelectOptionsModalProps<T extends OptionValue> {
   hookCoordinates?: Coordinates
   title?: string
   optionRender?: (option: SelectOption<T>, isSelected: boolean) => ReactNode
-  onSearchInput?: (input: string) => void
   searchPlaceholder?: string
-  showOnly?: T[]
   emptyListPlaceholder?: string
   parentSelectRef?: RefObject<HTMLDivElement | HTMLButtonElement>
   minWidth?: number
   ListBottomComponent?: ReactNode
   floatingOptions?: boolean
+  isSearchable?: boolean
 }
 
 export function SelectOptionsModal<T extends OptionValue>({
@@ -276,36 +270,40 @@ export function SelectOptionsModal<T extends OptionValue>({
   hookCoordinates,
   title,
   optionRender,
-  onSearchInput,
   searchPlaceholder,
-  showOnly,
   emptyListPlaceholder,
   parentSelectRef,
   minWidth,
   ListBottomComponent,
-  floatingOptions
+  floatingOptions,
+  isSearchable
 }: SelectOptionsModalProps<T>) {
   const { t } = useTranslation()
   const optionSelectRef = useRef<HTMLDivElement>(null)
   const theme = useTheme()
   const searchInputRef = useRef<HTMLInputElement>(null)
 
-  // We hide instead of simply not rendering filtered options to avoid changing the height/width of the modal when
-  // filtering. When the size of the modal depends on its contents, its size might change when filtering some options
-  // out, unless its size is fixed.
-  const [visibleOptions] = showOnly ? partition(options, (option) => showOnly.includes(option.value)) : [options, []]
+  const [searchInput, setSearchInput] = useState('')
+  const filteredOptions =
+    searchInput.length > 2
+      ? options.filter((option) =>
+          option.searchString
+            ? option.searchString.includes(searchInput)
+            : option.label.toLocaleLowerCase().includes(searchInput)
+        )
+      : options
   const isEmpty = options.length === 0 && emptyListPlaceholder
-  const emptySearchResults = visibleOptions.length === 0 && onSearchInput
+  const emptySearchResults = filteredOptions.length === 0 && isSearchable
 
   const handleOptionSelect = useCallback(
     (value: T) => {
-      const selectedValue = visibleOptions.find((o) => o.value === value)
+      const selectedValue = filteredOptions.find((o) => o.value === value)
       if (!selectedValue) return
 
       setValue(selectedValue)
       onClose()
     },
-    [onClose, visibleOptions, setValue]
+    [onClose, filteredOptions, setValue]
   )
 
   const parentSelectWidth = parentSelectRef?.current?.clientWidth
@@ -329,14 +327,14 @@ export function SelectOptionsModal<T extends OptionValue>({
       hookCoordinates={hookCoordinates}
       minWidth={width}
       extraHeaderContent={
-        onSearchInput &&
+        isSearchable &&
         !isEmpty && (
           <Searchbar
             name="search"
             inputFieldRef={searchInputRef}
             placeholder={searchPlaceholder ?? t('Search')}
             Icon={SearchIcon}
-            onChange={(e) => onSearchInput(e.target.value)}
+            onChange={(e) => setSearchInput(e.target.value.toLocaleLowerCase())}
             heightSize="small"
             noMargin
           />
@@ -354,7 +352,7 @@ export function SelectOptionsModal<T extends OptionValue>({
         ) : emptySearchResults ? (
           <OptionItem selected={false}>{t('No options match the search criteria.')}</OptionItem>
         ) : null}
-        {visibleOptions.map((option) => {
+        {filteredOptions.map((option) => {
           const isSelected = option.value === selectedOption?.value
           return (
             <OptionItem

--- a/apps/desktop-wallet/src/features/send/AddressInputs.tsx
+++ b/apps/desktop-wallet/src/features/send/AddressInputs.tsx
@@ -37,7 +37,6 @@ import AddressSelectModal from '@/modals/AddressSelectModal'
 import { useMoveFocusOnPreviousModal } from '@/modals/ModalContainer'
 import ModalPortal from '@/modals/ModalPortal'
 import { selectAllContacts } from '@/storage/addresses/addressesSelectors'
-import { filterContacts } from '@/utils/contacts'
 
 interface AddressInputsProps {
   defaultFromAddress: AddressHash
@@ -67,18 +66,15 @@ const AddressInputs = ({
 
   const [isContactSelectModalOpen, setIsContactSelectModalOpen] = useState(false)
   const [isAddressSelectModalOpen, setIsAddressSelectModalOpen] = useState(false)
-  const [filteredContacts, setFilteredContacts] = useState(contacts)
 
   const contactSelectOptions: SelectOption<AddressHash>[] = contacts.map((contact) => ({
     value: contact.address,
-    label: contact.name
+    label: contact.name,
+    searchString: `${contact.name.toLowerCase()} ${contact.address.toLowerCase()}`
   }))
 
   const handleContactSelect = (contactAddress: SelectOption<AddressHash>) =>
     onContactSelect && onContactSelect(contactAddress.value)
-
-  const handleContactsSearch = (searchInput: string) =>
-    setFilteredContacts(filterContacts(contacts, searchInput.toLowerCase()))
 
   const handleToOwnAddressModalClose = () => {
     setIsAddressSelectModalOpen(false)
@@ -87,7 +83,6 @@ const AddressInputs = ({
 
   const handleContactSelectModalClose = () => {
     setIsContactSelectModalOpen(false)
-    setFilteredContacts(contacts)
     moveFocusOnPreviousModal()
   }
 
@@ -156,10 +151,9 @@ const AddressInputs = ({
           <SelectOptionsModal
             title={t('Choose a contact')}
             options={contactSelectOptions}
-            showOnly={filteredContacts.map((contact) => contact.address)}
             setValue={handleContactSelect}
             onClose={handleContactSelectModalClose}
-            onSearchInput={handleContactsSearch}
+            isSearchable
             searchPlaceholder={t('Search for name or a hash...')}
             optionRender={(contact) => (
               <SelectOptionItemContent

--- a/apps/desktop-wallet/src/features/send/TokensAmountInputs.tsx
+++ b/apps/desktop-wallet/src/features/send/TokensAmountInputs.tsx
@@ -191,115 +191,112 @@ const TokensAmountInputs = ({
   }
 
   return (
-    <InputsSection
-      title={t(assetAmounts.length < 2 ? 'Asset' : 'Assets')}
-      HeaderActions={
-        canAddMultipleAssets && (
-          <AddAssetSection>
-            <ActionLink Icon={Plus} onClick={handleAddAssetClick} withBackground iconPosition="left">
-              {t('Add asset')}
-            </ActionLink>
-          </AddAssetSection>
-        )
-      }
-      className={className}
-    >
-      <AssetAmounts ref={selectedValueRef}>
-        {assetAmounts.map(({ id, amountInput = '' }, index) => {
-          const tokenBalances = tokensBalances.find((token) => token.id === id)
+    <>
+      <InputsSection title={t(assetAmounts.length < 2 ? 'Asset' : 'Assets')} className={className}>
+        <AssetAmounts ref={selectedValueRef}>
+          {assetAmounts.map(({ id, amountInput = '' }, index) => {
+            const tokenBalances = tokensBalances.find((token) => token.id === id)
 
-          if (!tokenBalances) return
+            if (!tokenBalances) return
 
-          const ft = listedFts.find((token) => token.id === id) ?? unlistedFts.find((token) => token.id === id)
+            const ft = listedFts.find((token) => token.id === id) ?? unlistedFts.find((token) => token.id === id)
 
-          // TODO: If ALPH, subtract dust for each other token, possibly by querying the node `/addresses/{address}/utxos`
-          const availableHumanReadableAmount = toHumanReadableAmount(
-            tokenBalances.availableBalance ?? BigInt(0),
-            ft?.decimals ?? 0
-          )
+            // TODO: If ALPH, subtract dust for each other token, possibly by querying the node `/addresses/{address}/utxos`
+            const availableHumanReadableAmount = toHumanReadableAmount(
+              tokenBalances.availableBalance ?? BigInt(0),
+              ft?.decimals ?? 0
+            )
 
-          return (
-            <BoxStyled key={id}>
-              <AssetSelect
-                onMouseDown={() => handleOpenAddressTokensSelectModal(index)}
-                onKeyDown={(e) => onEnterOrSpace(e, () => handleOpenAddressTokensSelectModal(index))}
-              >
-                <SelectInput
-                  className={className}
-                  disabled={disabled || !allowMultiple || !canAddMultipleAssets}
-                  id={id}
+            return (
+              <BoxStyled key={id}>
+                <AssetSelect
+                  onMouseDown={() => handleOpenAddressTokensSelectModal(index)}
+                  onKeyDown={(e) => onEnterOrSpace(e, () => handleOpenAddressTokensSelectModal(index))}
                 >
-                  <AssetLogo tokenId={id} size={20} />
-                  <AssetName>
-                    <Truncate>
-                      <SelectOptionTokenName tokenId={id} />
-                    </Truncate>
-                  </AssetName>
-                  {!disabled && (
-                    <SelectVerticalDots>
-                      <MoreVertical size={16} />
-                    </SelectVerticalDots>
-                  )}
-                </SelectInput>
-              </AssetSelect>
+                  <SelectInput
+                    className={className}
+                    disabled={disabled || !allowMultiple || !canAddMultipleAssets}
+                    id={id}
+                  >
+                    <AssetLogo tokenId={id} size={20} />
+                    <AssetName>
+                      <Truncate>
+                        <SelectOptionTokenName tokenId={id} />
+                      </Truncate>
+                    </AssetName>
+                    {!disabled && (
+                      <SelectVerticalDots>
+                        <MoreVertical size={16} />
+                      </SelectVerticalDots>
+                    )}
+                  </SelectInput>
+                </AssetSelect>
 
-              {!nftIds.includes(id) && (
-                <>
-                  <HorizontalDividerStyled />
+                {!nftIds.includes(id) && (
+                  <>
+                    <HorizontalDividerStyled />
 
-                  <AssetAmountRow>
-                    <AssetAmountInput
-                      value={amountInput}
-                      onChange={(e) => handleTokenAmountChange(index, e.target.value)}
-                      onClick={() => setSelectedTokenRowIndex(index)}
-                      onMouseDown={() => setSelectedTokenRowIndex(index)}
-                      onKeyDown={(e) => onEnterOrSpace(e, () => setSelectedTokenRowIndex(index))}
-                      type="number"
-                      min={id === ALPH.id ? minAmountInAlph : 0}
-                      max={availableHumanReadableAmount}
-                      aria-label={t('Amount')}
-                      label={`${t('Amount')} ${ft ? `(${ft.symbol})` : ''}`}
-                      error={errors[index]}
-                    />
+                    <AssetAmountRow>
+                      <AssetAmountInput
+                        value={amountInput}
+                        onChange={(e) => handleTokenAmountChange(index, e.target.value)}
+                        onClick={() => setSelectedTokenRowIndex(index)}
+                        onMouseDown={() => setSelectedTokenRowIndex(index)}
+                        onKeyDown={(e) => onEnterOrSpace(e, () => setSelectedTokenRowIndex(index))}
+                        type="number"
+                        min={id === ALPH.id ? minAmountInAlph : 0}
+                        max={availableHumanReadableAmount}
+                        aria-label={t('Amount')}
+                        label={`${t('Amount')} ${ft ? `(${ft.symbol})` : ''}`}
+                        error={errors[index]}
+                      />
 
-                    <AvailableAmountColumn>
-                      <AvailableAmount tabIndex={0}>
-                        <Amount
-                          tokenId={id}
-                          value={tokenBalances.availableBalance}
-                          nbOfDecimalsToShow={4}
-                          color={theme.font.secondary}
-                          isLoading={isLoadingTokensBalances}
-                        />
-                        <span> {t('Available').toLowerCase()}</span>
-                      </AvailableAmount>
-                      <ActionLink onClick={() => handleTokenAmountChange(index, availableHumanReadableAmount)}>
-                        {t('Use max amount')}
-                      </ActionLink>
-                    </AvailableAmountColumn>
-                  </AssetAmountRow>
-                </>
-              )}
-              {assetAmounts.length > 1 && <DeleteButton onClick={() => handleRemoveAssetClick(index)} />}
-            </BoxStyled>
-          )
-        })}
-      </AssetAmounts>
-      <ModalPortal>
-        {isAssetSelectModalOpen && selectedOption && remainingAvailableAssetsOptions.length > 0 && (
-          <SelectOptionsModal
-            title={t('Select an asset')}
-            options={remainingAvailableAssetsOptions}
-            selectedOption={selectedOption}
-            setValue={selectAsset}
-            onClose={handleAssetSelectModalClose}
-            parentSelectRef={selectedValueRef}
-            optionRender={renderOption}
-            isSearchable
-          />
-        )}
-      </ModalPortal>
-    </InputsSection>
+                      <AvailableAmountColumn>
+                        <AvailableAmount tabIndex={0}>
+                          <Amount
+                            tokenId={id}
+                            value={tokenBalances.availableBalance}
+                            nbOfDecimalsToShow={4}
+                            color={theme.font.secondary}
+                            isLoading={isLoadingTokensBalances}
+                          />
+                          <span> {t('Available').toLowerCase()}</span>
+                        </AvailableAmount>
+                        <ActionLink onClick={() => handleTokenAmountChange(index, availableHumanReadableAmount)}>
+                          {t('Use max amount')}
+                        </ActionLink>
+                      </AvailableAmountColumn>
+                    </AssetAmountRow>
+                  </>
+                )}
+                {assetAmounts.length > 1 && <DeleteButton onClick={() => handleRemoveAssetClick(index)} />}
+              </BoxStyled>
+            )
+          })}
+        </AssetAmounts>
+        <ModalPortal>
+          {isAssetSelectModalOpen && selectedOption && remainingAvailableAssetsOptions.length > 0 && (
+            <SelectOptionsModal
+              title={t('Select an asset')}
+              options={remainingAvailableAssetsOptions}
+              selectedOption={selectedOption}
+              setValue={selectAsset}
+              onClose={handleAssetSelectModalClose}
+              parentSelectRef={selectedValueRef}
+              optionRender={renderOption}
+              isSearchable
+            />
+          )}
+        </ModalPortal>
+      </InputsSection>
+      {canAddMultipleAssets && (
+        <AddAssetSection>
+          <ActionLink Icon={Plus} onClick={handleAddAssetClick} withBackground iconPosition="left">
+            {t('Add asset')}
+          </ActionLink>
+        </AddAssetSection>
+      )}
+    </>
   )
 }
 

--- a/apps/desktop-wallet/src/modals/AddressSelectModal.tsx
+++ b/apps/desktop-wallet/src/modals/AddressSelectModal.tsx
@@ -17,13 +17,17 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { AddressHash } from '@alephium/shared'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { useFetchWalletBalancesAlphByAddress } from '@/api/apiDataHooks/wallet/useFetchWalletBalancesAlph'
+import { useFetchWalletBalancesTokensByAddress } from '@/api/apiDataHooks/wallet/useFetchWalletBalancesTokens'
+import useFetchWalletFts from '@/api/apiDataHooks/wallet/useFetchWalletFts'
+import useFetchWalletNftsSearchStrings from '@/api/apiDataHooks/wallet/useFetchWalletNftsSearchStrings'
 import { SelectOption, SelectOptionsModal } from '@/components/Inputs/Select'
 import SelectOptionAddress from '@/components/Inputs/SelectOptionAddress'
-import { useFilterAddressesByText } from '@/features/addressFiltering/addressFilteringHooks'
 import { useAppSelector } from '@/hooks/redux'
+import { useFetchSortedAddressesHashes } from '@/hooks/useAddresses'
 import { selectAllAddresses } from '@/storage/addresses/addressesSelectors'
 
 interface AddressSelectModalProps {
@@ -44,15 +48,8 @@ const AddressSelectModal = ({
   emptyListPlaceholder
 }: AddressSelectModalProps) => {
   const { t } = useTranslation()
-  const addresses = useAppSelector(selectAllAddresses)
 
-  const [searchInput, setSearchInput] = useState('')
-  const filteredAddresses = useFilterAddressesByText(searchInput.toLowerCase())
-
-  const addressSelectOptions: SelectOption<AddressHash>[] = addressOptions.map((addressHash) => ({
-    value: addressHash,
-    label: addresses.find((address) => address.hash === addressHash)?.label ?? addressHash
-  }))
+  const addressSelectOptions: SelectOption<AddressHash>[] = useAddressSelectOptions()
 
   const defaultSelectedOption = addressSelectOptions.find((a) => a.value === defaultSelectedAddress)
   const [selectedOption, setSelectedOption] = useState(defaultSelectedOption)
@@ -76,11 +73,9 @@ const AddressSelectModal = ({
       title={title}
       options={addressSelectOptions}
       selectedOption={selectedOption}
-      showOnly={filteredAddresses}
       setValue={handleAddressSelect}
       onClose={onClose}
-      onSearchInput={setSearchInput}
-      searchPlaceholder={t('Search for name or a hash...')}
+      isSearchable
       minWidth={620}
       optionRender={(option, isSelected) => <SelectOptionAddress addressHash={option.value} isSelected={isSelected} />}
       emptyListPlaceholder={emptyListPlaceholder || t('There are no available addresses.')}
@@ -90,3 +85,57 @@ const AddressSelectModal = ({
 }
 
 export default AddressSelectModal
+
+// TODO: See how it can be DRY'ed with useFilterAddressesByText
+const useAddressSelectOptions = () => {
+  const addresses = useAppSelector(selectAllAddresses)
+  const { data: sortedAddressHashes } = useFetchSortedAddressesHashes()
+  const { listedFts, unlistedFts } = useFetchWalletFts({ sort: false })
+  const { data: nftsSearchStringsByNftId } = useFetchWalletNftsSearchStrings()
+  const { data: addressesAlphBalances } = useFetchWalletBalancesAlphByAddress()
+  const { data: addressesTokensBalances } = useFetchWalletBalancesTokensByAddress()
+
+  return useMemo(
+    () =>
+      sortedAddressHashes.map((hash) => {
+        const address = addresses.find((address) => address.hash === hash)
+        const addressAlphBalances = addressesAlphBalances[hash]
+        const addressHasAlphBalances = (addressAlphBalances?.totalBalance ?? 0) > 0
+        const addressTokensBalances = addressesTokensBalances[hash] ?? []
+        const addressTokensSearchableString = addressTokensBalances
+          .map(({ id }) => {
+            const listedFt = listedFts.find((token) => token.id === id)
+
+            if (listedFt) return `${listedFt.name.toLowerCase()} ${listedFt.symbol.toLowerCase()} ${id}`
+
+            const unlistedFt = unlistedFts.find((token) => token.id === id)
+
+            if (unlistedFt) return `${unlistedFt.name.toLowerCase()} ${unlistedFt.symbol.toLowerCase()} ${id}`
+
+            const nftSearchString = nftsSearchStringsByNftId[id]
+
+            if (nftSearchString) return nftSearchString.toLowerCase()
+
+            return ''
+          })
+          .join(' ')
+
+        return {
+          value: hash,
+          label: address?.label || hash,
+          searchString: `${hash.toLowerCase()} ${address?.label?.toLowerCase() ?? ''} ${
+            addressHasAlphBalances ? 'alephium alph' : ''
+          } ${addressTokensSearchableString}`
+        }
+      }),
+    [
+      addresses,
+      addressesAlphBalances,
+      addressesTokensBalances,
+      listedFts,
+      nftsSearchStringsByNftId,
+      sortedAddressHashes,
+      unlistedFts
+    ]
+  )
+}


### PR DESCRIPTION
This PR implements 2 of the most frequent requests we had from our community:
- Be able to search for an asset in the send modal
- Be able to filter addresses with NFT names

It also optimizes our searchable select modals and reduces rerenders by keeping a local state instead of passing it to the parent component.

Related issues:
- https://github.com/alephium/alephium-frontend/issues/923
- https://github.com/alephium/alephium-frontend/issues/881
- https://github.com/alephium/alephium-frontend/issues/394