### PR TITLE
Remove listener removal

### DIFF
--- a/apps/mobile-wallet/src/features/buy/buyUtils.ts
+++ b/apps/mobile-wallet/src/features/buy/buyUtils.ts
@@ -1,9 +1,0 @@
-import { dismissBrowser } from 'expo-web-browser'
-
-const CLOSE_BANXA_TAB_DEEP_LINK = 'alephium://close-banxa-tab'
-
-export const closeBanxaTabOnDeepLink = (event: { url: string }) => {
-  if (event.url.includes(CLOSE_BANXA_TAB_DEEP_LINK)) {
-    dismissBrowser()
-  }
-}


### PR DESCRIPTION
I replaced the listener with the recommended `useURL` hook

<img width="1099" alt="image" src="https://github.com/user-attachments/assets/918f3992-4988-471f-a8da-8a1d0fb18141" />
