### PR TITLE
Fix wallet auto-connect in mobile in-app browser

### DIFF
--- a/.changeset/witty-trains-spend.md
+++ b/.changeset/witty-trains-spend.md
@@ -1,0 +1,5 @@
+---
+'@alephium/mobile-wallet': patch
+---
+
+Fix in-app browser auto-connect

--- a/apps/mobile-wallet/src/features/ecosystem/authorizedConnections/authorizedConnectionsUtils.ts
+++ b/apps/mobile-wallet/src/features/ecosystem/authorizedConnections/authorizedConnectionsUtils.ts
@@ -1,5 +1,5 @@
 import { RequestOptions } from '@alephium/wallet-dapp-provider'
-import { groupOfAddress } from '@alephium/web3'
+import { groupOfAddress, isGrouplessAddress } from '@alephium/web3'
 
 import { AuthorizedConnection } from '~/features/ecosystem/authorizedConnections/authorizedConnectionsTypes'
 
@@ -9,6 +9,7 @@ export const matchRequestOptionsToAuthorizedConnection =
     (requestOptions.address === undefined || storedConnection.address === requestOptions.address) &&
     (requestOptions.networkId === undefined || storedConnection.networkName === requestOptions.networkId) &&
     (requestOptions.addressGroup === undefined ||
+      isGrouplessAddress(storedConnection.address) ||
       groupOfAddress(storedConnection.address) === requestOptions.addressGroup)
 
 export const getAuthorizedConnectionId = (connection: AuthorizedConnection) =>

--- a/apps/mobile-wallet/src/features/ecosystem/dAppMessaging/injectedJs.ts
+++ b/apps/mobile-wallet/src/features/ecosystem/dAppMessaging/injectedJs.ts
@@ -17,11 +17,9 @@ ${windowMessagePolyfill}
 
 ${alephiumProvider.code}
 
-window.addEventListener("load", () => {
-  if (typeof AlephiumWalletProvider !== 'undefined') {
-    AlephiumWalletProvider.attach();
-  }
-});
+if (typeof AlephiumWalletProvider !== 'undefined') {
+  AlephiumWalletProvider.attach();
+}
 
 // window.onerror = function(message, source, lineno, colno, error) {
 //   window.ReactNativeWebView.postMessage(JSON.stringify({
@@ -36,7 +34,13 @@ window.addEventListener("load", () => {
 //     type: 'CONSOLE_LOG',
 //     data: args
 //   }));
-//   return true;
+// };
+
+// window.console.error = function(...args) {
+//   window.ReactNativeWebView.postMessage(JSON.stringify({
+//     type: 'CONSOLE_ERROR',
+//     data: args.map(a => a instanceof Error ? a.message : a)
+//   }));
 // };
 
 true; // note: this is required, or you'll sometimes get silent failures

--- a/packages/wallet-dapp-provider/src/alephiumWindowObject.ts
+++ b/packages/wallet-dapp-provider/src/alephiumWindowObject.ts
@@ -78,8 +78,6 @@ export const alephiumWindowObject: AlephiumWindowObject = new (class extends Ale
   unsafeEnable = async (options?: EnableOptions) => this.#unsafeEnable(options)
 
   #unsafeEnable = async (options?: EnableOptions) => {
-    this.#checkTabFocused()
-
     const walletAccountP = Promise.race([
       waitForMessage('ALPH_CONNECT_DAPP_RES', USER_ACTION_TIMEOUT),
       waitForMessage('ALPH_REJECT_PREAUTHORIZATION', USER_ACTION_TIMEOUT).then(() => 'USER_ABORTED' as const)


### PR DESCRIPTION
The in-app browser's auto-connect was broken by 3 issues:

1. The injected provider's `attach()` was deferred to the window load event, which fires after React's `useEffect`. By the time `attach()` ran, the dApp's auto-connect had already failed and given up.
2. Even with the provider available, `document.hasFocus()` returns `false` in React Native WebView during page load, causing `#checkTabFocused()` to throw "Unsolicited request" and abort the connection handshake.
3. Groupless addresses where not taken into consideration

Fix by calling `attach()` immediately after the UMD bundle and removing the `document.hasFocus()` check from `#unsafeEnable`. The check was designed to prevent background browser tabs from initiating connections (extension wallet), but `wallet-dapp-provider` is only used in the mobile in-app browser where the user explicitly opened the dApp.