### PR TITLE
Hide bytecode field behind an expandable section

### DIFF
--- a/.changeset/afraid-feet-impress.md
+++ b/.changeset/afraid-feet-impress.md
@@ -1,0 +1,5 @@
+---
+"@alephium/mobile-wallet": patch
+---
+
+Hide bytecode field behind an expandable section

--- a/apps/mobile-wallet/src/components/ExpandableRow.tsx
+++ b/apps/mobile-wallet/src/components/ExpandableRow.tsx
@@ -18,7 +18,6 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { ChevronDown } from 'lucide-react-native'
 import { ReactNode, useState } from 'react'
-import { useTranslation } from 'react-i18next'
 import { StyleProp, View, ViewStyle } from 'react-native'
 import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated'
 import styled, { useTheme } from 'styled-components/native'
@@ -28,29 +27,30 @@ import AppText from '~/components/AppText'
 interface ExpandableRowProps {
   children: ReactNode
   title?: string
+  titleComponent?: ReactNode
   style?: StyleProp<ViewStyle>
 }
 
-const ExpandableRow = ({ children, title, style }: ExpandableRowProps) => {
+const ExpandableRow = ({ children, title, titleComponent, style }: ExpandableRowProps) => {
   const theme = useTheme()
-  const { t } = useTranslation()
 
   const [isExpanded, setIsExpanded] = useState(false)
 
   const toggleExpanded = () => setIsExpanded(!isExpanded)
 
   const collapsableSectionStyle = useAnimatedStyle(() => ({
-    opacity: withTiming(isExpanded ? 1 : 0)
+    opacity: withTiming(isExpanded ? 1 : 0),
+    height: withTiming(isExpanded ? 'auto' : 0)
   }))
 
   const chevronStyle = useAnimatedStyle(() => ({
-    transform: [{ rotate: withTiming(isExpanded ? '180deg' : '0deg') }]
+    transform: [{ rotate: withTiming(isExpanded ? '-180deg' : '-90deg') }]
   }))
 
   return (
     <View style={style}>
       <Header onPress={toggleExpanded}>
-        <Title>{title ?? t('Advanced options')}</Title>
+        {titleComponent ?? <Title>{title}</Title>}
         <Animated.View style={chevronStyle}>
           <ChevronDownStyled size={20} color={theme.font.primary} />
         </Animated.View>

--- a/apps/mobile-wallet/src/components/ExpandableRow.tsx
+++ b/apps/mobile-wallet/src/components/ExpandableRow.tsx
@@ -18,6 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { ChevronDown } from 'lucide-react-native'
 import { ReactNode, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { StyleProp, View, ViewStyle } from 'react-native'
 import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated'
 import styled, { useTheme } from 'styled-components/native'
@@ -33,7 +34,7 @@ interface ExpandableRowProps {
 
 const ExpandableRow = ({ children, title, titleComponent, style }: ExpandableRowProps) => {
   const theme = useTheme()
-
+  const { t } = useTranslation()
   const [isExpanded, setIsExpanded] = useState(false)
 
   const toggleExpanded = () => setIsExpanded(!isExpanded)
@@ -50,7 +51,7 @@ const ExpandableRow = ({ children, title, titleComponent, style }: ExpandableRow
   return (
     <View style={style}>
       <Header onPress={toggleExpanded}>
-        {titleComponent ?? <Title>{title}</Title>}
+        {titleComponent ?? <Title>{title ?? t('Advanced options')}</Title>}
         <Animated.View style={chevronStyle}>
           <ChevronDownStyled size={20} color={theme.font.primary} />
         </Animated.View>
@@ -81,5 +82,6 @@ const ChevronDownStyled = styled(ChevronDown)`
 const Header = styled.TouchableOpacity`
   flex-direction: row;
   width: 100%;
-  padding: 25px 0 25px 6px;
+  padding: 25px 20px 25px 6px;
+  justify-content: space-between;
 `

--- a/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectSessionRequestModal.tsx
+++ b/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectSessionRequestModal.tsx
@@ -43,6 +43,7 @@ import AppText from '~/components/AppText'
 import AssetAmountWithLogo from '~/components/AssetAmountWithLogo'
 import Button from '~/components/buttons/Button'
 import ButtonsRow from '~/components/buttons/ButtonsRow'
+import ExpandableRow from '~/components/ExpandableRow'
 import BoxSurface from '~/components/layout/BoxSurface'
 import { ModalContent, ModalContentProps } from '~/components/layout/ModalContent'
 import { BottomModalScreenTitle, ScreenSection } from '~/components/layout/Screen'
@@ -321,9 +322,17 @@ const WalletConnectSessionRequestModal = <T extends SessionRequestData>({
           )}
 
           {(requestData.type === 'deploy-contract' || requestData.type === 'call-contract') && (
-            <Row isVertical title={t('Bytecode')} titleColor="secondary">
-              <AppText>{requestData.wcData.bytecode}</AppText>
-            </Row>
+            <ExpandableRow
+              titleComponent={
+                <AppTextStyled medium color="secondary">
+                  {t('Bytecode')}
+                </AppTextStyled>
+              }
+            >
+              <Row isVertical>
+                <AppText>{requestData.wcData.bytecode}</AppText>
+              </Row>
+            </ExpandableRow>
           )}
           {requestData.type === 'sign-unsigned-tx' && (
             <>
@@ -384,4 +393,8 @@ const FeeBox = styled.View`
 const DAppIcon = styled(Image)`
   width: 50px;
   height: 50px;
+`
+
+const AppTextStyled = styled(AppText)`
+  padding-left: 14px;
 `


### PR DESCRIPTION
Closes:
- #762

| before | after |
| ----- | ----- |
| <img width="487" alt="image" src="https://github.com/user-attachments/assets/30c15581-1d22-4740-93f6-01d00845924b"> | <img width="487" alt="image" src="https://github.com/user-attachments/assets/6468ff9f-e94c-4332-ad17-820a5deea958"> |
