### PR TITLE
Simplify banxa flow using WebBrowser

### DIFF
--- a/apps/mobile-wallet/locales/en-US/translation.json
+++ b/apps/mobile-wallet/locales/en-US/translation.json
@@ -399,5 +399,6 @@
   "Decrypt": "Decrypt",
   "Warning": "Warning",
   "No assets here, yet.": "No assets here, yet.",
-  "There is something wrong in the received WalletConnect data.": "There is something wrong in the received WalletConnect data."
+  "There is something wrong in the received WalletConnect data.": "There is something wrong in the received WalletConnect data.",
+  "Loading your balances...": "Loading your balances..."
 }

--- a/apps/mobile-wallet/src/components/AddressesTokensList.tsx
+++ b/apps/mobile-wallet/src/components/AddressesTokensList.tsx
@@ -2,8 +2,7 @@ import { AddressHash, Asset } from '@alephium/shared'
 import { Skeleton } from 'moti/skeleton'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ActivityIndicator, StyleProp, ViewStyle } from 'react-native'
-import Animated, { CurvedTransition } from 'react-native-reanimated'
+import { ActivityIndicator } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import AppText from '~/components/AppText'
@@ -18,7 +17,6 @@ import TokenListItem from './TokenListItem'
 interface AddressesTokensListProps {
   addressHash?: AddressHash
   isRefreshing?: boolean
-  style?: StyleProp<ViewStyle>
 }
 
 type LoadingIndicator = {
@@ -27,7 +25,7 @@ type LoadingIndicator = {
 
 type TokensRow = Asset | UnknownTokensEntry | LoadingIndicator
 
-const AddressesTokensList = ({ addressHash, isRefreshing, style }: AddressesTokensListProps) => {
+const AddressesTokensList = ({ addressHash, isRefreshing }: AddressesTokensListProps) => {
   const selectAddressesKnownFungibleTokens = useMemo(makeSelectAddressesKnownFungibleTokens, [])
   const knownFungibleTokens = useAppSelector((s) => selectAddressesKnownFungibleTokens(s, addressHash))
   const selectAddressesCheckedUnknownTokens = useMemo(makeSelectAddressesCheckedUnknownTokens, [])
@@ -63,8 +61,24 @@ const AddressesTokensList = ({ addressHash, isRefreshing, style }: AddressesToke
     setTokenRows(entries)
   }, [addressHash, showTokensSkeleton, knownFungibleTokens, unknownTokens.length])
 
+  if (addressesBalancesStatus === 'uninitialized')
+    return (
+      <EmptyPlaceholderStyled>
+        <AppText size={28}>⏳</AppText>
+        <AppText>{t('Loading your balances...')}</AppText>
+      </EmptyPlaceholderStyled>
+    )
+
+  if (!isRefreshing && tokenRows.length === 0)
+    return (
+      <EmptyPlaceholderStyled>
+        <AppText size={28}>👀</AppText>
+        <AppText>{t('No assets here, yet.')}</AppText>
+      </EmptyPlaceholderStyled>
+    )
+
   return (
-    <ListContainer style={style} layout={CurvedTransition}>
+    <ListContainer>
       {tokenRows.map((entry, index) =>
         isAsset(entry) ? (
           <TokenListItem
@@ -79,20 +93,6 @@ const AddressesTokensList = ({ addressHash, isRefreshing, style }: AddressesToke
             <Skeleton show colorMode={theme.name} width={36} height={36} radius="round" />
             <Skeleton show colorMode={theme.name} width={200} height={36} />
           </LoadingRow>
-        )
-      )}
-      {addressesBalancesStatus === 'uninitialized' ? (
-        <EmptyPlaceholder>
-          <AppText size={28}>⏳</AppText>
-          <AppText>{t('Loading your balances...')}</AppText>
-        </EmptyPlaceholder>
-      ) : (
-        !isRefreshing &&
-        tokenRows.length === 0 && (
-          <EmptyPlaceholder>
-            <AppText size={28}>👀</AppText>
-            <AppText>{t('No assets here, yet.')}</AppText>
-          </EmptyPlaceholder>
         )
       )}
 
@@ -120,10 +120,14 @@ const LoadingRow = styled.View`
   margin: 0 ${DEFAULT_MARGIN}px;
 `
 
-const ListContainer = styled(Animated.View)`
+const ListContainer = styled.View`
   border-radius: ${BORDER_RADIUS_BIG}px;
   overflow: hidden;
   position: relative;
+  margin: 0 ${DEFAULT_MARGIN}px;
+`
+
+const EmptyPlaceholderStyled = styled(EmptyPlaceholder)`
   margin: 0 ${DEFAULT_MARGIN}px;
 `
 

--- a/apps/mobile-wallet/src/components/AddressesTokensList.tsx
+++ b/apps/mobile-wallet/src/components/AddressesTokensList.tsx
@@ -36,10 +36,13 @@ const AddressesTokensList = ({ addressHash, isRefreshing, style }: AddressesToke
   const isLoadingUnverified = useAppSelector((s) => s.fungibleTokens.loadingUnverified)
   const isLoadingVerified = useAppSelector((s) => s.fungibleTokens.loadingVerified)
   const isLoadingTokenTypes = useAppSelector((s) => s.fungibleTokens.loadingTokenTypes)
+  const addressesBalancesStatus = useAppSelector((s) => s.addresses.balancesStatus)
   const theme = useTheme()
   const { t } = useTranslation()
 
-  const showTokensSkeleton = isLoadingTokenBalances || isLoadingUnverified || isLoadingVerified || isLoadingTokenTypes
+  const showTokensSkeleton =
+    (isLoadingTokenBalances || isLoadingUnverified || isLoadingVerified || isLoadingTokenTypes) &&
+    addressesBalancesStatus === 'initialized'
 
   const [tokenRows, setTokenRows] = useState<TokensRow[]>([])
 
@@ -78,12 +81,21 @@ const AddressesTokensList = ({ addressHash, isRefreshing, style }: AddressesToke
           </LoadingRow>
         )
       )}
-      {!isRefreshing && tokenRows.length === 0 && (
+      {addressesBalancesStatus === 'uninitialized' ? (
         <EmptyPlaceholder>
-          <AppText size={28}>👀</AppText>
-          <AppText>{t('No assets here, yet.')}</AppText>
+          <AppText size={28}>⏳</AppText>
+          <AppText>{t('Loading your balances...')}</AppText>
         </EmptyPlaceholder>
+      ) : (
+        !isRefreshing &&
+        tokenRows.length === 0 && (
+          <EmptyPlaceholder>
+            <AppText size={28}>👀</AppText>
+            <AppText>{t('No assets here, yet.')}</AppText>
+          </EmptyPlaceholder>
+        )
       )}
+
       {isRefreshing && (
         <>
           <LoadingOverlay />

--- a/apps/mobile-wallet/src/components/BalanceSummary.tsx
+++ b/apps/mobile-wallet/src/components/BalanceSummary.tsx
@@ -1,7 +1,6 @@
 import { AddressHash, CURRENCIES } from '@alephium/shared'
-import { Skeleton } from 'moti/skeleton'
 import { useMemo } from 'react'
-import { View, ViewProps } from 'react-native'
+import { ActivityIndicator, View, ViewProps } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import Amount from '~/components/Amount'
@@ -33,9 +32,7 @@ const BalanceSummary = ({ dateLabel, style, ...props }: BalanceSummaryProps) => 
         </View>
 
         {addressesBalancesStatus === 'uninitialized' ? (
-          <View style={{ marginTop: 13 }}>
-            <Skeleton show colorMode={theme.name} width={200} height={38} />
-          </View>
+          <ActivityIndicator size="large" color={theme.font.primary} style={{ marginTop: 10 }} />
         ) : (
           <Amount value={balanceInFiat} isFiat suffix={CURRENCIES[currency].symbol} semiBold size={40} />
         )}

--- a/apps/mobile-wallet/src/components/BalanceSummary.tsx
+++ b/apps/mobile-wallet/src/components/BalanceSummary.tsx
@@ -1,6 +1,6 @@
 import { AddressHash, CURRENCIES } from '@alephium/shared'
 import { useMemo } from 'react'
-import { ActivityIndicator, View, ViewProps } from 'react-native'
+import { ActivityIndicator, View } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import Amount from '~/components/Amount'
@@ -10,11 +10,11 @@ import { makeSelectAddressesTokensWorth } from '~/store/addresses/addressesSelec
 import { selectAddressIds } from '~/store/addressesSlice'
 import { DEFAULT_MARGIN } from '~/style/globalStyle'
 
-interface BalanceSummaryProps extends ViewProps {
+interface BalanceSummaryProps {
   dateLabel: string
 }
 
-const BalanceSummary = ({ dateLabel, style, ...props }: BalanceSummaryProps) => {
+const BalanceSummary = ({ dateLabel }: BalanceSummaryProps) => {
   const theme = useTheme()
   const currency = useAppSelector((s) => s.settings.currency)
   const addressesBalancesStatus = useAppSelector((s) => s.addresses.balancesStatus)
@@ -23,7 +23,7 @@ const BalanceSummary = ({ dateLabel, style, ...props }: BalanceSummaryProps) => 
   const balanceInFiat = useAppSelector((s) => selectAddessesTokensWorth(s, addressHashes))
 
   return (
-    <BalanceSummaryContainer style={style} {...props}>
+    <BalanceSummaryStyled>
       <TextContainer>
         <View>
           <AppText color="tertiary" semiBold>
@@ -37,13 +37,13 @@ const BalanceSummary = ({ dateLabel, style, ...props }: BalanceSummaryProps) => 
           <Amount value={balanceInFiat} isFiat suffix={CURRENCIES[currency].symbol} semiBold size={40} />
         )}
       </TextContainer>
-    </BalanceSummaryContainer>
+    </BalanceSummaryStyled>
   )
 }
 
 export default BalanceSummary
 
-const BalanceSummaryContainer = styled.View`
+const BalanceSummaryStyled = styled.View`
   justify-content: center;
   align-items: center;
   margin: 10px 0 16px 0;

--- a/apps/mobile-wallet/src/features/buy/BuyModal.tsx
+++ b/apps/mobile-wallet/src/features/buy/BuyModal.tsx
@@ -1,3 +1,4 @@
+import { AddressHash } from '@alephium/shared'
 import { openBrowserAsync } from 'expo-web-browser'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -12,31 +13,36 @@ import BottomModal from '~/features/modals/BottomModal'
 import { closeModal } from '~/features/modals/modalActions'
 import withModal from '~/features/modals/withModal'
 import { useAppDispatch, useAppSelector } from '~/hooks/redux'
-import { selectDefaultAddress } from '~/store/addressesSlice'
+import { selectAddressByHash } from '~/store/addressesSlice'
 import { DEFAULT_MARGIN } from '~/style/globalStyle'
 
-const BuyModal = withModal(({ id }) => {
+export interface BuyModalProps {
+  receiveAddressHash: AddressHash
+}
+
+const BuyModal = withModal<BuyModalProps>(({ id, receiveAddressHash }) => {
   const { t } = useTranslation()
   const theme = useTheme()
   const insets = useSafeAreaInsets()
-  const defaultAddress = useAppSelector(selectDefaultAddress)
   const dispatch = useAppDispatch()
+  const receiveAddress = useAppSelector((s) => selectAddressByHash(s, receiveAddressHash))
 
   const handleDisclaimerAcceptPress = () => {
-    openBrowserAsync(
-      'https://alephium.banxa.com/' +
-        `?walletAddress=${defaultAddress.hash}` +
-        `&theme=${theme.name}` +
-        `&backgroundColor=${theme.bg.primary.slice(1)}` + // TODO: In light theme it's rgba, removing the first char is problematic
-        `&textColor=${theme.font.primary.slice(1)}` +
-        `&primaryColor=${theme.global.accent.slice(1)}` +
-        `&secondaryColor=${theme.global.complementary.slice(1)}`,
-      {
-        createTask: false, // Android: the browser opens within our app without a new task in the task manager
-        toolbarColor: theme.bg.back1, // TODO: Wanted to use theme.bg.primary, but in light theme it's rgba and it looks black, not white
-        controlsColor: theme.global.accent // iOS: color of button texts
-      }
-    )
+    receiveAddress &&
+      openBrowserAsync(
+        'https://alephium.banxa.com/' +
+          `?walletAddress=${receiveAddressHash}` +
+          `&theme=${theme.name}` +
+          `&backgroundColor=${theme.bg.primary.slice(1)}` + // TODO: In light theme it's rgba, removing the first char is problematic
+          `&textColor=${theme.font.primary.slice(1)}` +
+          `&primaryColor=${theme.global.accent.slice(1)}` +
+          `&secondaryColor=${theme.global.complementary.slice(1)}`,
+        {
+          createTask: false, // Android: the browser opens within our app without a new task in the task manager
+          toolbarColor: theme.bg.back1, // TODO: Wanted to use theme.bg.primary, but in light theme it's rgba and it looks black, not white
+          controlsColor: theme.global.accent // iOS: color of button texts
+        }
+      )
 
     dispatch(closeModal({ id }))
   }

--- a/apps/mobile-wallet/src/features/buy/BuyModal.tsx
+++ b/apps/mobile-wallet/src/features/buy/BuyModal.tsx
@@ -1,9 +1,6 @@
-import { NavigationProp, useNavigation } from '@react-navigation/native'
-import { useEffect, useRef, useState } from 'react'
+import { openBrowserAsync } from 'expo-web-browser'
 import { Trans, useTranslation } from 'react-i18next'
-import { BackHandler, Platform } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import WebView, { WebViewNavigation } from 'react-native-webview'
 import styled, { useTheme } from 'styled-components/native'
 
 import AppText from '~/components/AppText'
@@ -15,111 +12,63 @@ import BottomModal from '~/features/modals/BottomModal'
 import { closeModal } from '~/features/modals/modalActions'
 import withModal from '~/features/modals/withModal'
 import { useAppDispatch, useAppSelector } from '~/hooks/redux'
-import { InWalletTabsParamList } from '~/navigation/InWalletNavigation'
 import { selectDefaultAddress } from '~/store/addressesSlice'
 import { DEFAULT_MARGIN } from '~/style/globalStyle'
 
 const BuyModal = withModal(({ id }) => {
   const { t } = useTranslation()
-  const navigation = useNavigation<NavigationProp<InWalletTabsParamList>>()
   const theme = useTheme()
-  const webViewRef = useRef<WebView>(null)
   const insets = useSafeAreaInsets()
   const defaultAddress = useAppSelector(selectDefaultAddress)
-  const [isDisclaimerAccepted, setIsDisclaimerAccepted] = useState(false)
-  const [currentUrl, setCurrentUrl] = useState('')
   const dispatch = useAppDispatch()
-  const onClose = () => dispatch(closeModal({ id }))
 
-  useEffect(() => {
-    if (Platform.OS === 'android') {
-      const onAndroidBackPress = () => {
-        if (webViewRef.current) {
-          webViewRef.current.goBack()
-          return true // prevent default behavior (exit app)
-        }
-        return false
+  const handleDisclaimerAcceptPress = () => {
+    openBrowserAsync(
+      'https://alephium.banxa.com/' +
+        `?walletAddress=${defaultAddress.hash}` +
+        `&theme=${theme.name}` +
+        `&backgroundColor=${theme.bg.primary.slice(1)}` + // TODO: In light theme it's rgba, removing the first char is problematic
+        `&textColor=${theme.font.primary.slice(1)}` +
+        `&primaryColor=${theme.global.accent.slice(1)}` +
+        `&secondaryColor=${theme.global.complementary.slice(1)}`,
+      {
+        createTask: false, // Android: the browser opens within our app without a new task in the task manager
+        toolbarColor: theme.bg.back1, // TODO: Wanted to use theme.bg.primary, but in light theme it's rgba and it looks black, not white
+        controlsColor: theme.global.accent // iOS: color of button texts
       }
+    )
 
-      BackHandler.addEventListener('hardwareBackPress', onAndroidBackPress)
-      return () => {
-        BackHandler.removeEventListener('hardwareBackPress', onAndroidBackPress)
-      }
-    }
-  }, [])
-
-  const banxaInitialURL =
-    'https://alephium.banxa.com/' +
-    `?walletAddress=${defaultAddress.hash}` +
-    `&theme=${theme.name}` +
-    `&backgroundColor=${theme.bg.primary.slice(1)}` +
-    `&textColor=${theme.font.primary.slice(1)}` +
-    `&primaryColor=${theme.global.accent.slice(1)}` +
-    `&secondaryColor=${theme.global.complementary.slice(1)}`
-
-  useEffect(() => {
-    if (!currentUrl) {
-      setCurrentUrl(banxaInitialURL)
-    }
-  }, [defaultAddress, theme, currentUrl, banxaInitialURL])
-
-  const handleNavigationChange = (e: WebViewNavigation) => {
-    // Close modal if url equals default return URL configured in Banxa dashboard
-    if (e.url.includes('alephium.org')) {
-      navigation.navigate('ActivityScreen')
-      setCurrentUrl(banxaInitialURL)
-      onClose()
-    } else {
-      setCurrentUrl(e.url)
-    }
+    dispatch(closeModal({ id }))
   }
 
   return (
     <BottomModal modalId={id} title={t('Buy')} maximisedContent noPadding contentContainerStyle={{ flex: 1 }}>
-      {!isDisclaimerAccepted ? (
-        <DisclaimerContent>
-          <ScreenTitle title={t('Disclaimer')} />
-          <TextContainer>
-            <AppText>
-              <Trans
-                t={t}
-                i18nKey="banxaDisclaimer"
-                components={{
-                  1: <LinkToWeb url="https://www.banxa.com" />
-                }}
-              >
-                {
-                  'You are about to access 3rd party services provided by <1>Banxa.com</1> through an in-app browser. Alephium does not control Banxa’s services. Banxa’s terms and conditions will apply, so please read and understand them before proceeding.'
-                }
-              </Trans>
-            </AppText>
-          </TextContainer>
-          <BottomButtons fullWidth>
-            <Button
-              title={t("Alright, let's get to it.")}
-              onPress={() => setIsDisclaimerAccepted(true)}
-              variant="highlight"
-              style={{ marginBottom: insets.bottom }}
-            />
-          </BottomButtons>
-        </DisclaimerContent>
-      ) : (
-        <WebView
-          ref={webViewRef}
-          source={{
-            uri: currentUrl
-          }}
-          originWhitelist={['*']}
-          allowsInlineMediaPlayback
-          enableApplePay
-          mediaPlaybackRequiresUserAction={false}
-          containerStyle={{ padding: 0 }}
-          allowsBackForwardNavigationGestures
-          onNavigationStateChange={handleNavigationChange}
-          setSupportMultipleWindows={false}
-          nestedScrollEnabled
-        />
-      )}
+      <DisclaimerContent>
+        <ScreenTitle title={t('Disclaimer')} />
+        <TextContainer>
+          <AppText>
+            <Trans
+              t={t}
+              i18nKey="banxaDisclaimer"
+              components={{
+                1: <LinkToWeb url="https://www.banxa.com" />
+              }}
+            >
+              {
+                'You are about to access 3rd party services provided by <1>Banxa.com</1> through an in-app browser. Alephium does not control Banxa’s services. Banxa’s terms and conditions will apply, so please read and understand them before proceeding.'
+              }
+            </Trans>
+          </AppText>
+        </TextContainer>
+        <BottomButtons fullWidth>
+          <Button
+            title={t("Alright, let's get to it.")}
+            onPress={handleDisclaimerAcceptPress}
+            variant="highlight"
+            style={{ marginBottom: insets.bottom }}
+          />
+        </BottomButtons>
+      </DisclaimerContent>
     </BottomModal>
   )
 })

--- a/apps/mobile-wallet/src/features/buy/buyUtils.ts
+++ b/apps/mobile-wallet/src/features/buy/buyUtils.ts
@@ -1,0 +1,9 @@
+import { dismissBrowser } from 'expo-web-browser'
+
+const CLOSE_BANXA_TAB_DEEP_LINK = 'alephium://close-banxa-tab'
+
+export const closeBanxaTabOnDeepLink = (event: { url: string }) => {
+  if (event.url.includes(CLOSE_BANXA_TAB_DEEP_LINK)) {
+    dismissBrowser()
+  }
+}

--- a/apps/mobile-wallet/src/features/buy/useBanxaUrl.ts
+++ b/apps/mobile-wallet/src/features/buy/useBanxaUrl.ts
@@ -1,0 +1,18 @@
+import { AddressHash } from '@alephium/shared'
+import { useTheme } from 'styled-components/native'
+
+const useBanxaUrl = (receiveAddressHash: AddressHash) => {
+  const theme = useTheme()
+
+  return (
+    'https://alephium.banxa.com/' +
+    `?walletAddress=${receiveAddressHash}` +
+    `&theme=${theme.name}` +
+    `&backgroundColor=${theme.bg.primary.slice(1)}` + // TODO: In light theme it's rgba, removing the first char is problematic
+    `&textColor=${theme.font.primary.slice(1)}` +
+    `&primaryColor=${theme.global.accent.slice(1)}` +
+    `&secondaryColor=${theme.global.complementary.slice(1)}`
+  )
+}
+
+export default useBanxaUrl

--- a/apps/mobile-wallet/src/features/buy/useBanxaUrl.ts
+++ b/apps/mobile-wallet/src/features/buy/useBanxaUrl.ts
@@ -8,7 +8,7 @@ const useBanxaUrl = (receiveAddressHash: AddressHash) => {
     'https://alephium.banxa.com/' +
     `?walletAddress=${receiveAddressHash}` +
     `&theme=${theme.name}` +
-    `&backgroundColor=${theme.bg.primary.slice(1)}` + // TODO: In light theme it's rgba, removing the first char is problematic
+    `&backgroundColor=${theme.bg.back1.slice(1)}` +
     `&textColor=${theme.font.primary.slice(1)}` +
     `&primaryColor=${theme.global.accent.slice(1)}` +
     `&secondaryColor=${theme.global.complementary.slice(1)}`

--- a/apps/mobile-wallet/src/features/modals/AppModals.tsx
+++ b/apps/mobile-wallet/src/features/modals/AppModals.tsx
@@ -45,7 +45,7 @@ const AppModals = () => {
 
         switch (params.name) {
           case 'BuyModal':
-            return <BuyModal key={id} id={id} />
+            return <BuyModal key={id} id={id} {...params.props} />
           case 'BackupReminderModal':
             return <BackupReminderModal key={id} id={id} {...params.props} />
           case 'SwitchNetworkModal':

--- a/apps/mobile-wallet/src/features/receive/screens/QRCodeScreen.tsx
+++ b/apps/mobile-wallet/src/features/receive/screens/QRCodeScreen.tsx
@@ -12,8 +12,9 @@ import ScrollScreen, { ScrollScreenProps } from '~/components/layout/ScrollScree
 import Surface from '~/components/layout/Surface'
 import Row from '~/components/Row'
 import { useHeaderContext } from '~/contexts/HeaderContext'
+import { openModal } from '~/features/modals/modalActions'
 import useScrollToTopOnFocus from '~/hooks/layout/useScrollToTopOnFocus'
-import { useAppSelector } from '~/hooks/redux'
+import { useAppDispatch, useAppSelector } from '~/hooks/redux'
 import { ReceiveNavigationParamList } from '~/navigation/ReceiveNavigation'
 import { selectAddressByHash } from '~/store/addressesSlice'
 import { BORDER_RADIUS_BIG } from '~/style/globalStyle'
@@ -25,6 +26,7 @@ const QRCodeScreen = ({ navigation, route: { params }, ...props }: ScreenProps) 
   const { screenScrollHandler, screenScrollY } = useHeaderContext()
   const address = useAppSelector((s) => selectAddressByHash(s, params.addressHash))
   const { t } = useTranslation()
+  const dispatch = useAppDispatch()
 
   useScrollToTopOnFocus(screenScrollY)
 
@@ -33,6 +35,9 @@ const QRCodeScreen = ({ navigation, route: { params }, ...props }: ScreenProps) 
 
     copyAddressToClipboard(params.addressHash)
   }
+
+  const openBuyModal = () =>
+    dispatch(openModal({ name: 'BuyModal', props: { receiveAddressHash: params.addressHash } }))
 
   return (
     <ScrollScreen
@@ -51,8 +56,9 @@ const QRCodeScreen = ({ navigation, route: { params }, ...props }: ScreenProps) 
           <QRCode size={200} value={params.addressHash} />
         </QRCodeContainer>
       </ScreenSection>
-      <ScreenSection centered>
+      <ScreenSection centered verticalGap>
         <Button short title={t('Copy address')} onPress={handleCopyAddressPress} iconProps={{ name: 'copy' }} />
+        <Button short title={t('Buy')} onPress={openBuyModal} iconProps={{ name: 'credit-card' }} />
       </ScreenSection>
       <ScreenSection>
         <Surface>

--- a/apps/mobile-wallet/src/screens/Dashboard/DashboardCardButton.tsx
+++ b/apps/mobile-wallet/src/screens/Dashboard/DashboardCardButton.tsx
@@ -1,0 +1,30 @@
+import Ionicons from '@expo/vector-icons/Feather'
+import Animated, { LinearTransition } from 'react-native-reanimated'
+import styled, { useTheme } from 'styled-components/native'
+
+import AppText from '~/components/AppText'
+import Button, { ButtonProps } from '~/components/buttons/Button'
+
+interface DashboardCardButtonProps extends ButtonProps {}
+
+const AnimatedIonicons = Animated.createAnimatedComponent(Ionicons)
+
+const DashboardCardButton = ({ title, iconProps, ...props }: DashboardCardButtonProps) => {
+  const theme = useTheme()
+
+  return (
+    <ButtonStyled variant="contrast" squared flex {...props}>
+      {iconProps && <AnimatedIonicons layout={LinearTransition} color={theme.font.contrast} size={22} {...iconProps} />}
+      <AppText color="contrast" semiBold size={12}>
+        {title}
+      </AppText>
+    </ButtonStyled>
+  )
+}
+
+export default DashboardCardButton
+
+const ButtonStyled = styled(Button)`
+  flex-direction: column;
+  gap: 2px;
+`

--- a/apps/mobile-wallet/src/screens/Dashboard/DashboardScreen.tsx
+++ b/apps/mobile-wallet/src/screens/Dashboard/DashboardScreen.tsx
@@ -11,7 +11,6 @@ import Amount from '~/components/Amount'
 import AnimatedBackground from '~/components/AnimatedBackground'
 import AppText from '~/components/AppText'
 import BalanceSummary from '~/components/BalanceSummary'
-import Button from '~/components/buttons/Button'
 import EmptyPlaceholder from '~/components/EmptyPlaceholder'
 import { headerOffsetTop } from '~/components/headers/BaseHeader'
 import BottomBarScrollScreen, { BottomBarScrollScreenProps } from '~/components/layout/BottomBarScrollScreen'
@@ -52,7 +51,7 @@ const DashboardScreen = ({ navigation, ...props }: ScreenProps) => {
   const selectAddessesTokensWorth = useMemo(makeSelectAddressesTokensWorth, [])
   const balanceInFiat = useAppSelector(selectAddessesTokensWorth)
   const addressHashes = useAppSelector(selectAddressIds) as AddressHash[]
-  const addressesStatus = useAppSelector((s) => s.addresses.status)
+  const addressesBalancesStatus = useAppSelector((s) => s.addresses.balancesStatus)
   const isMnemonicBackedUp = useAppSelector((s) => s.wallet.isMnemonicBackedUp)
   const needsBackupReminder = useAppSelector((s) => s.backup.needsReminder)
   const defaultAddressHash = useAppSelector(selectDefaultAddress).hash
@@ -130,30 +129,14 @@ const DashboardScreen = ({ navigation, ...props }: ScreenProps) => {
           )}
         </RoundedCardStyled>
       </CardContainer>
+
       <AddressesTokensList />
-      {totalBalance === BigInt(0) && addressesStatus === 'initialized' && (
+
+      {totalBalance === BigInt(0) && addressesBalancesStatus === 'initialized' && (
         <EmptyPlaceholder style={{ marginHorizontal: DEFAULT_MARGIN }}>
           <AppText size={28}>🌈</AppText>
           <AppText color="secondary">{t('There is so much left to discover!')}</AppText>
           <AppText color="tertiary">{t('Start by adding funds to your wallet.')}</AppText>
-          <EmptyWalletActionButtons>
-            <Button
-              title={t('Receive')}
-              onPress={handleReceivePress}
-              iconProps={{ name: 'download' }}
-              variant="contrast"
-              squared
-              short
-            />
-            <Button
-              title={t('Buy')}
-              onPress={openBuyModal}
-              iconProps={{ name: 'credit-card' }}
-              variant="contrast"
-              squared
-              short
-            />
-          </EmptyWalletActionButtons>
         </EmptyPlaceholder>
       )}
     </DashboardScreenStyled>

--- a/apps/mobile-wallet/src/screens/Dashboard/DashboardScreen.tsx
+++ b/apps/mobile-wallet/src/screens/Dashboard/DashboardScreen.tsx
@@ -27,6 +27,7 @@ import { ReceiveNavigationParamList } from '~/navigation/ReceiveNavigation'
 import { SendNavigationParamList } from '~/navigation/SendNavigation'
 import { getIsNewWallet, storeIsNewWallet } from '~/persistent-storage/wallet'
 import CameraScanButton from '~/screens/Dashboard/CameraScanButton'
+import DashboardCardButton from '~/screens/Dashboard/DashboardCardButton'
 import DashboardSecondaryButtons from '~/screens/Dashboard/DashboardSecondaryButtons'
 import WalletSettingsButton from '~/screens/Dashboard/WalletSettingsButton'
 import { makeSelectAddressesTokensWorth } from '~/store/addresses/addressesSelectors'
@@ -122,25 +123,9 @@ const DashboardScreen = ({ navigation, ...props }: ScreenProps) => {
           <BalanceSummary dateLabel={t('VALUE TODAY')} />
           {totalBalance > BigInt(0) && (
             <ButtonsRowContainer>
-              <>
-                <Button onPress={handleSendPress} iconProps={{ name: 'send' }} variant="contrast" squared flex short />
-                <Button
-                  onPress={handleReceivePress}
-                  iconProps={{ name: 'download' }}
-                  variant="contrast"
-                  squared
-                  flex
-                  short
-                />
-                <Button
-                  onPress={openBuyModal}
-                  iconProps={{ name: 'credit-card' }}
-                  variant="contrast"
-                  squared
-                  flex
-                  short
-                />
-              </>
+              <DashboardCardButton title={t('Send')} onPress={handleSendPress} iconProps={{ name: 'send' }} />
+              <DashboardCardButton title={t('Receive')} onPress={handleReceivePress} iconProps={{ name: 'download' }} />
+              <DashboardCardButton title={t('Buy')} onPress={openBuyModal} iconProps={{ name: 'credit-card' }} />
             </ButtonsRowContainer>
           )}
         </RoundedCardStyled>

--- a/apps/mobile-wallet/src/screens/Dashboard/DashboardScreen.tsx
+++ b/apps/mobile-wallet/src/screens/Dashboard/DashboardScreen.tsx
@@ -152,6 +152,7 @@ const DashboardScreenStyled = styled(BottomBarScrollScreen)`
 
 const CardContainer = styled.View`
   margin: 0 ${DEFAULT_MARGIN}px;
+  flex: 1;
 `
 
 const RoundedCardStyled = styled(RoundedCard)`

--- a/apps/mobile-wallet/src/screens/Dashboard/DashboardScreen.tsx
+++ b/apps/mobile-wallet/src/screens/Dashboard/DashboardScreen.tsx
@@ -117,8 +117,8 @@ const DashboardScreen = ({ navigation, ...props }: ScreenProps) => {
     >
       <CardContainer style={{ marginTop: insets.top }}>
         <RoundedCardStyled>
-          <DashboardSecondaryButtons />
           <AnimatedBackground height={400} scrollY={screenScrollY} isAnimated />
+          <DashboardSecondaryButtons />
           <BalanceSummary dateLabel={t('VALUE TODAY')} />
 
           <ButtonsRowContainer>

--- a/apps/mobile-wallet/src/screens/Dashboard/DashboardScreen.tsx
+++ b/apps/mobile-wallet/src/screens/Dashboard/DashboardScreen.tsx
@@ -30,7 +30,7 @@ import CameraScanButton from '~/screens/Dashboard/CameraScanButton'
 import DashboardSecondaryButtons from '~/screens/Dashboard/DashboardSecondaryButtons'
 import WalletSettingsButton from '~/screens/Dashboard/WalletSettingsButton'
 import { makeSelectAddressesTokensWorth } from '~/store/addresses/addressesSelectors'
-import { selectAddressIds, selectTotalBalance } from '~/store/addressesSlice'
+import { selectAddressIds, selectDefaultAddress, selectTotalBalance } from '~/store/addressesSlice'
 import { DEFAULT_MARGIN, VERTICAL_GAP } from '~/style/globalStyle'
 
 interface ScreenProps
@@ -54,6 +54,7 @@ const DashboardScreen = ({ navigation, ...props }: ScreenProps) => {
   const addressesStatus = useAppSelector((s) => s.addresses.status)
   const isMnemonicBackedUp = useAppSelector((s) => s.wallet.isMnemonicBackedUp)
   const needsBackupReminder = useAppSelector((s) => s.backup.needsReminder)
+  const defaultAddressHash = useAppSelector(selectDefaultAddress).hash
 
   const { data: isNewWallet } = useAsyncData(getIsNewWallet)
 
@@ -95,7 +96,8 @@ const DashboardScreen = ({ navigation, ...props }: ScreenProps) => {
     }
   }
 
-  const openBuyModal = () => dispatch(openModal({ name: 'BuyModal' }))
+  const openBuyModal = () =>
+    dispatch(openModal({ name: 'BuyModal', props: { receiveAddressHash: defaultAddressHash } }))
 
   return (
     <DashboardScreenStyled

--- a/apps/mobile-wallet/src/screens/Dashboard/DashboardScreen.tsx
+++ b/apps/mobile-wallet/src/screens/Dashboard/DashboardScreen.tsx
@@ -120,13 +120,14 @@ const DashboardScreen = ({ navigation, ...props }: ScreenProps) => {
           <DashboardSecondaryButtons />
           <AnimatedBackground height={400} scrollY={screenScrollY} isAnimated />
           <BalanceSummary dateLabel={t('VALUE TODAY')} />
-          {totalBalance > BigInt(0) && (
-            <ButtonsRowContainer>
+
+          <ButtonsRowContainer>
+            {totalBalance > BigInt(0) && (
               <DashboardCardButton title={t('Send')} onPress={handleSendPress} iconProps={{ name: 'send' }} />
-              <DashboardCardButton title={t('Receive')} onPress={handleReceivePress} iconProps={{ name: 'download' }} />
-              <DashboardCardButton title={t('Buy')} onPress={openBuyModal} iconProps={{ name: 'credit-card' }} />
-            </ButtonsRowContainer>
-          )}
+            )}
+            <DashboardCardButton title={t('Receive')} onPress={handleReceivePress} iconProps={{ name: 'download' }} />
+            <DashboardCardButton title={t('Buy')} onPress={openBuyModal} iconProps={{ name: 'credit-card' }} />
+          </ButtonsRowContainer>
         </RoundedCardStyled>
       </CardContainer>
 
@@ -163,9 +164,4 @@ const ButtonsRowContainer = styled(Animated.View)`
   align-items: center;
   justify-content: center;
   gap: 10px;
-`
-
-const EmptyWalletActionButtons = styled.View`
-  gap: ${VERTICAL_GAP / 2}px;
-  margin-top: ${VERTICAL_GAP}px;
 `

--- a/apps/mobile-wallet/src/screens/Dashboard/DashboardSecondaryButtons.tsx
+++ b/apps/mobile-wallet/src/screens/Dashboard/DashboardSecondaryButtons.tsx
@@ -1,7 +1,5 @@
 import { NavigationProp, useNavigation } from '@react-navigation/native'
-import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleProp, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
 import Button from '~/components/buttons/Button'
@@ -11,11 +9,7 @@ import { SendNavigationParamList } from '~/navigation/SendNavigation'
 import WalletConnectButton from '~/screens/Dashboard/WalletConnectButton'
 import { showToast } from '~/utils/layout'
 
-interface DashboardSecondaryButtonsProps {
-  style?: StyleProp<ViewStyle>
-}
-
-const DashboardSecondaryButtons = ({ style }: DashboardSecondaryButtonsProps) => {
+const DashboardSecondaryButtons = () => {
   const isMnemonicBackedUp = useAppSelector((s) => s.wallet.isMnemonicBackedUp)
   const networkStatus = useAppSelector((s) => s.network.status)
   const isWalletConnectEnabled = useAppSelector((s) => s.settings.walletConnect)
@@ -55,12 +49,11 @@ const DashboardSecondaryButtons = ({ style }: DashboardSecondaryButtonsProps) =>
   )
 }
 
-export default memo(DashboardSecondaryButtons)
+export default DashboardSecondaryButtons
 
 const DashboardSecondaryButtonsStyled = styled.View`
   flex: 1;
   margin-top: -10px;
-  z-index: 1;
 `
 
 const Buttons = styled.View`


### PR DESCRIPTION
This PR:
1. Simplifies BuyModal code
2. Relies on the OS's native browser and opening a tab * **within the app** * (does not create a new task in the task manager - we're still in the app)
3. Fixes rendering issues reported by testers (see below)
4. Fixes Google Pay
5. Adds Buy button in Receive screen and uses selected receive address
6. Adds text below icons in dashboard card buttons
7. Fixes loading glitches
   - https://github.com/alephium/alephium-frontend/issues/1089

## Related website PR
- https://github.com/alephium/www/pull/181

## Demo

https://github.com/user-attachments/assets/d4814531-f8c4-402a-bd28-f6a68faf5516

<img width="870" alt="image" src="https://github.com/user-attachments/assets/609f6e28-2f8d-47f2-a66f-5a1b3e261f2b" />


## Rendering issues

<details><summary>Click to see screenshots</summary>

Tab icons show at the bottom of the webview after switching between apps:

<img width="300" src="https://github.com/user-attachments/assets/0181ddf5-fcf9-43e4-a65d-b35446216ad1" />

</details>