### PR TITLE
DApp Connect tip

### DIFF
--- a/apps/mobile-wallet/locales/en-US/translation.json
+++ b/apps/mobile-wallet/locales/en-US/translation.json
@@ -481,5 +481,7 @@
   "Connected at {{ datetime }} on {{ network }}": "Connected at {{ datetime }} on {{ network }}",
   "Manage dApp connections": "Manage dApp connections",
   "Preauthorized connections": "Preauthorized connections",
-  "Revoked connection to {{ host }}": "Revoked connection to {{ host }}"
+  "Revoked connection to {{ host }}": "Revoked connection to {{ host }}",
+  "Useful tip": "Useful tip",
+  "connectTipModalMessage": "For a smoother experience when connecting to a dApp, use the <1>Browser/Extension</1> button instead of WalletConnect."
 }

--- a/apps/mobile-wallet/src/features/connectTip/ConnectTipModal.tsx
+++ b/apps/mobile-wallet/src/features/connectTip/ConnectTipModal.tsx
@@ -1,0 +1,35 @@
+import { memo } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+
+import AppText from '~/components/AppText'
+import { ModalScreenTitle, ScreenSection } from '~/components/layout/Screen'
+import BottomModal2 from '~/features/modals/BottomModal2'
+
+const ConnectTipModal = memo(() => {
+  const { t } = useTranslation()
+
+  return (
+    <BottomModal2 notScrollable contentVerticalGap>
+      <ScreenSection>
+        <ModalScreenTitle>{t('Useful tip')} 💡</ModalScreenTitle>
+      </ScreenSection>
+      <ScreenSection>
+        <AppText color="secondary" size={18}>
+          <Trans
+            t={t}
+            i18nKey="connectTipModalMessage"
+            components={{
+              1: <AppText size={18} bold />
+            }}
+          >
+            {
+              'For a smoother experience when connecting to a dApp, use the <1>Browser/Extension</1> button instead of WalletConnect.'
+            }
+          </Trans>
+        </AppText>
+      </ScreenSection>
+    </BottomModal2>
+  )
+})
+
+export default ConnectTipModal

--- a/apps/mobile-wallet/src/features/connectTip/connectTipStorage.ts
+++ b/apps/mobile-wallet/src/features/connectTip/connectTipStorage.ts
@@ -1,0 +1,7 @@
+import { storage } from '~/persistent-storage/storage'
+
+const CONNECT_TIP_SHOWN_ONCE_KEY = 'connectTipShownOnce'
+
+export const isConnectTipShownOnce = () => storage.getBoolean(CONNECT_TIP_SHOWN_ONCE_KEY)
+
+export const setConnectTipShownOnce = () => storage.set(CONNECT_TIP_SHOWN_ONCE_KEY, true)

--- a/apps/mobile-wallet/src/features/ecosystem/dAppMessaging/DappBrowserContext.tsx
+++ b/apps/mobile-wallet/src/features/ecosystem/dAppMessaging/DappBrowserContext.tsx
@@ -12,6 +12,7 @@ import { createContext, ReactNode, RefObject, useCallback, useContext, useEffect
 import WebView from 'react-native-webview'
 
 import { buildDeployContractTransaction } from '~/api/transactions'
+import { isConnectTipShownOnce, setConnectTipShownOnce } from '~/features/connectTip/connectTipStorage'
 import {
   connectionAuthorized,
   hostConnectionRemoved
@@ -62,9 +63,17 @@ export const DappBrowserContextProvider = ({ children, dAppUrl, dAppName }: Dapp
   )
 
   const handleIsDappPreauthorized = useCallback(
-    (data: RequestOptions, messageId: string) =>
-      replyToDapp({ type: 'ALPH_IS_PREAUTHORIZED_RES', data: isConnectionAuthorized(data) }, messageId),
-    [replyToDapp]
+    (data: RequestOptions, messageId: string) => {
+      const isPreauthorized = isConnectionAuthorized(data)
+
+      if (!isPreauthorized && !isConnectTipShownOnce()) {
+        dispatch(openModal({ name: 'ConnectTipModal' }))
+        setConnectTipShownOnce()
+      }
+
+      replyToDapp({ type: 'ALPH_IS_PREAUTHORIZED_RES', data: isPreauthorized }, messageId)
+    },
+    [dispatch, replyToDapp]
   )
 
   const handleRejectDappConnection = useCallback(

--- a/apps/mobile-wallet/src/features/ecosystem/dAppMessaging/injectedJs.ts
+++ b/apps/mobile-wallet/src/features/ecosystem/dAppMessaging/injectedJs.ts
@@ -1,6 +1,20 @@
 import alephiumProvider from '@alephium/wallet-dapp-provider/lib/provider.umd.json'
+import { Platform } from 'react-native'
+
+const windowMessagePolyfill =
+  Platform.OS === 'android'
+    ? `
+if (window.originalPostMessage) return;
+window.originalPostMessage = window.postMessage;
+document.addEventListener('message', function(event) {
+  window.dispatchEvent(new MessageEvent('message', { data: event.data }));
+});
+`
+    : ''
 
 export const INJECTED_JAVASCRIPT = `
+${windowMessagePolyfill}
+
 ${alephiumProvider.code}
 
 window.addEventListener("load", () => {

--- a/apps/mobile-wallet/src/features/ecosystem/dAppMessaging/injectedJs.ts
+++ b/apps/mobile-wallet/src/features/ecosystem/dAppMessaging/injectedJs.ts
@@ -23,21 +23,21 @@ window.addEventListener("load", () => {
   }
 });
 
-window.onerror = function(message, source, lineno, colno, error) {
-  window.ReactNativeWebView.postMessage(JSON.stringify({
-    type: 'CONSOLE_ERROR',
-    data: { message, source, lineno, colno, error: error?.toString() }
-  }));
-  return true;
-};
+// window.onerror = function(message, source, lineno, colno, error) {
+//   window.ReactNativeWebView.postMessage(JSON.stringify({
+//     type: 'CONSOLE_ERROR',
+//     data: { message, source, lineno, colno, error: error?.toString() }
+//   }));
+//   return true;
+// };
 
-window.console.log = function(...args) {
-  window.ReactNativeWebView.postMessage(JSON.stringify({
-    type: 'CONSOLE_LOG',
-    data: args
-  }));
-  return true;
-};
+// window.console.log = function(...args) {
+//   window.ReactNativeWebView.postMessage(JSON.stringify({
+//     type: 'CONSOLE_LOG',
+//     data: args
+//   }));
+//   return true;
+// };
 
 true; // note: this is required, or you'll sometimes get silent failures
 `

--- a/apps/mobile-wallet/src/features/modals/AppModals.tsx
+++ b/apps/mobile-wallet/src/features/modals/AppModals.tsx
@@ -17,6 +17,7 @@ import TokenQuickActionsModal from '~/features/assetsDisplay/tokenDisplay/TokenQ
 import AutoLockOptionsModal from '~/features/auto-lock/AutoLockOptionsModal'
 import BackupReminderModal from '~/features/backup/BackupReminderModal'
 import BuyModal from '~/features/buy/BuyModal'
+import ConnectTipModal from '~/features/connectTip/ConnectTipModal'
 import DAppDetailsModal from '~/features/ecosystem/DAppDetailsModal'
 import DAppQuickActionsModal from '~/features/ecosystem/DAppQuickActionsModal'
 import EditDappUrlModal from '~/features/ecosystem/EditDappUrlModal'
@@ -179,6 +180,8 @@ const Modal = ({ params }: Omit<ModalInstance, 'isClosing' | 'id'>) => {
       return <EditDappUrlModal {...params.props} />
     case 'DataFetchErrorModal':
       return <DataFetchErrorModal {...params.props} />
+    case 'ConnectTipModal':
+      return <ConnectTipModal />
     default:
       return null
   }

--- a/apps/mobile-wallet/src/features/modals/modalTypes.ts
+++ b/apps/mobile-wallet/src/features/modals/modalTypes.ts
@@ -17,6 +17,7 @@ import TokenQuickActionsModal from '~/features/assetsDisplay/tokenDisplay/TokenQ
 import AutoLockOptionsModal from '~/features/auto-lock/AutoLockOptionsModal'
 import BackupReminderModal from '~/features/backup/BackupReminderModal'
 import BuyModal from '~/features/buy/BuyModal'
+import ConnectTipModal from '~/features/connectTip/ConnectTipModal'
 import DAppDetailsModal from '~/features/ecosystem/DAppDetailsModal'
 import DAppQuickActionsModal from '~/features/ecosystem/DAppQuickActionsModal'
 import EditDappUrlModal from '~/features/ecosystem/EditDappUrlModal'
@@ -100,7 +101,8 @@ export const ModalComponents = {
   SignUnsignedTxModal,
   SignMessageTxModal,
   EditDappUrlModal,
-  DataFetchErrorModal
+  DataFetchErrorModal,
+  ConnectTipModal
 }
 
 export type ModalName = keyof typeof ModalComponents


### PR DESCRIPTION
I've added a simple "useful tip" modal that shows only once, the first time the wallet receives the `ALPH_IS_PREAUTHORIZED` message from the dApp and the reply is `false`. It will not appear again.

<img width="350" alt="image" src="https://github.com/user-attachments/assets/8bb511f7-37cc-4205-9cc3-5ab1dc53ad59" />
