### PR TITLE
Keep explorer confirmations counter live

### DIFF
--- a/.changeset/brave-moons-count.md
+++ b/.changeset/brave-moons-count.md
@@ -1,0 +1,5 @@
+---
+'@alephium/explorer': patch
+---
+
+Fix transaction confirmations showing 0 and never increasing

--- a/apps/explorer/src/api/infos/infosApi.test.ts
+++ b/apps/explorer/src/api/infos/infosApi.test.ts
@@ -1,0 +1,93 @@
+import { explorer } from '@alephium/web3'
+import { QueryClient, QueryObserver } from '@tanstack/react-query'
+
+import { infosQueries } from '@/api/infos/infosApi'
+import { computeConfirmations } from '@/utils/confirmations'
+
+const { getInfosHeights } = vi.hoisted(() => ({ getInfosHeights: vi.fn() }))
+
+vi.mock('@/api/client', () => ({
+  default: { explorer: { infos: { getInfosHeights } } }
+}))
+
+const txBlock: explorer.BlockEntryLite = {
+  hash: '0000000000000000000000000000000000000000000000000000000000000001',
+  timestamp: 1784035982281,
+  chainFrom: 0,
+  chainTo: 1,
+  height: 100,
+  txNumber: 1,
+  mainChain: true,
+  hashRate: '5175173459918688'
+}
+
+const mockAdvancingChainTip = (startingHeight: number) => {
+  let height = startingHeight - 1
+
+  getInfosHeights.mockImplementation(() => {
+    height += 1
+    return Promise.resolve([{ chainFrom: 0, chainTo: 1, height, value: height }])
+  })
+}
+
+const observeHeights = (isAppVisible: boolean) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  const observer = new QueryObserver(queryClient, infosQueries.all.heights(isAppVisible))
+  const unsubscribe = observer.subscribe(() => undefined)
+
+  return {
+    getChainHeights: () => observer.getCurrentResult().data as explorer.PerChainHeight[] | undefined,
+    stop: () => {
+      unsubscribe()
+      queryClient.clear()
+    }
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  getInfosHeights.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+it('keeps refetching the chain heights while the page is visible', async () => {
+  mockAdvancingChainTip(100)
+
+  const { stop } = observeHeights(true)
+
+  await vi.advanceTimersByTimeAsync(60000)
+  stop()
+
+  expect(getInfosHeights.mock.calls.length).toBeGreaterThan(1)
+})
+
+it('stops refetching the chain heights while the page is hidden', async () => {
+  mockAdvancingChainTip(100)
+
+  const { stop } = observeHeights(false)
+
+  await vi.advanceTimersByTimeAsync(60000)
+  stop()
+
+  expect(getInfosHeights).toHaveBeenCalledTimes(1)
+})
+
+it('makes the confirmations of a confirmed tx tick up without a page reload', async () => {
+  mockAdvancingChainTip(txBlock.height)
+
+  const { getChainHeights, stop } = observeHeights(true)
+
+  await vi.advanceTimersByTimeAsync(0)
+  const confirmationsOnLoad = computeConfirmations(txBlock, getChainHeights()?.[0])
+
+  await vi.advanceTimersByTimeAsync(30000)
+  const confirmationsLater = computeConfirmations(txBlock, getChainHeights()?.[0])
+
+  stop()
+
+  expect(confirmationsOnLoad).toEqual(1)
+  expect(confirmationsLater).toBeGreaterThan(confirmationsOnLoad)
+})

--- a/apps/explorer/src/api/infos/infosApi.ts
+++ b/apps/explorer/src/api/infos/infosApi.ts
@@ -2,12 +2,16 @@ import { queryOptions } from '@tanstack/react-query'
 
 import client from '@/api/client'
 
+const CHAIN_HEIGHTS_REFETCH_INTERVAL = 10000
+
 export const infosQueries = {
   all: {
-    heights: () =>
+    // Keep polling while the page is open, including after the tx confirms, so the confirmation count keeps advancing.
+    heights: (isAppVisible = true) =>
       queryOptions({
         queryKey: ['heights'],
-        queryFn: client.explorer.infos.getInfosHeights
+        queryFn: client.explorer.infos.getInfosHeights,
+        refetchInterval: isAppVisible ? CHAIN_HEIGHTS_REFETCH_INTERVAL : undefined
       })
   }
 }

--- a/apps/explorer/src/pages/TransactionInfoPage.tsx
+++ b/apps/explorer/src/pages/TransactionInfoPage.tsx
@@ -1,7 +1,6 @@
 import { MAX_API_RETRIES } from '@alephium/shared/api'
 import { isConfirmedTx } from '@alephium/shared/transactions'
 import { ALPH } from '@alephium/token-list'
-import { explorer } from '@alephium/web3'
 import { PerChainHeight } from '@alephium/web3/api/explorer'
 import { useQuery } from '@tanstack/react-query'
 import { useCallback, useEffect, useState } from 'react'
@@ -29,6 +28,7 @@ import Timestamp from '@/components/Timestamp'
 import TransactionIOList from '@/components/TransactionIOList'
 import { useSnackbar } from '@/hooks/useSnackbar'
 import { AssetType } from '@/types/assets'
+import { computeConfirmations } from '@/utils/confirmations'
 import { calculateIoAmountsDelta } from '@/utils/transactions'
 
 type ParamTypes = {
@@ -84,7 +84,7 @@ const TransactionInfoPage = () => {
     enabled: !!confirmedTxInfo
   })
 
-  const { data: chainHeights } = useQuery(queries.infos.all.heights())
+  const { data: chainHeights } = useQuery(queries.infos.all.heights(isAppVisible))
 
   const assetIds = [...new Set(confirmedTxInfo?.inputs?.flatMap((i) => i.tokens?.map((t) => t.id)))].filter(
     (id): id is string => !!id
@@ -347,17 +347,6 @@ const TransactionInfoPage = () => {
       )}
     </Section>
   )
-}
-
-const computeConfirmations = (txBlock?: explorer.BlockEntryLite, txChain?: explorer.PerChainHeight): number => {
-  let confirmations = 0
-
-  if (txBlock && txChain) {
-    const chainHeight = txChain.value
-    confirmations = chainHeight - txBlock.height + 1
-  }
-
-  return confirmations
 }
 
 const IOItemContainer = styled.div`

--- a/apps/explorer/src/utils/confirmations.test.ts
+++ b/apps/explorer/src/utils/confirmations.test.ts
@@ -1,0 +1,52 @@
+import { explorer } from '@alephium/web3'
+
+import { computeConfirmations } from './confirmations'
+
+const blockAtHeight = (height: number): explorer.BlockEntryLite => ({
+  hash: '0000000000000000000000000000000000000000000000000000000000000001',
+  timestamp: 1784035982281,
+  chainFrom: 0,
+  chainTo: 1,
+  height,
+  txNumber: 1,
+  mainChain: true,
+  hashRate: '5175173459918688'
+})
+
+const chainAtHeight = (height: number): explorer.PerChainHeight => ({
+  chainFrom: 0,
+  chainTo: 1,
+  height,
+  value: height
+})
+
+it('counts a tx in the tip block as 1 confirmation, not 0', () => {
+  expect(computeConfirmations(blockAtHeight(7140547), chainAtHeight(7140547))).toEqual(1)
+})
+
+it('counts a tx N blocks below the tip as N + 1 confirmations', () => {
+  expect(computeConfirmations(blockAtHeight(7140547), chainAtHeight(7140548))).toEqual(2)
+  expect(computeConfirmations(blockAtHeight(7140547), chainAtHeight(7140557))).toEqual(11)
+})
+
+it('never reports fewer than 1 confirmation for a tx that is already in a block', () => {
+  // A stale chain height can lag behind the block the tx was just mined into. The tx is in a
+  // block, so it has at least 1 confirmation: reporting 0 or a negative count is never truthful.
+  expect(computeConfirmations(blockAtHeight(7140547), chainAtHeight(7140546))).toEqual(1)
+  expect(computeConfirmations(blockAtHeight(7140547), chainAtHeight(7140540))).toEqual(1)
+})
+
+it('falls back to 1 confirmation when the chain height is unknown', () => {
+  expect(computeConfirmations(blockAtHeight(7140547), undefined)).toEqual(1)
+})
+
+it('reports 0 confirmations when the block is unknown', () => {
+  expect(computeConfirmations(undefined, chainAtHeight(7140547))).toEqual(0)
+  expect(computeConfirmations(undefined, undefined)).toEqual(0)
+})
+
+it('reports 0 confirmations when the block height is missing', () => {
+  const blockWithoutHeight = { ...blockAtHeight(7140547), height: undefined as unknown as number }
+
+  expect(computeConfirmations(blockWithoutHeight, chainAtHeight(7140547))).toEqual(0)
+})

--- a/apps/explorer/src/utils/confirmations.ts
+++ b/apps/explorer/src/utils/confirmations.ts
@@ -1,0 +1,10 @@
+import { explorer } from '@alephium/web3'
+
+export const computeConfirmations = (txBlock?: explorer.BlockEntryLite, txChain?: explorer.PerChainHeight): number => {
+  if (!txBlock || !Number.isFinite(txBlock.height)) return 0
+
+  const chainHeight = txChain && Number.isFinite(txChain.value) ? txChain.value : txBlock.height
+
+  // A tx in a block has >= 1 confirmation by definition; a lower chain height only means our data is lagging.
+  return Math.max(chainHeight - txBlock.height + 1, 1)
+}


### PR DESCRIPTION
- Fixes #1330

The chain-heights query had no `refetchInterval`, so it was fetched once at page load and never again. The confirmations badge stayed frozen, and showed **0** (or negative) when the page was opened on a still-pending tx: the heights were cached before the tx was mined, so `chainHeight - txBlock.height + 1` collapsed to zero.

Fix: poll heights every 10s while the page is visible (crucially, it keeps polling after the tx confirms), clamp the count at >= 1 for a known block, and stop a `NaN` rendering when the block height is missing.