### PR TITLE
Fix data loading in mobile wallet

### DIFF
--- a/.changeset/large-flowers-eat.md
+++ b/.changeset/large-flowers-eat.md
@@ -1,0 +1,5 @@
+---
+"@alephium/mobile-wallet": patch
+---
+
+Fix data loading

--- a/apps/mobile-wallet/src/api/addresses.ts
+++ b/apps/mobile-wallet/src/api/addresses.ts
@@ -1,8 +1,6 @@
 import { AddressBalancesSyncResult, AddressHash, AddressTokensSyncResult, client } from '@alephium/shared'
 import { AddressTokenBalance, Transaction } from '@alephium/web3/dist/src/api/api-explorer'
 
-import { Address } from '~/types/addresses'
-
 const PAGE_LIMIT = 100
 
 export const fetchAddressesTokens = async (addressHashes: AddressHash[]): Promise<AddressTokensSyncResult[]> => {
@@ -48,12 +46,12 @@ export const fetchAddressesBalances = async (addressHashes: AddressHash[]): Prom
   return results
 }
 
-export const fetchAddressesTransactionsNextPage = async (
-  addresses: Address[],
-  nextPage: number
+export const fetchAddressesTransactionsPage = async (
+  addressesHashes: AddressHash[],
+  page: number
 ): Promise<Transaction[]> =>
   (
     await Promise.all(
-      addresses.map(({ hash }) => client.explorer.addresses.getAddressesAddressTransactions(hash, { page: nextPage }))
+      addressesHashes.map((hash) => client.explorer.addresses.getAddressesAddressTransactions(hash, { page }))
     )
   ).flat()

--- a/apps/mobile-wallet/src/api/addresses.ts
+++ b/apps/mobile-wallet/src/api/addresses.ts
@@ -48,16 +48,12 @@ export const fetchAddressesBalances = async (addressHashes: AddressHash[]): Prom
   return results
 }
 
-export const fetchAddressesTransactionsNextPage = async (addresses: Address[], nextPage: number) => {
-  let transactions: Transaction[] = []
-  const args = { page: nextPage }
-  const addressHashes = addresses.map((address) => address.hash)
-
-  if (addressHashes.length === 1) {
-    transactions = await client.explorer.addresses.getAddressesAddressTransactions(addressHashes[0], args)
-  } else if (addressHashes.length > 1) {
-    transactions = await client.explorer.addresses.postAddressesTransactions(args, addressHashes)
-  }
-
-  return transactions
-}
+export const fetchAddressesTransactionsNextPage = async (
+  addresses: Address[],
+  nextPage: number
+): Promise<Transaction[]> =>
+  (
+    await Promise.all(
+      addresses.map(({ hash }) => client.explorer.addresses.getAddressesAddressTransactions(hash, { page: nextPage }))
+    )
+  ).flat()

--- a/apps/mobile-wallet/src/api/addresses.ts
+++ b/apps/mobile-wallet/src/api/addresses.ts
@@ -1,4 +1,10 @@
-import { AddressBalancesSyncResult, AddressHash, AddressTokensSyncResult, client } from '@alephium/shared'
+import {
+  AddressBalancesSyncResult,
+  AddressHash,
+  AddressTokensSyncResult,
+  client,
+  TRANSACTIONS_PAGE_DEFAULT_LIMIT
+} from '@alephium/shared'
 import { AddressTokenBalance, Transaction } from '@alephium/web3/dist/src/api/api-explorer'
 
 const PAGE_LIMIT = 100
@@ -52,6 +58,11 @@ export const fetchAddressesTransactionsPage = async (
 ): Promise<Transaction[]> =>
   (
     await Promise.all(
-      addressesHashes.map((hash) => client.explorer.addresses.getAddressesAddressTransactions(hash, { page }))
+      addressesHashes.map((hash) =>
+        client.explorer.addresses.getAddressesAddressTransactions(hash, {
+          page,
+          limit: TRANSACTIONS_PAGE_DEFAULT_LIMIT
+        })
+      )
     )
   ).flat()

--- a/apps/mobile-wallet/src/components/layout/TransactionsFlashList.tsx
+++ b/apps/mobile-wallet/src/components/layout/TransactionsFlashList.tsx
@@ -1,5 +1,6 @@
+import { TRANSACTIONS_PAGE_DEFAULT_LIMIT } from '@alephium/shared'
 import { FlashList, FlashListProps } from '@shopify/flash-list'
-import { ForwardedRef, forwardRef, useCallback } from 'react'
+import { ForwardedRef, forwardRef, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
@@ -49,9 +50,14 @@ const TransactionsFlashList = forwardRef(
 
     const isLoading = useAppSelector((s) => s.loaders.loadingTransactionsNextPage)
     const allConfirmedTransactionsLoaded = useAppSelector((s) => s.confirmedTransactions.allLoaded)
+    const pageLoaded = useAppSelector((s) => s.confirmedTransactions.pageLoaded)
+    const displayedConfirmedTransactions = useMemo(
+      () => confirmedTransactions.slice(0, pageLoaded * TRANSACTIONS_PAGE_DEFAULT_LIMIT),
+      [confirmedTransactions, pageLoaded]
+    )
 
     const renderConfirmedTransactionItem = ({ item, index }: TransactionItem) =>
-      renderTransactionItem({ item, index, isLast: index === confirmedTransactions.length - 1 })
+      renderTransactionItem({ item, index, isLast: index === displayedConfirmedTransactions.length - 1 })
 
     const renderTransactionItem = ({ item: tx, isLast }: TransactionItem) => (
       <TransactionListItem
@@ -77,13 +83,13 @@ const TransactionsFlashList = forwardRef(
         {...props}
         ref={ref}
         scrollEventThrottle={16}
-        data={confirmedTransactions}
+        data={displayedConfirmedTransactions}
         renderItem={renderConfirmedTransactionItem}
         keyExtractor={transactionKeyExtractor}
         onEndReached={loadNextTransactionsPage}
         refreshControl={<RefreshSpinner />}
         refreshing={pendingTransactions.length > 0}
-        extraData={confirmedTransactions.length > 0 ? confirmedTransactions[0].hash : ''}
+        extraData={displayedConfirmedTransactions.length > 0 ? displayedConfirmedTransactions[0].hash : ''}
         estimatedItemSize={64}
         contentContainerStyle={{ paddingHorizontal: DEFAULT_MARGIN }}
         ListEmptyComponent={
@@ -116,7 +122,7 @@ const TransactionsFlashList = forwardRef(
         ListFooterComponent={
           <Footer>
             <InfiniteLoadingIndicator>
-              {allConfirmedTransactionsLoaded && confirmedTransactions.length > 0 && (
+              {allConfirmedTransactionsLoaded && displayedConfirmedTransactions.length > 0 && (
                 <AppText color="tertiary" semiBold style={{ maxWidth: '75%', textAlign: 'center' }}>
                   👏 {t('You reached the end of the transactions history.')}
                 </AppText>

--- a/apps/mobile-wallet/src/screens/ActivityScreen.tsx
+++ b/apps/mobile-wallet/src/screens/ActivityScreen.tsx
@@ -1,6 +1,5 @@
-import { StackScreenProps } from '@react-navigation/stack'
 import { FlashList } from '@shopify/flash-list'
-import { useMemo, useRef } from 'react'
+import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import BaseHeader from '~/components/headers/BaseHeader'
@@ -10,20 +9,14 @@ import TransactionsFlashList from '~/components/layout/TransactionsFlashList'
 import useAutoScrollOnDragEnd from '~/hooks/layout/useAutoScrollOnDragEnd'
 import useScreenScrollHandler from '~/hooks/layout/useScreenScrollHandler'
 import { useAppSelector } from '~/hooks/redux'
-import { InWalletTabsParamList } from '~/navigation/InWalletNavigation'
-import RootStackParamList from '~/navigation/rootStackRoutes'
-import { makeSelectAddressesConfirmedTransactions } from '~/store/confirmedTransactionsSlice'
-import { makeSelectAddressesPendingTransactions } from '~/store/pendingTransactionsSlice'
+import { selectAddressesConfirmedTransactions } from '~/store/confirmedTransactionsSlice'
+import { selectAddressesPendingTransactions } from '~/store/pendingTransactionsSlice'
 import { AddressTransaction } from '~/types/transactions'
 
-type ScreenProps = StackScreenProps<InWalletTabsParamList & RootStackParamList, 'ActivityScreen'>
-
-const ActivityScreen = ({ navigation }: ScreenProps) => {
+const ActivityScreen = () => {
   const listRef = useRef<FlashList<AddressTransaction>>(null)
   const { t } = useTranslation()
 
-  const selectAddressesConfirmedTransactions = useMemo(makeSelectAddressesConfirmedTransactions, [])
-  const selectAddressesPendingTransactions = useMemo(makeSelectAddressesPendingTransactions, [])
   const confirmedTransactions = useAppSelector(selectAddressesConfirmedTransactions)
   const pendingTransactions = useAppSelector(selectAddressesPendingTransactions)
 

--- a/apps/mobile-wallet/src/store/addressesSlice.ts
+++ b/apps/mobile-wallet/src/store/addressesSlice.ts
@@ -85,9 +85,8 @@ export const syncLatestTransactions = createAsyncThunk(
           ? _addresses
           : [_addresses]
 
-    if (areAddressesNew) {
-      await Promise.all([dispatch(syncAddressesBalances(addresses)), dispatch(syncAddressesTokens(addresses))])
-    }
+    if (areAddressesNew)
+      Promise.all([dispatch(syncAddressesBalances(addresses)), dispatch(syncAddressesTokens(addresses))])
 
     let latestTransactions: Transaction[] = []
     const args = { page: 1 }
@@ -131,12 +130,11 @@ export const syncLatestTransactions = createAsyncThunk(
     const addressesToFetchData =
       state.addresses.status === 'uninitialized' ? (state.addresses.ids as AddressHash[]) : addressesWithNewTransactions
 
-    if (!areAddressesNew && addressesToFetchData.length > 0) {
-      await Promise.all([
+    if (!areAddressesNew && addressesToFetchData.length > 0)
+      Promise.all([
         dispatch(syncAddressesBalances(addressesToFetchData)),
         dispatch(syncAddressesTokens(addressesToFetchData))
       ])
-    }
 
     return newTransactionsResults
   }

--- a/apps/mobile-wallet/src/store/addressesSlice.ts
+++ b/apps/mobile-wallet/src/store/addressesSlice.ts
@@ -1,5 +1,4 @@
 import {
-  ADDRESSES_QUERY_LIMIT,
   AddressFungibleToken,
   AddressHash,
   appReset,
@@ -32,7 +31,6 @@ import {
   isAnyOf,
   PayloadAction
 } from '@reduxjs/toolkit'
-import { chunk } from 'lodash'
 
 import { fetchAddressesBalances, fetchAddressesTokens, fetchAddressesTransactionsNextPage } from '~/api/addresses'
 import { addressMetadataIncludesHash } from '~/persistent-storage/wallet'
@@ -160,13 +158,7 @@ export const syncAllAddressesTransactionsNextPage = createAsyncThunk(
     let newTransactions: explorer.Transaction[] = []
 
     while (!enoughNewTransactionsFound) {
-      const results = await Promise.all(
-        chunk(addresses, ADDRESSES_QUERY_LIMIT).map((addressesChunk) =>
-          fetchAddressesTransactionsNextPage(addressesChunk, nextPageToLoad)
-        )
-      )
-
-      const nextPageTransactions = results.flat()
+      const nextPageTransactions = await fetchAddressesTransactionsNextPage(addresses, nextPageToLoad)
 
       if (nextPageTransactions.length === 0) break
 

--- a/apps/mobile-wallet/src/store/addressesSlice.ts
+++ b/apps/mobile-wallet/src/store/addressesSlice.ts
@@ -89,19 +89,14 @@ export const syncLatestTransactions = createAsyncThunk(
       Promise.all([dispatch(syncAddressesBalances(addresses)), dispatch(syncAddressesTokens(addresses))])
 
     let latestTransactions: Transaction[] = []
-    const args = { page: 1 }
 
-    if (addresses.length === 1) {
-      latestTransactions = await client.explorer.addresses.getAddressesAddressTransactions(addresses[0], args)
-    } else if (addresses.length > 1) {
-      const results = await Promise.all(
-        chunk(addresses, ADDRESSES_QUERY_LIMIT).map((addressesChunk) =>
-          client.explorer.addresses.postAddressesTransactions(args, addressesChunk)
-        )
+    const results = await Promise.all(
+      addresses.map((addressHash) =>
+        client.explorer.addresses.getAddressesAddressTransactions(addressHash, { page: 1 })
       )
+    )
 
-      latestTransactions = results.flat()
-    }
+    latestTransactions = results.flat()
 
     const newTransactionsResults = addresses.reduce(
       (acc, addressHash) => {

--- a/apps/mobile-wallet/src/store/confirmedTransactionsSlice.ts
+++ b/apps/mobile-wallet/src/store/confirmedTransactionsSlice.ts
@@ -61,20 +61,19 @@ const confirmedTransactionsSlice = createSlice({
 export const { selectAll: selectAllConfirmedTransactions, selectById: selectConfirmedTransactionByHash } =
   confirmedTransactionsAdapter.getSelectors<RootState>((state) => state[sliceName])
 
-export const makeSelectAddressesConfirmedTransactions = () =>
-  createSelector(
-    [
-      selectAllAddresses,
-      selectAllConfirmedTransactions,
-      (_, addressHashes?: AddressHash | AddressHash[]) => addressHashes
-    ],
-    (allAddresses, confirmedTransactions, addressHashes): AddressConfirmedTransaction[] =>
-      selectAddressConfirmedTransactions(
-        allAddresses,
-        confirmedTransactions,
-        addressHashes
-      ) as AddressConfirmedTransaction[]
-  )
+export const selectAddressesConfirmedTransactions = createSelector(
+  [
+    selectAllAddresses,
+    selectAllConfirmedTransactions,
+    (_, addressHashes?: AddressHash | AddressHash[]) => addressHashes
+  ],
+  (allAddresses, confirmedTransactions, addressHashes): AddressConfirmedTransaction[] =>
+    selectAddressConfirmedTransactions(
+      allAddresses,
+      confirmedTransactions,
+      addressHashes
+    ) as AddressConfirmedTransaction[]
+)
 
 export const makeSelectContactConfirmedTransactions = () =>
   createSelector(

--- a/apps/mobile-wallet/src/store/pendingTransactionsSlice.ts
+++ b/apps/mobile-wallet/src/store/pendingTransactionsSlice.ts
@@ -47,16 +47,11 @@ export const { selectAll: selectAllPendingTransactions } = pendingTransactionsAd
   (state) => state[sliceName]
 )
 
-export const makeSelectAddressesPendingTransactions = () =>
-  createSelector(
-    [
-      selectAllAddresses,
-      selectAllPendingTransactions,
-      (_, addressHashes?: AddressHash | AddressHash[]) => addressHashes
-    ],
-    (allAddresses, pendingTransactions, addressHashes): AddressPendingTransaction[] =>
-      selectAddressPendingTransactions(allAddresses, pendingTransactions, addressHashes) as AddressPendingTransaction[]
-  )
+export const selectAddressesPendingTransactions = createSelector(
+  [selectAllAddresses, selectAllPendingTransactions, (_, addressHashes?: AddressHash | AddressHash[]) => addressHashes],
+  (allAddresses, pendingTransactions, addressHashes): AddressPendingTransaction[] =>
+    selectAddressPendingTransactions(allAddresses, pendingTransactions, addressHashes) as AddressPendingTransaction[]
+)
 
 export const makeSelectContactPendingTransactions = () =>
   createSelector(

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -31,3 +31,5 @@ export const FIVE_MINUTES_MS = 5 * ONE_MINUTE_MS
 export const ONE_HOUR_MS = 60 * ONE_MINUTE_MS
 
 export const ONE_DAY_MS = 24 * ONE_HOUR_MS
+
+export const TRANSACTIONS_PAGE_DEFAULT_LIMIT = 20


### PR DESCRIPTION
Replaces `POST` endpoint with `GET`. This means that "gaps" might be introduced in the Redux transactions slice. To solve the "gaps" issue in the tx list we only allow chunks of `20` items to be displayed in the aggregated tx list, even if we have more on Redux. That way, when the user loads the next page, Redux will be updated with the next page of txs of each address, but the UI will display the next 20 aggregated txs.