### PR TITLE
Drop local isAddressValid wrapper, use web3 isValidAddress directly

### DIFF
--- a/.changeset/swift-notes-fold.md
+++ b/.changeset/swift-notes-fold.md
@@ -1,0 +1,6 @@
+---
+'alephium-desktop-wallet': patch
+'@alephium/mobile-wallet': patch
+---
+
+Use isValidAddress from @alephium/web3 directly instead of a local wrapper

--- a/apps/desktop-wallet/src/features/send/sendModal/SendModalAddressesStep.tsx
+++ b/apps/desktop-wallet/src/features/send/sendModal/SendModalAddressesStep.tsx
@@ -1,5 +1,6 @@
 import { selectAddressByHash } from '@alephium/shared/store'
 import { useFetchAddressesHashesWithBalance } from '@alephium/shared-react'
+import { isValidAddress } from '@alephium/web3'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -8,7 +9,7 @@ import AddressInputs from '@/features/send/sendModal/AddressInputs'
 import { TransferAddressesTxModalOnSubmitData, TransferTxModalData } from '@/features/send/sendModal/sendTypes'
 import { useAppSelector } from '@/hooks/redux'
 import { ModalFooterButton, ModalFooterButtons } from '@/modals/CenteredModal'
-import { isAddressValid, requiredErrorMessage } from '@/utils/form-validation'
+import { requiredErrorMessage } from '@/utils/form-validation'
 
 interface SendModalAddressesStepProps {
   data: TransferTxModalData
@@ -36,7 +37,7 @@ const SendModalAddressesStep = ({ data, onSubmit, onCancel }: SendModalAddresses
 
   const handleToAddressChange = useCallback(
     (value: string) => {
-      setToAddress(value, !value ? requiredErrorMessage : isAddressValid(value) ? '' : t('This address is not valid'))
+      setToAddress(value, !value ? requiredErrorMessage : isValidAddress(value) ? '' : t('This address is not valid'))
     },
     [setToAddress, t]
   )

--- a/apps/desktop-wallet/src/modals/ContactFormModal.tsx
+++ b/apps/desktop-wallet/src/modals/ContactFormModal.tsx
@@ -1,6 +1,7 @@
 import { getHumanReadableError } from '@alephium/shared'
 import { contactDeletedFromPersistentStorage, contactStoredInPersistentStorage } from '@alephium/shared/store'
 import { Contact, ContactFormData } from '@alephium/shared/types'
+import { isValidAddress } from '@alephium/web3'
 import { UserMinus } from 'lucide-react'
 import { memo } from 'react'
 import { Controller, useForm } from 'react-hook-form'
@@ -15,12 +16,7 @@ import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import CenteredModal, { ModalFooterButton, ModalFooterButtons } from '@/modals/CenteredModal'
 import { contactDeletionFailed, contactStorageFailed } from '@/storage/addresses/addressesActions'
 import { contactsStorage } from '@/storage/addresses/contactsPersistentStorage'
-import {
-  isAddressValid,
-  isContactAddressValid,
-  isContactNameValid,
-  requiredErrorMessage
-} from '@/utils/form-validation'
+import { isContactAddressValid, isContactNameValid, requiredErrorMessage } from '@/utils/form-validation'
 
 export interface ContactFormModalProps {
   contact?: Contact
@@ -126,7 +122,7 @@ const ContactFormModal = memo(({ id, contact }: ModalBaseProp & ContactFormModal
           rules={{
             required: true,
             validate: {
-              isAddressValid,
+              isAddressValid: (address) => isValidAddress(address) || t('This address is not valid'),
               isContactAddressValid: (address) => isContactAddressValid({ address, id: contact?.id })
             }
           }}

--- a/apps/desktop-wallet/src/utils/form-validation.ts
+++ b/apps/desktop-wallet/src/utils/form-validation.ts
@@ -1,12 +1,10 @@
 import { Contact } from '@alephium/shared/types'
-import { isValidAddress, Optional } from '@alephium/web3'
+import { Optional } from '@alephium/web3'
 
 import i18n from '@/features/localization/i18n'
 import { store } from '@/storage/store'
 
 export const requiredErrorMessage = i18n.t('This field is required')
-
-export const isAddressValid = (value: string) => isValidAddress(value) || i18n.t('This address is not valid')
 
 export const isContactAddressValid = ({ address, id }: Optional<Omit<Contact, 'name'>, 'id'>) => {
   const state = store.getState()

--- a/apps/mobile-wallet/src/features/send/screens/DestinationScreen.tsx
+++ b/apps/mobile-wallet/src/features/send/screens/DestinationScreen.tsx
@@ -23,7 +23,6 @@ import { PossibleNextScreenAfterDestination, SendNavigationParamList } from '~/n
 import { selectAllContacts } from '~/store/addresses/addressesSelectors'
 import { cameraToggled } from '~/store/appSlice'
 import { VERTICAL_GAP } from '~/style/globalStyle'
-import { validateIsAddressValid } from '~/utils/forms'
 import { showToast } from '~/utils/layout'
 
 interface DestinationScreenProps extends StackScreenProps<SendNavigationParamList, 'DestinationScreen'>, ScreenProps {}
@@ -156,7 +155,7 @@ const DestinationScreen = ({ navigation, route: { params }, ...props }: Destinat
           )}
           rules={{
             required: true,
-            validate: validateIsAddressValid
+            validate: (value) => isValidAddress(value) || t('This address is not valid')
           }}
           control={control}
         />

--- a/apps/mobile-wallet/src/screens/Addresses/Contact/ContactFormBaseScreen.tsx
+++ b/apps/mobile-wallet/src/screens/Addresses/Contact/ContactFormBaseScreen.tsx
@@ -1,4 +1,5 @@
 import { AddressHash, ContactFormData } from '@alephium/shared/types'
+import { isValidAddress } from '@alephium/web3'
 import { Controller, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
@@ -9,7 +10,6 @@ import ScrollScreen, { ScrollScreenProps } from '~/components/layout/ScrollScree
 import i18n from '~/features/localization/i18n'
 import NewContactCameraScanButton from '~/features/qrCodeScan/NewContactCameraScanButton'
 import { isContactAddressValid, isContactNameValid } from '~/utils/form-validation'
-import { validateIsAddressValid } from '~/utils/forms'
 
 interface ContactFormBaseScreenProps extends ScrollScreenProps {
   initialValues: ContactFormData
@@ -83,7 +83,7 @@ const ContactFormBaseScreen = ({
           rules={{
             required: true,
             validate: {
-              isAddressValid: validateIsAddressValid,
+              isAddressValid: (address) => isValidAddress(address) || t('This address is not valid'),
               isContactAddressValid: (address) => isContactAddressValid({ address, id: initialValues?.id })
             }
           }}

--- a/apps/mobile-wallet/src/utils/forms.ts
+++ b/apps/mobile-wallet/src/utils/forms.ts
@@ -1,5 +1,0 @@
-import { isValidAddress } from '@alephium/web3'
-
-import i18n from '~/features/localization/i18n'
-
-export const validateIsAddressValid = (value: string) => isValidAddress(value) || i18n.t('This address is not valid')


### PR DESCRIPTION
Hi alephium team, i worked on this issue. Closes #720.

Removes the isAddressValid wrapper that was duplicated across apps/desktop-wallet and apps/mobile-wallet, and swaps the call sites to isValidAddress from @alephium/web3 directly. Also deletes apps/mobile-wallet/src/utils/forms.ts, which only held a duplicate validateIsAddressValid.

Two side effects worth flagging. First, SendModalAddressesStep was silently swallowing the invalid-address error message. The wrapper returned either true or the error string, both truthy, so the ternary feeding the error slot always picked the empty string. Now that the call site uses isValidAddress (a plain boolean), the error text actually shows. Second, the error message re-translates on language change now. The wrappers called i18n.t at module load time, so the string was frozen on whichever language was active at startup. The inline validators use t from useTranslation and re-evaluate each render.

Ran pnpm run lint and pnpm run typecheck at the workspace root, both green. No tests reference isAddressValid or validateIsAddressValid. Changeset included, patch bump on alephium-desktop-wallet and @alephium/mobile-wallet.