### PR TITLE
Fix bottom screen padding

### DIFF
--- a/apps/mobile-wallet/src/components/layout/Screen.tsx
+++ b/apps/mobile-wallet/src/components/layout/Screen.tsx
@@ -40,7 +40,7 @@ const Screen = ({ children, headerOptions, safeAreaPadding, ...props }: ScreenPr
   const HeaderComponent = headerOptions?.type === 'stack' ? StackHeader : BaseHeader
 
   const paddingStyle: StyleProp<ViewStyle> = safeAreaPadding
-    ? { paddingTop: insets.top, paddingBottom: insets.bottom }
+    ? { paddingTop: insets.top, paddingBottom: insets.bottom || 20 }
     : {}
 
   return (


### PR DESCRIPTION
On some devices, `inset.bottom` is 0 so if we want extra padding we have to provide it