### PR TITLE
Improve WC connection drops UX

### DIFF
--- a/apps/mobile-wallet/locales/en-US/translation.json
+++ b/apps/mobile-wallet/locales/en-US/translation.json
@@ -261,7 +261,6 @@
   "Scan QR code": "Scan QR code",
   "Scan an Alephium address QR code": "Scan an Alephium address QR code",
   "Scan an Alephium address QR code to add to your contacts list.": "Scan an Alephium address QR code to add to your contacts list.",
-  "Scan an Alephium address QR code to send funds to.": "Scan an Alephium address QR code to send funds to.",
   "Scan an Alephium address QR code to send funds to or a WalletConnect QR code to connect to a dApp.": "Scan an Alephium address QR code to send funds to or a WalletConnect QR code to connect to a dApp.",
   "Could not connect to WalletConnect": "Could not connect to WalletConnect",
   "Current connections": "Current connections",
@@ -468,5 +467,7 @@
   "Unknown error": "Unknown error",
   "DApp URL": "DApp URL",
   "Load dApp": "Load dApp",
-  "Invalid URL": "Invalid URL"
+  "Invalid URL": "Invalid URL",
+  "Clear cache": "Clear cache",
+  "DApps": "DApps"
 }

--- a/apps/mobile-wallet/locales/en-US/translation.json
+++ b/apps/mobile-wallet/locales/en-US/translation.json
@@ -469,5 +469,9 @@
   "Load dApp": "Load dApp",
   "Invalid URL": "Invalid URL",
   "Clear cache": "Clear cache",
-  "DApps": "DApps"
+  "DApps": "DApps",
+  "Remove all connections": "Remove all connections",
+  "WalletConnect connection unexpectedly dropped.": "WalletConnect connection unexpectedly dropped.",
+  "Please, refresh {{ dAppUrl }}.": "Please, refresh {{ dAppUrl }}.",
+  "WalletConnect cache cleared": "WalletConnect cache cleared"
 }

--- a/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectSessionProposalModal.tsx
+++ b/apps/mobile-wallet/src/contexts/walletConnect/WalletConnectSessionProposalModal.tsx
@@ -153,14 +153,15 @@ const WalletConnectSessionProposalModal = memo<WalletConnectSessionProposalModal
           }
         }
 
-        const { topic, acknowledged } = await walletConnectClient.approveSession({
+        const approvalResponse = await walletConnectClient.approveSession({
           id: proposalEventId,
           relayProtocol,
           namespaces
         })
-        console.log('👉 APPROVAL TOPIC RECEIVED:', topic)
+
+        console.log('👉 APPROVAL TOPIC RECEIVED:', approvalResponse.topic)
         console.log('✅ APPROVING: DONE!')
-        console.log('👉 DID DAPP ACTUALLY ACKNOWLEDGE?', acknowledged)
+        console.log('👉 DID DAPP ACTUALLY ACKNOWLEDGE?', approvalResponse.acknowledged)
 
         sendAnalytics({ event: 'WC: Approved connection' })
       } catch (e) {

--- a/apps/mobile-wallet/src/features/ecosystem/DAppWebViewScreen.tsx
+++ b/apps/mobile-wallet/src/features/ecosystem/DAppWebViewScreen.tsx
@@ -15,10 +15,9 @@ import { useWalletConnectContext } from '~/contexts/walletConnect/WalletConnectC
 import AddToFavoritesButton from '~/features/ecosystem/AddToFavoritesButton'
 import { activateAppLoading, deactivateAppLoading } from '~/features/loader/loaderActions'
 import { openModal } from '~/features/modals/modalActions'
-import { useAppDispatch, useAppSelector } from '~/hooks/redux'
+import { useAppDispatch } from '~/hooks/redux'
 import RootStackParamList from '~/navigation/rootStackRoutes'
 import { DEFAULT_MARGIN } from '~/style/globalStyle'
-import { showToast, ToastDuration } from '~/utils/layout'
 
 interface DAppWebViewScreenProps extends NativeStackScreenProps<RootStackParamList, 'DAppWebViewScreen'>, ScreenProps {}
 
@@ -171,7 +170,6 @@ const useDetectWCUrlInClipboardAndPair = () => {
   const dispatch = useAppDispatch()
   const { t } = useTranslation()
   const { pairWithDapp } = useWalletConnectContext()
-  const isWalletConnectEnabled = useAppSelector((s) => s.settings.walletConnect)
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
 
   useEffect(() => {
@@ -181,21 +179,11 @@ const useDetectWCUrlInClipboardAndPair = () => {
       if (content.startsWith('wc:')) {
         Clipboard.setStringAsync('')
 
-        if (!isWalletConnectEnabled) {
-          showToast({
-            text1: t('Experimental feature'),
-            text2: t('WalletConnect is an experimental feature. You can enable it in the settings.'),
-            type: 'info',
-            visibilityTime: ToastDuration.LONG,
-            onPress: () => navigation.navigate('SettingsScreen')
-          })
-        } else {
-          dispatch(activateAppLoading(t('Connecting')))
+        dispatch(activateAppLoading(t('Connecting')))
 
-          await pairWithDapp(content)
+        await pairWithDapp(content)
 
-          dispatch(deactivateAppLoading())
-        }
+        dispatch(deactivateAppLoading())
       }
     }
 
@@ -204,7 +192,7 @@ const useDetectWCUrlInClipboardAndPair = () => {
     const intervalId = setInterval(checkClipboard, 1000)
 
     return () => clearInterval(intervalId)
-  }, [dispatch, isWalletConnectEnabled, navigation, pairWithDapp, t])
+  }, [dispatch, navigation, pairWithDapp, t])
 }
 
 const WebViewStyled = styled(WebView)`

--- a/apps/mobile-wallet/src/features/settings/settingsPersistentStorage.ts
+++ b/apps/mobile-wallet/src/features/settings/settingsPersistentStorage.ts
@@ -13,7 +13,6 @@ export const defaultGeneralSettings: GeneralSettings = {
   currency: 'USD',
   analytics: true,
   analyticsId: undefined,
-  walletConnect: false,
   usesBiometrics: false,
   language: undefined,
   region: undefined,

--- a/apps/mobile-wallet/src/features/settings/settingsScreen/SettingsScreen.tsx
+++ b/apps/mobile-wallet/src/features/settings/settingsScreen/SettingsScreen.tsx
@@ -78,7 +78,7 @@ const SettingsScreen = ({ navigation, ...props }: ScreenProps) => {
     )
   }
 
-  const handleWalletConnectEnablePress = () => {
+  const handleWalletConnectClearCache = () => {
     resetWalletConnectStorage()
     resetWalletConnectClientInitializationAttempts()
   }
@@ -126,8 +126,8 @@ const SettingsScreen = ({ navigation, ...props }: ScreenProps) => {
         <ScreenSection>
           <ScreenSectionTitle>{t('DApps')}</ScreenSectionTitle>
 
-          <Row title="WalletConnect" subtitle={t('Clear cache')} isLast>
-            <Button title={t('Clear cache')} short onPress={handleWalletConnectEnablePress} />
+          <Row title="WalletConnect" subtitle={t('Remove all connections')} isLast>
+            <Button title={t('Clear cache')} short onPress={handleWalletConnectClearCache} />
           </Row>
         </ScreenSection>
 

--- a/apps/mobile-wallet/src/features/settings/settingsScreen/SettingsScreen.tsx
+++ b/apps/mobile-wallet/src/features/settings/settingsScreen/SettingsScreen.tsx
@@ -4,10 +4,10 @@ import * as Application from 'expo-application'
 import { capitalize } from 'lodash'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Alert } from 'react-native'
 import { useTheme } from 'styled-components/native'
 
 import AppText from '~/components/AppText'
+import Button from '~/components/buttons/Button'
 import { ScreenSection, ScreenSectionTitle } from '~/components/layout/Screen'
 import ScrollScreen, { ScrollScreenProps } from '~/components/layout/ScrollScreen'
 import ModalWithBackdrop from '~/components/ModalWithBackdrop'
@@ -21,12 +21,7 @@ import RegionSettingsRow from '~/features/settings/regionSettings/RegionSettings
 import SettingsAssetsSection from '~/features/settings/settingsScreen/SettingsAssetsSection'
 import SettingsDevSection from '~/features/settings/settingsScreen/SettingsDevSection'
 import SettingsSecuritySection from '~/features/settings/settingsScreen/SettingsSecuritySection'
-import {
-  analyticsToggled,
-  discreetModeToggled,
-  themeChanged,
-  walletConnectToggled
-} from '~/features/settings/settingsSlice'
+import { analyticsToggled, discreetModeToggled, themeChanged } from '~/features/settings/settingsSlice'
 import { useAppDispatch, useAppSelector } from '~/hooks/redux'
 import RootStackParamList from '~/navigation/rootStackRoutes'
 import { resetNavigation } from '~/utils/navigation'
@@ -40,7 +35,6 @@ const SettingsScreen = ({ navigation, ...props }: ScreenProps) => {
   const discreetMode = useAppSelector((s) => s.settings.discreetMode)
   const currentTheme = useAppSelector((s) => s.settings.theme)
   const currentCurrency = useAppSelector((s) => s.settings.currency)
-  const isWalletConnectEnabled = useAppSelector((s) => s.settings.walletConnect)
   const currentNetworkName = useAppSelector((s) => s.network.name)
   const language = useAppSelector((s) => s.settings.language)
   const analytics = useAppSelector((s) => s.settings.analytics)
@@ -78,8 +72,6 @@ const SettingsScreen = ({ navigation, ...props }: ScreenProps) => {
 
   const toggleAnalytics = () => dispatch(analyticsToggled())
 
-  const toggleWalletConnect = () => dispatch(walletConnectToggled())
-
   const handleDeleteButtonPress = () => {
     dispatch(
       openModal({ name: 'WalletDeleteModal', props: { onDelete: () => resetNavigation(navigation, 'LandingScreen') } })
@@ -87,25 +79,8 @@ const SettingsScreen = ({ navigation, ...props }: ScreenProps) => {
   }
 
   const handleWalletConnectEnablePress = () => {
-    if (!isWalletConnectEnabled) {
-      Alert.alert(
-        t('Enabling experimental feature'),
-        t('The WalletConnect feature is experimental, use it at your own risk.'),
-        [
-          { text: t('Cancel') },
-          {
-            text: t('I understand'),
-            onPress: () => {
-              toggleWalletConnect()
-              resetWalletConnectClientInitializationAttempts()
-            }
-          }
-        ]
-      )
-    } else {
-      resetWalletConnectStorage()
-      toggleWalletConnect()
-    }
+    resetWalletConnectStorage()
+    resetWalletConnectClientInitializationAttempts()
   }
 
   return (
@@ -149,10 +124,10 @@ const SettingsScreen = ({ navigation, ...props }: ScreenProps) => {
         <SettingsAssetsSection />
 
         <ScreenSection>
-          <ScreenSectionTitle>{t('Experimental features')}</ScreenSectionTitle>
+          <ScreenSectionTitle>{t('DApps')}</ScreenSectionTitle>
 
-          <Row title="WalletConnect" subtitle={t('Connect to dApps')} isLast>
-            <Toggle value={isWalletConnectEnabled} onValueChange={handleWalletConnectEnablePress} />
+          <Row title="WalletConnect" subtitle={t('Clear cache')} isLast>
+            <Button title={t('Clear cache')} short onPress={handleWalletConnectEnablePress} />
           </Row>
         </ScreenSection>
 

--- a/apps/mobile-wallet/src/features/settings/settingsSlice.ts
+++ b/apps/mobile-wallet/src/features/settings/settingsSlice.ts
@@ -45,9 +45,6 @@ const settingsSlice = createSlice({
     analyticsToggled: (state) => {
       state.analytics = !state.analytics
     },
-    walletConnectToggled: (state) => {
-      state.walletConnect = !state.walletConnect
-    },
     biometricsToggled: (state) => {
       state.usesBiometrics = !state.usesBiometrics
     },
@@ -92,7 +89,6 @@ export const {
   discreetModeToggled,
   passwordRequirementToggled,
   analyticsToggled,
-  walletConnectToggled,
   biometricsToggled,
   autoLockSecondsChanged
 } = settingsSlice.actions
@@ -108,7 +104,6 @@ settingsListenerMiddleware.startListening({
     fiatCurrencyChanged,
     analyticsIdGenerated,
     analyticsToggled,
-    walletConnectToggled,
     biometricsToggled,
     autoLockSecondsChanged,
     allBiometricsEnabled,

--- a/apps/mobile-wallet/src/screens/Dashboard/CameraScanButton.tsx
+++ b/apps/mobile-wallet/src/screens/Dashboard/CameraScanButton.tsx
@@ -12,7 +12,6 @@ import { selectAllContacts } from '~/store/addresses/addressesSelectors'
 import { showToast } from '~/utils/layout'
 
 const CameraScanButton = () => {
-  const isWalletConnectEnabled = useAppSelector((s) => s.settings.walletConnect)
   const walletConnectClientStatus = useAppSelector((s) => s.clients.walletConnect.status)
   const contacts = useAppSelector(selectAllContacts)
   const navigation = useNavigation<NavigationProp<RootStackParamList>>()
@@ -33,7 +32,7 @@ const CameraScanButton = () => {
   const handleWalletConnectUriScanned = (uri: string) => {
     sendAnalytics({ event: 'WC: Scanned WC QR code' })
 
-    if (isWalletConnectEnabled && walletConnectClientStatus === 'initialized') {
+    if (walletConnectClientStatus === 'initialized') {
       pairWithDapp(uri)
     } else {
       showToast({
@@ -50,11 +49,7 @@ const CameraScanButton = () => {
 
   return (
     <CameraScanButtonBase
-      text={
-        isWalletConnectEnabled
-          ? t('Scan an Alephium address QR code to send funds to or a WalletConnect QR code to connect to a dApp.')
-          : t('Scan an Alephium address QR code to send funds to.')
-      }
+      text={t('Scan an Alephium address QR code to send funds to or a WalletConnect QR code to connect to a dApp.')}
       origin="dashboard"
       onValidAddressScanned={handleValidAddressScanned}
       onWalletConnectUriScanned={handleWalletConnectUriScanned}

--- a/apps/mobile-wallet/src/screens/Dashboard/DashboardSecondaryButtons.tsx
+++ b/apps/mobile-wallet/src/screens/Dashboard/DashboardSecondaryButtons.tsx
@@ -11,7 +11,6 @@ import { showToast } from '~/utils/layout'
 const DashboardSecondaryButtons = () => {
   const isMnemonicBackedUp = useAppSelector((s) => s.wallet.isMnemonicBackedUp)
   const networkStatus = useAppSelector((s) => s.network.status)
-  const isWalletConnectEnabled = useAppSelector((s) => s.settings.walletConnect)
   const navigation = useNavigation<NavigationProp<RootStackParamList>>()
   const { t } = useTranslation()
 
@@ -23,15 +22,12 @@ const DashboardSecondaryButtons = () => {
       onPress: () => navigation.navigate('SettingsScreen')
     })
 
-  const areNoButtonsVisible = !isWalletConnectEnabled && isMnemonicBackedUp && networkStatus !== 'offline'
-  const onlySideButtonVisible = isWalletConnectEnabled && isMnemonicBackedUp && networkStatus !== 'offline'
-
-  if (areNoButtonsVisible) return null
+  if (isMnemonicBackedUp && networkStatus !== 'offline') return null
 
   return (
-    <DashboardSecondaryButtonsStyled style={{ height: onlySideButtonVisible ? 15 : 30 }}>
+    <DashboardSecondaryButtonsStyled style={{ height: 15 }}>
       <Buttons>
-        {isWalletConnectEnabled && <WalletConnectButton />}
+        <WalletConnectButton />
         {networkStatus === 'offline' && (
           <Button
             onPress={showOfflineMessage}

--- a/apps/mobile-wallet/src/screens/Dashboard/DashboardSecondaryButtons.tsx
+++ b/apps/mobile-wallet/src/screens/Dashboard/DashboardSecondaryButtons.tsx
@@ -22,8 +22,6 @@ const DashboardSecondaryButtons = () => {
       onPress: () => navigation.navigate('SettingsScreen')
     })
 
-  if (isMnemonicBackedUp && networkStatus !== 'offline') return null
-
   return (
     <DashboardSecondaryButtonsStyled style={{ height: 15 }}>
       <Buttons>

--- a/apps/mobile-wallet/src/types/settings.ts
+++ b/apps/mobile-wallet/src/types/settings.ts
@@ -10,7 +10,6 @@ export interface GeneralSettings {
   currency: Currency
   analytics: boolean
   analyticsId?: string
-  walletConnect: boolean
   usesBiometrics: boolean
   autoLockSeconds: number
   language?: Language


### PR DESCRIPTION
- Related to #1358
- Implements a polling mechanism to check if the WC sessions get dropped, in which case it shows a message to the user.
- Removes WalletConnect from app settings (what's the point of having it turned off while everyone can access the ecosystem page? On DW we don't allow disabling it)
- Adds "Clear WalletConnect Cache" button in wallet settings (just like the DW)