### PR TITLE
Fix retry

### DIFF
--- a/apps/mobile-wallet/src/api/addresses.ts
+++ b/apps/mobile-wallet/src/api/addresses.ts
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AddressBalancesSyncResult, AddressHash, AddressTokensSyncResult, throttledClient } from '@alephium/shared'
+import { AddressBalancesSyncResult, AddressHash, AddressTokensSyncResult, client } from '@alephium/shared'
 import { AddressTokenBalance, Transaction } from '@alephium/web3/dist/src/api/api-explorer'
 
 import { Address, AddressTransactionsSyncResult } from '~/types/addresses'
@@ -32,7 +32,7 @@ export const fetchAddressesTokens = async (addressHashes: AddressHash[]): Promis
     let page = 1
 
     while (page === 1 || addressTokensPageResults.length === PAGE_LIMIT) {
-      addressTokensPageResults = await throttledClient.explorer.addresses.getAddressesAddressTokensBalance(hash, {
+      addressTokensPageResults = await client.explorer.addresses.getAddressesAddressTokensBalance(hash, {
         limit: PAGE_LIMIT,
         page
       })
@@ -57,11 +57,8 @@ export const fetchAddressesTransactions = async (
   const results = []
 
   for (const addressHash of addressHashes) {
-    const transactions = await throttledClient.explorer.addresses.getAddressesAddressTransactions(addressHash, {
-      page: 1
-    })
-    const mempoolTransactions =
-      await throttledClient.explorer.addresses.getAddressesAddressMempoolTransactions(addressHash)
+    const transactions = await client.explorer.addresses.getAddressesAddressTransactions(addressHash, { page: 1 })
+    const mempoolTransactions = await client.explorer.addresses.getAddressesAddressMempoolTransactions(addressHash)
 
     results.push({
       hash: addressHash,
@@ -77,7 +74,7 @@ export const fetchAddressesBalances = async (addressHashes: AddressHash[]): Prom
   const results = []
 
   for (const addressHash of addressHashes) {
-    const balances = await throttledClient.explorer.addresses.getAddressesAddressBalance(addressHash)
+    const balances = await client.explorer.addresses.getAddressesAddressBalance(addressHash)
 
     results.push({
       hash: addressHash,
@@ -94,9 +91,9 @@ export const fetchAddressesTransactionsNextPage = async (addresses: Address[], n
   const addressHashes = addresses.map((address) => address.hash)
 
   if (addressHashes.length === 1) {
-    transactions = await throttledClient.explorer.addresses.getAddressesAddressTransactions(addressHashes[0], args)
+    transactions = await client.explorer.addresses.getAddressesAddressTransactions(addressHashes[0], args)
   } else if (addressHashes.length > 1) {
-    transactions = await throttledClient.explorer.addresses.postAddressesTransactions(args, addressHashes)
+    transactions = await client.explorer.addresses.postAddressesTransactions(args, addressHashes)
   }
 
   return transactions

--- a/apps/mobile-wallet/src/api/transactions.ts
+++ b/apps/mobile-wallet/src/api/transactions.ts
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AddressHash, AssetAmount, throttledClient } from '@alephium/shared'
+import { AddressHash, AssetAmount, client } from '@alephium/shared'
 import { transactionSign } from '@alephium/web3'
 
 import i18n from '~/features/localization/i18n'
@@ -28,7 +28,7 @@ import { getAddressAssetsAvailableBalance } from '~/utils/addresses'
 import { getOptionalTransactionAssetAmounts, getTransactionAssetAmounts } from '~/utils/transactions'
 
 export const buildSweepTransactions = async (fromAddress: Address, toAddressHash: AddressHash) => {
-  const { unsignedTxs } = await throttledClient.node.transactions.postTransactionsSweepAddressBuild({
+  const { unsignedTxs } = await client.node.transactions.postTransactionsSweepAddressBuild({
     fromPublicKey: await getAddressAsymetricKey(fromAddress.hash, 'public'),
     toAddress: toAddressHash
   })
@@ -81,7 +81,7 @@ export const buildTransferTransaction = async ({
 }: TransferTxData) => {
   const { attoAlphAmount, tokens } = getTransactionAssetAmounts(assetAmounts)
 
-  return await throttledClient.node.transactions.postTransactionsBuild({
+  return await client.node.transactions.postTransactionsBuild({
     fromPublicKey: await getAddressAsymetricKey(fromAddress, 'public'),
     destinations: [
       {
@@ -104,7 +104,7 @@ export const buildCallContractTransaction = async ({
 }: CallContractTxData) => {
   const { attoAlphAmount, tokens } = getOptionalTransactionAssetAmounts(assetAmounts)
 
-  return await throttledClient.node.contracts.postContractsUnsignedTxExecuteScript({
+  return await client.node.contracts.postContractsUnsignedTxExecuteScript({
     fromPublicKey: await getAddressAsymetricKey(fromAddress, 'public'),
     bytecode,
     attoAlphAmount,
@@ -122,7 +122,7 @@ export const buildDeployContractTransaction = async ({
   gasAmount,
   gasPrice
 }: DeployContractTxData) =>
-  await throttledClient.node.contracts.postContractsUnsignedTxDeployContract({
+  await client.node.contracts.postContractsUnsignedTxDeployContract({
     fromPublicKey: await getAddressAsymetricKey(fromAddress, 'public'),
     bytecode: bytecode,
     initialAttoAlphAmount: initialAlphAmount?.amount?.toString(),
@@ -137,7 +137,7 @@ export const signAndSendTransaction = async (fromAddress: AddressHash, txId: str
   if (!address) throw new Error(`${i18n.t('Could not find address in store')}: ${fromAddress}`)
 
   const signature = transactionSign(txId, await getAddressAsymetricKey(address.hash, 'private'))
-  const data = await throttledClient.node.transactions.postTransactionsSubmit({ unsignedTx, signature })
+  const data = await client.node.transactions.postTransactionsSubmit({ unsignedTx, signature })
 
   return { ...data, signature }
 }

--- a/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectContext.tsx
+++ b/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectContext.tsx
@@ -21,12 +21,12 @@ import '@walletconnect/react-native-compat'
 import {
   AddressHash,
   AssetAmount,
+  client,
   getHumanReadableError,
   isNetworkValid,
   parseSessionProposalEvent,
   SessionProposalEvent,
   SessionRequestEvent,
-  throttledClient,
   WALLETCONNECT_ERRORS,
   walletConnectClientInitialized,
   walletConnectClientInitializeFailed,
@@ -506,9 +506,7 @@ export const WalletConnectContextProvider = ({ children }: { children: ReactNode
 
             setLoading('Responding to WalletConnect')
             console.log('⏳ DECODING TX WITH DATA:', wcTxData)
-            const decodedResult = await throttledClient.node.transactions.postTransactionsDecodeUnsignedTx({
-              unsignedTx
-            })
+            const decodedResult = await client.node.transactions.postTransactionsDecodeUnsignedTx({ unsignedTx })
             console.log('✅ DECODING TX: DONE!')
             setLoading('')
 
@@ -527,7 +525,7 @@ export const WalletConnectContextProvider = ({ children }: { children: ReactNode
           case 'alph_requestNodeApi': {
             walletConnectClient.core.expirer.set(requestEvent.id, calcExpiry(5))
             const p = requestEvent.params.request.params as ApiRequestArguments
-            const result = await throttledClient.node.request(p)
+            const result = await client.node.request(p)
 
             console.log('👉 WALLETCONNECT ASKED FOR THE NODE API')
 
@@ -538,7 +536,7 @@ export const WalletConnectContextProvider = ({ children }: { children: ReactNode
           case 'alph_requestExplorerApi': {
             walletConnectClient.core.expirer.set(requestEvent.id, calcExpiry(5))
             const p = requestEvent.params.request.params as ApiRequestArguments
-            const result = await throttledClient.explorer.request(p)
+            const result = await client.explorer.request(p)
 
             console.log('👉 WALLETCONNECT ASKED FOR THE EXPLORER API')
 

--- a/apps/mobile-wallet/src/store/addressDiscoverySlice.ts
+++ b/apps/mobile-wallet/src/store/addressDiscoverySlice.ts
@@ -17,13 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { keyring, NonSensitiveAddressData } from '@alephium/keyring'
-import {
-  AddressIndex,
-  appReset,
-  customNetworkSettingsSaved,
-  networkPresetSwitched,
-  throttledClient
-} from '@alephium/shared'
+import { AddressIndex, appReset, client, customNetworkSettingsSaved, networkPresetSwitched } from '@alephium/shared'
 import { explorer, groupOfAddress, TOTAL_NUMBER_OF_GROUPS } from '@alephium/web3'
 import {
   createAsyncThunk,
@@ -121,11 +115,11 @@ export const discoverAddresses = createAsyncThunk(
 
         groupData.highestIndex = newAddressData.index
 
-        const data = await throttledClient.explorer.addresses.postAddressesUsed([newAddressData.hash])
+        const data = await client.explorer.addresses.postAddressesUsed([newAddressData.hash])
         const addressIsActive = data.length > 0 && data[0]
 
         if (addressIsActive) {
-          const { balance } = await throttledClient.explorer.addresses.getAddressesAddressBalance(newAddressData.hash)
+          const { balance } = await client.explorer.addresses.getAddressesAddressBalance(newAddressData.hash)
           dispatch(addressDiscovered({ ...newAddressData, balance }))
 
           groupData.gap = 0

--- a/apps/mobile-wallet/src/store/addressesSlice.ts
+++ b/apps/mobile-wallet/src/store/addressesSlice.ts
@@ -24,6 +24,7 @@ import {
   Asset,
   balanceHistoryAdapter,
   calculateAssetsData,
+  client,
   customNetworkSettingsSaved,
   extractNewTransactions,
   getTransactionsOfAddress,
@@ -35,7 +36,6 @@ import {
   selectAllPricesHistories,
   selectNFTIds,
   sortAssets,
-  throttledClient,
   TokenDisplayBalances
 } from '@alephium/shared'
 import { ALPH } from '@alephium/token-list'
@@ -111,11 +111,11 @@ export const syncLatestTransactions = createAsyncThunk(
     const args = { page: 1 }
 
     if (addresses.length === 1) {
-      latestTransactions = await throttledClient.explorer.addresses.getAddressesAddressTransactions(addresses[0], args)
+      latestTransactions = await client.explorer.addresses.getAddressesAddressTransactions(addresses[0], args)
     } else if (addresses.length > 1) {
       const results = await Promise.all(
         chunk(addresses, ADDRESSES_QUERY_LIMIT).map((addressesChunk) =>
-          throttledClient.explorer.addresses.postAddressesTransactions(args, addressesChunk)
+          client.explorer.addresses.postAddressesTransactions(args, addressesChunk)
         )
       )
 

--- a/packages/shared/src/api/client.ts
+++ b/packages/shared/src/api/client.ts
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { ExplorerProvider, NodeProvider } from '@alephium/web3'
 
-import { exponentialBackoffFetchRetry } from '@/api/fetchRetry'
+import { throttledExponentialBackoffFetchRetry } from '@/api/fetchRetry'
 import { defaultNetworkSettings } from '@/network'
 import { NetworkSettings } from '@/types/network'
 
@@ -43,8 +43,8 @@ export class Client {
 
   private getClients(nodeHost: NetworkSettings['nodeHost'], explorerApiHost: NetworkSettings['explorerApiHost']) {
     return {
-      explorer: new ExplorerProvider(explorerApiHost, undefined, exponentialBackoffFetchRetry),
-      node: new NodeProvider(nodeHost, undefined, exponentialBackoffFetchRetry)
+      explorer: new ExplorerProvider(explorerApiHost, undefined, throttledExponentialBackoffFetchRetry),
+      node: new NodeProvider(nodeHost, undefined, throttledExponentialBackoffFetchRetry)
     }
   }
 }

--- a/packages/shared/src/api/fetchRetry.ts
+++ b/packages/shared/src/api/fetchRetry.ts
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import fetchRetry from 'fetch-retry'
+import pThrottle from 'p-throttle'
 
 export const MAX_API_RETRIES = 3
 
@@ -29,3 +30,10 @@ export const exponentialBackoffFetchRetry = fetchRetry(fetch, {
   retries: MAX_API_RETRIES + 1,
   retryDelay: (attempt) => Math.pow(2, attempt) * 1000
 })
+
+const throttle = pThrottle({
+  limit: 10,
+  interval: 1000
+})
+
+export const throttledExponentialBackoffFetchRetry = throttle(exponentialBackoffFetchRetry)


### PR DESCRIPTION
I realized that by switching from `client` to `throttledClient` in the mobile wallet, while the mobile wallet has not yet been refactored to use Tanstack, we lost the retry feature of the `fetch-retry` that `client` was using. This PR adds throttling to the existing `client`, on top of `fetch-retry`. Once the mobile wallet is refactored to use Tanstack, we can eliminate one of the clients and keep the one without the retry mechanism, since retrying is handled by Tanstack.