### PR TITLE
Fix scan modal opening, dry up useScreenOrModaIsFocused

### DIFF
--- a/apps/mobile-wallet/src/components/animatedBackground/AnimatedBackground.tsx
+++ b/apps/mobile-wallet/src/components/animatedBackground/AnimatedBackground.tsx
@@ -13,7 +13,7 @@ import Animated, {
 } from 'react-native-reanimated'
 import styled, { useTheme } from 'styled-components/native'
 
-import { useAppScreenIsFocused } from '~/utils/navigation'
+import { useScreenOrModaIsFocused } from '~/utils/navigation'
 
 interface AnimatedBackgroundProps {
   offsetTop?: number
@@ -30,7 +30,7 @@ const springConfig = {
 
 const AnimatedBackground = memo(({ offsetTop = 0, shade }: AnimatedBackgroundProps) => {
   const theme = useTheme()
-  const isFocused = useAppScreenIsFocused()
+  const isFocused = useScreenOrModaIsFocused()
   const [containerDimensions, setContainerDimensions] = useState({ width: 0, height: 0 })
   const gyroscope = useAnimatedSensor(SensorType.ROTATION, {
     interval: isFocused ? FPS_60 : 1000000

--- a/apps/mobile-wallet/src/features/qrCodeScan/CameraScanButtonBase.tsx
+++ b/apps/mobile-wallet/src/features/qrCodeScan/CameraScanButtonBase.tsx
@@ -10,7 +10,7 @@ import QRCodeScannerModal from '~/components/QRCodeScannerModal'
 import { useAppDispatch, useAppSelector } from '~/hooks/redux'
 import { cameraToggled } from '~/store/appSlice'
 import { showToast } from '~/utils/layout'
-import { useAppScreenIsFocused } from '~/utils/navigation'
+import { useScreenIsFocused } from '~/utils/navigation'
 
 interface CameraScanButtonBaseProps extends ButtonProps {
   onValidAddressScanned: (addressHash: AddressHash) => void
@@ -28,7 +28,7 @@ const CameraScanButtonBase = ({
   generateInvalidDataText,
   ...props
 }: CameraScanButtonBaseProps) => {
-  const isFocused = useAppScreenIsFocused()
+  const isFocused = useScreenIsFocused()
   const isCameraOpen = useAppSelector((s) => s.app.isCameraOpen)
   const dispatch = useAppDispatch()
   const { t } = useTranslation()

--- a/apps/mobile-wallet/src/utils/navigation.ts
+++ b/apps/mobile-wallet/src/utils/navigation.ts
@@ -1,5 +1,4 @@
-import { createNavigationContainerRef, NavigationProp, useNavigation } from '@react-navigation/native'
-import { useCallback, useSyncExternalStore } from 'react'
+import { createNavigationContainerRef, NavigationProp, useIsFocused } from '@react-navigation/native'
 
 import { selectIsAnyModalOpened } from '~/features/modals/modalSelectors'
 import useIsTopModal from '~/features/modals/useIsTopModal'
@@ -27,25 +26,12 @@ export const resetNavigation = (
   navigation.reset(getInitialNavigationState(initialRouteName))
 }
 
-export const useAppScreenIsFocused = () => {
-  const navigation = useNavigation()
+export const useScreenIsFocused = useIsFocused
+
+export const useScreenOrModaIsFocused = () => {
   const isAnyModalOpened = useAppSelector(selectIsAnyModalOpened)
   const isTopModal = useIsTopModal()
+  const isScreenFocused = useIsFocused()
 
-  const subscribe = useCallback(
-    (callback: () => void) => {
-      const unsubscribeFocus = navigation.addListener('focus', callback)
-      const unsubscribeBlur = navigation.addListener('blur', callback)
-
-      return () => {
-        unsubscribeFocus()
-        unsubscribeBlur()
-      }
-    },
-    [navigation]
-  )
-
-  const screenFocused = !!useSyncExternalStore(subscribe, navigation.isFocused, navigation.isFocused)
-
-  return isTopModal || (!isAnyModalOpened && screenFocused)
+  return isTopModal || (!isAnyModalOpened && isScreenFocused)
 }


### PR DESCRIPTION
The scan modal isn't a "proper" modal (not stored in redux), hence the previous bug.