### PR TITLE
Fix stale Jest references in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,12 +48,14 @@ pnpm --filter @alephium/mobile-wallet start
 ### Running a single test file
 
 ```bash
-# Vitest-based packages (explorer, desktop-wallet, shared, shared-react, keyring)
+# Every package uses Vitest
 pnpm --filter @alephium/shared exec vitest run path/to/file.test.ts
-
-# Jest-based packages (mobile-wallet, encryptor)
-pnpm --filter @alephium/mobile-wallet exec jest path/to/file.test.ts
+pnpm --filter @alephium/mobile-wallet exec vitest run path/to/file.test.ts
 ```
+
+Note that the mobile wallet only collects tests matching `__tests__/**/*.{test,spec}.{js,ts}`
+(see `apps/mobile-wallet/vitest.config.ts`), whereas the other packages colocate their test
+files next to the source.
 
 ## Architecture
 
@@ -61,7 +63,7 @@ pnpm --filter @alephium/mobile-wallet exec jest path/to/file.test.ts
 
 - **`apps/explorer`** — Blockchain explorer web app (Vite + React + React Router)
 - **`apps/desktop-wallet`** — Desktop wallet (Electron + Vite + React). Electron main process in `electron/main.ts`, preload in `electron/preload.ts`
-- **`apps/mobile-wallet`** — Mobile wallet (React Native + Expo 54). Uses Jest (not Vitest) for tests
+- **`apps/mobile-wallet`** — Mobile wallet (React Native + Expo 54)
 
 ### Shared Packages
 


### PR DESCRIPTION
Every package in the monorepo runs Vitest, but `AGENTS.md` (which `CLAUDE.md` symlinks to) still told contributors and agents to run `jest` for the mobile wallet and encryptor. That command fails outright - Jest is not even a dependency anymore.

Found while working on #1655: the instructions sent me looking for a Jest setup that does not exist.

Also documents the one real difference that remains between packages: the mobile wallet only collects tests matching `__tests__/**/*.{test,spec}.{js,ts}` (per `apps/mobile-wallet/vitest.config.ts`), while every other package colocates test files next to the source. Worth writing down, because a colocated test in the mobile wallet is silently never run - it does not fail, it just does not exist as far as the runner is concerned.

Verified: every package's `test` script is `vitest run` (`apps/*`, `packages/encryptor`, `packages/keyring`, `packages/shared`, `packages/shared-react`).