### PR TITLE
Add Thai Baht and Hong Kong Dollar

### DIFF
--- a/.changeset/calm-hairs-rescue.md
+++ b/.changeset/calm-hairs-rescue.md
@@ -1,0 +1,5 @@
+---
+"@alephium/mobile-wallet": patch
+---
+
+Enable Thai Baht (THB) and Hong Kong Dollar (HKD) fiat currencies

--- a/.changeset/eighty-squids-drive.md
+++ b/.changeset/eighty-squids-drive.md
@@ -1,0 +1,5 @@
+---
+"alephium-desktop-wallet": patch
+---
+
+Enable Thai Baht (THB) and Hong Kong Dollar (HKD) fiat currencies

--- a/packages/shared/src/currencies.ts
+++ b/packages/shared/src/currencies.ts
@@ -56,5 +56,10 @@ export const CURRENCIES: Record<Currency, CurrencyData> = {
     name: 'Australian Dollar',
     ticker: 'AUD',
     symbol: 'A$'
+  },
+  THB: {
+    name: 'Thai Baht',
+    ticker: 'THB',
+    symbol: '฿'
   }
 }

--- a/packages/shared/src/currencies.ts
+++ b/packages/shared/src/currencies.ts
@@ -8,9 +8,9 @@ type CurrencyData = {
 
 export const CURRENCIES: Record<Currency, CurrencyData> = {
   CHF: {
-    name: 'Swiss francs',
+    name: 'Swiss Franc',
     ticker: 'CHF',
-    symbol: 'CHF'
+    symbol: 'Fr.'
   },
   EUR: {
     name: 'Euro',

--- a/packages/shared/src/currencies.ts
+++ b/packages/shared/src/currencies.ts
@@ -61,5 +61,10 @@ export const CURRENCIES: Record<Currency, CurrencyData> = {
     name: 'Thai Baht',
     ticker: 'THB',
     symbol: '฿'
+  },
+  HKD: {
+    name: 'Hong Kong Dollar',
+    ticker: 'HKD',
+    symbol: 'HK$'
   }
 }

--- a/packages/shared/src/types/currencies.ts
+++ b/packages/shared/src/types/currencies.ts
@@ -1,1 +1,1 @@
-export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB' | 'TRY' | 'CAD' | 'AUD' | 'THB'
+export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB' | 'TRY' | 'CAD' | 'AUD' | 'THB' | 'HKD'

--- a/packages/shared/src/types/currencies.ts
+++ b/packages/shared/src/types/currencies.ts
@@ -1,1 +1,1 @@
-export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB' | 'TRY' | 'CAD' | 'AUD'
+export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB' | 'TRY' | 'CAD' | 'AUD' | 'THB'


### PR DESCRIPTION
@tdroxler I get 404 errors from explorer backend for the fiat currency `THB`

```
       GET https://backend.mainnet.alephium.org/market/prices/ALPH/charts?currency=thb
        
       POST https://backend.mainnet.alephium.org/market/prices?currency=thb 4
```

Could we please enable it in the next explorer backend release? Thanks!

TODO:
- [x] Enable THB on explorer backend
- [x] Enable HKD on explorer backend
- [x] Test that it works fine
- [ ] Merge this PR