### PR TITLE
Fix tx caching and add activity indicator

### DIFF
--- a/.changeset/fruity-bars-sniff.md
+++ b/.changeset/fruity-bars-sniff.md
@@ -1,0 +1,5 @@
+---
+'alephium-desktop-wallet': patch
+---
+
+Display activity indicator when new transactions arrive

--- a/.changeset/warm-geckos-cheer.md
+++ b/.changeset/warm-geckos-cheer.md
@@ -1,0 +1,5 @@
+---
+'alephium-desktop-wallet': patch
+---
+
+Improve transactions loading in activity page

--- a/apps/desktop-wallet/src/features/transactionsDisplay/ActivityIndicator.tsx
+++ b/apps/desktop-wallet/src/features/transactionsDisplay/ActivityIndicator.tsx
@@ -1,0 +1,71 @@
+import { useFetchWalletTransactionsInfinite } from '@alephium/shared-react'
+import { explorer as e } from '@alephium/web3'
+import { uniqBy } from 'lodash'
+import { useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import styled from 'styled-components'
+
+import { sidebarExpandThresholdPx } from '@/style/globalStyles'
+
+const ActivityIndicator = () => {
+  // Our infinite query that fetches the wallet transactions is set up to delete the persisted cache after 5 minutes, so
+  // that we are not bloating the cache when addresses are being deleted/created. However, since this query was only
+  // used in the Activity page, when the user navigates to other pages for longer than 5 minutes, the cache will again
+  // be deleted. By keeping an active instance of the infinite query (and using it to display an activity indicator), we
+  // ensure that when addresses are deleted/created the old cache will be deleted after 5 minutes but the latest wallet
+  // transactions will be always be persisted, leading to a better UX.
+  const { data: fetchedConfirmedTxs, isLoading } = useFetchWalletTransactionsInfinite()
+
+  const [prevLatestTxs, setPrevLatestTxs] = useState<e.Transaction[]>([])
+  const [newTxCountIndicator, setNewTxCountIndicator] = useState(0)
+
+  const isOnActivityPage = useLocation().pathname === '/wallet/activity'
+
+  useEffect(() => {
+    if (isOnActivityPage) setNewTxCountIndicator(0)
+  }, [isOnActivityPage])
+
+  useEffect(() => {
+    if (fetchedConfirmedTxs.length === 0 || isLoading) {
+      return
+    }
+
+    if (prevLatestTxs.length === 0) {
+      setPrevLatestTxs(fetchedConfirmedTxs)
+      return
+    }
+
+    const newTxCount = uniqBy(
+      fetchedConfirmedTxs.filter((tx) => !prevLatestTxs.find((prevTx) => prevTx.hash === tx.hash)),
+      'hash'
+    ).length
+
+    if (newTxCount > 0 && !isOnActivityPage) {
+      setNewTxCountIndicator((prev) => prev + newTxCount)
+    }
+
+    setPrevLatestTxs(fetchedConfirmedTxs)
+  }, [fetchedConfirmedTxs, isLoading, isOnActivityPage, prevLatestTxs])
+
+  if (newTxCountIndicator === 0 || isOnActivityPage) return null
+
+  return <ActivityIndicatorStyled>{newTxCountIndicator}</ActivityIndicatorStyled>
+}
+
+export default ActivityIndicator
+
+const ActivityIndicatorStyled = styled.div`
+  position: absolute;
+  right: -5px;
+  top: -5px;
+  background-color: ${({ theme }) => theme.global.accent};
+  padding: 2px 5px;
+  border-radius: var(--radius-small);
+  font-size: 10px;
+
+  @media (min-width: ${sidebarExpandThresholdPx}px) {
+    right: 20px;
+    top: 50%;
+    transform: translate(50%, -50%);
+  }
+`

--- a/apps/desktop-wallet/src/features/transactionsDisplay/ActivityIndicator.tsx
+++ b/apps/desktop-wallet/src/features/transactionsDisplay/ActivityIndicator.tsx
@@ -1,51 +1,18 @@
-import { useFetchWalletTransactionsInfinite } from '@alephium/shared-react'
-import { explorer as e } from '@alephium/web3'
-import { uniqBy } from 'lodash'
-import { useEffect, useState } from 'react'
+import { useActivityIndicator } from '@alephium/shared-react'
 import { useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { sidebarExpandThresholdPx } from '@/style/globalStyles'
 
+// Our infinite query that fetches the wallet transactions is set up to delete the persisted cache after 5 minutes, so
+// that we are not bloating the cache when addresses are being deleted/created. However, since this query was only
+// used in the Activity page, when the user navigates to other pages for longer than 5 minutes, the cache will again
+// be deleted. By keeping an active instance of the infinite query (and using it to display an activity indicator), we
+// ensure that when addresses are deleted/created the old cache will be deleted after 5 minutes but the latest wallet
+// transactions will be always be persisted, leading to a better UX.
 const ActivityIndicator = () => {
-  // Our infinite query that fetches the wallet transactions is set up to delete the persisted cache after 5 minutes, so
-  // that we are not bloating the cache when addresses are being deleted/created. However, since this query was only
-  // used in the Activity page, when the user navigates to other pages for longer than 5 minutes, the cache will again
-  // be deleted. By keeping an active instance of the infinite query (and using it to display an activity indicator), we
-  // ensure that when addresses are deleted/created the old cache will be deleted after 5 minutes but the latest wallet
-  // transactions will be always be persisted, leading to a better UX.
-  const { data: fetchedConfirmedTxs, isLoading } = useFetchWalletTransactionsInfinite()
-
-  const [prevLatestTxs, setPrevLatestTxs] = useState<e.Transaction[]>([])
-  const [newTxCountIndicator, setNewTxCountIndicator] = useState(0)
-
   const isOnActivityPage = useLocation().pathname === '/wallet/activity'
-
-  useEffect(() => {
-    if (isOnActivityPage) setNewTxCountIndicator(0)
-  }, [isOnActivityPage])
-
-  useEffect(() => {
-    if (fetchedConfirmedTxs.length === 0 || isLoading) {
-      return
-    }
-
-    if (prevLatestTxs.length === 0) {
-      setPrevLatestTxs(fetchedConfirmedTxs)
-      return
-    }
-
-    const newTxCount = uniqBy(
-      fetchedConfirmedTxs.filter((tx) => !prevLatestTxs.find((prevTx) => prevTx.hash === tx.hash)),
-      'hash'
-    ).length
-
-    if (newTxCount > 0 && !isOnActivityPage) {
-      setNewTxCountIndicator((prev) => prev + newTxCount)
-    }
-
-    setPrevLatestTxs(fetchedConfirmedTxs)
-  }, [fetchedConfirmedTxs, isLoading, isOnActivityPage, prevLatestTxs])
+  const newTxCountIndicator = useActivityIndicator({ isDisabled: isOnActivityPage })
 
   if (newTxCountIndicator === 0 || isOnActivityPage) return null
 

--- a/apps/desktop-wallet/src/pages/unlockedWallet/UnlockedWalletLayout.tsx
+++ b/apps/desktop-wallet/src/pages/unlockedWallet/UnlockedWalletLayout.tsx
@@ -38,7 +38,7 @@ const UnlockedWalletLayout = ({ children, title, className }: UnlockedWalletLayo
           <NavItem Icon={Home} label={t('Overview')} to="/wallet/overview" />
           <ActivityNavItemStyled>
             <NavItem Icon={Clock} label={t('Activity')} to="/wallet/activity" />
-            <ActivityIndicator />
+            <ActivityIndicator /> {/* Helps improve Activity page UX, see component for more details */}
           </ActivityNavItemStyled>
           <NavItem Icon={Bookmark} label={t('Addresses')} to="/wallet/addresses" />
         </SideNavigation>

--- a/apps/desktop-wallet/src/pages/unlockedWallet/UnlockedWalletLayout.tsx
+++ b/apps/desktop-wallet/src/pages/unlockedWallet/UnlockedWalletLayout.tsx
@@ -12,6 +12,7 @@ import NavItem from '@/components/NavItem'
 import SideBar from '@/components/PageComponents/SideBar'
 import Scrollbar from '@/components/Scrollbar'
 import WalletNameButton from '@/components/WalletNameButton'
+import ActivityIndicator from '@/features/transactionsDisplay/ActivityIndicator'
 import { useAppSelector } from '@/hooks/redux'
 import { appHeaderHeightPx } from '@/style/globalStyles'
 
@@ -35,7 +36,10 @@ const UnlockedWalletLayout = ({ children, title, className }: UnlockedWalletLayo
         <SideNavigation>
           <WalletNameButton />
           <NavItem Icon={Home} label={t('Overview')} to="/wallet/overview" />
-          <NavItem Icon={Clock} label={t('Activity')} to="/wallet/activity" />
+          <ActivityNavItemStyled>
+            <NavItem Icon={Clock} label={t('Activity')} to="/wallet/activity" />
+            <ActivityIndicator />
+          </ActivityNavItemStyled>
           <NavItem Icon={Bookmark} label={t('Addresses')} to="/wallet/addresses" />
         </SideNavigation>
       </SideBar>
@@ -49,6 +53,10 @@ const UnlockedWalletLayout = ({ children, title, className }: UnlockedWalletLayo
     </motion.div>
   )
 }
+
+const ActivityNavItemStyled = styled.div`
+  position: relative;
+`
 
 export const UnlockedWalletPanel = styled.div<{
   top?: boolean

--- a/packages/shared-react/src/api/queries/transactionQueries.ts
+++ b/packages/shared-react/src/api/queries/transactionQueries.ts
@@ -113,8 +113,8 @@ export const walletTransactionsInfiniteQuery = ({
 }: WalletTransactionsInfiniteQueryProps) =>
   infiniteQueryOptions({
     queryKey: ['wallet', 'transactions', { networkId, addressHashes }],
-    // When the user navigates away from the Transfers page for 5 minutes or when addresses are generated/removed the
-    // cached data will be deleted.
+    // When there are no active instances of this query or when addresses are generated/removed the cached data will be
+    // deleted.
     ...getQueryConfig({ staleTime: Infinity, gcTime: FIVE_MINUTES_MS, networkId }),
     queryFn:
       !skip && networkId !== undefined

--- a/packages/shared-react/src/hooks/index.ts
+++ b/packages/shared-react/src/hooks/index.ts
@@ -1,4 +1,3 @@
 export * from './addresses'
-export * from './addresses/useAddresses'
-export * from './addresses/useUnsortedAddresses'
 export * from './transactions'
+export * from './useActivityIndicator'

--- a/packages/shared-react/src/hooks/useActivityIndicator.ts
+++ b/packages/shared-react/src/hooks/useActivityIndicator.ts
@@ -1,0 +1,44 @@
+import { explorer as e } from '@alephium/web3'
+import { uniqBy } from 'lodash'
+import { useEffect, useState } from 'react'
+
+import { useFetchWalletTransactionsInfinite } from '@/api/apiDataHooks'
+
+interface UseActivityIndicatorProps {
+  isDisabled: boolean
+}
+
+export const useActivityIndicator = ({ isDisabled }: UseActivityIndicatorProps) => {
+  const { data: fetchedConfirmedTxs, isLoading } = useFetchWalletTransactionsInfinite()
+
+  const [prevLatestTxs, setPrevLatestTxs] = useState<e.Transaction[]>([])
+  const [newTxCountIndicator, setNewTxCountIndicator] = useState(0)
+
+  useEffect(() => {
+    if (isDisabled) setNewTxCountIndicator(0)
+  }, [isDisabled])
+
+  useEffect(() => {
+    if (fetchedConfirmedTxs.length === 0 || isLoading) {
+      return
+    }
+
+    if (prevLatestTxs.length === 0) {
+      setPrevLatestTxs(fetchedConfirmedTxs)
+      return
+    }
+
+    const newTxCount = uniqBy(
+      fetchedConfirmedTxs.filter((tx) => !prevLatestTxs.find((prevTx) => prevTx.hash === tx.hash)),
+      'hash'
+    ).length
+
+    if (newTxCount > 0 && !isDisabled) {
+      setNewTxCountIndicator((prev) => prev + newTxCount)
+    }
+
+    setPrevLatestTxs(fetchedConfirmedTxs)
+  }, [fetchedConfirmedTxs, isLoading, isDisabled, prevLatestTxs])
+
+  return newTxCountIndicator
+}


### PR DESCRIPTION
While working on using Tanstack for fetching transaction data in the mobile wallet I had the idea of improving the UX in the desktop wallet, which led to killing 2 🐦 with 1 🪨 :

The problem was that 5 minutes after the user navigates away from the Activity screen the transactions cache data were deleted, because we want to avoid bloating the cache with useless data when addresses are deleted/created (the `queryKey` changes with changes in the list of addresses).

The solution is to keep an active instance of the same query that the Activity page is using, somewhere else. That's when I thought of implementing an Activity Indicator. This way, when addresses are deleted/created, the old cache will be deleted after 5 minutes, but the new cache will be persisted, which leads to the same behavior for the Activity page as for any other page of our app.

Related to:
- #20

