### PR TITLE
Refresh explorer address header when new txs land

### DIFF
--- a/.changeset/shaggy-pugs-refresh.md
+++ b/.changeset/shaggy-pugs-refresh.md
@@ -1,0 +1,5 @@
+---
+'@alephium/explorer': patch
+---
+
+Update the address page balance, worth and transaction count when new transactions arrive

--- a/apps/explorer/src/App.tsx
+++ b/apps/explorer/src/App.tsx
@@ -1,15 +1,13 @@
-import { ONE_DAY_MS } from '@alephium/shared'
-import { MAX_API_RETRIES } from '@alephium/shared/api'
 import { networkPresetSwitched } from '@alephium/shared/store'
 import { useInitializeThrottledClient } from '@alephium/shared-react'
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister'
-import { QueryClient } from '@tanstack/react-query'
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
 import { useEffect } from 'react'
 import { Route, Routes, useLocation, useNavigate } from 'react-router-dom'
 import styled, { ThemeProvider } from 'styled-components'
 
 import { getNetworkSettings } from '@/api/getNetworkSettings'
+import { queryClient } from '@/api/queryClient'
 import AppFooter from '@/components/AppFooter'
 import AppHeader from '@/components/AppHeader'
 import { SnackbarProvider } from '@/components/Snackbar/SnackbarProvider'
@@ -26,6 +24,10 @@ import TransactionInfoSection from '@/pages/TransactionInfoPage'
 import GlobalStyle, { deviceBreakPoints } from '@/styles/globalStyles'
 import { darkTheme, lightTheme } from '@/styles/themes'
 
+const persister = createSyncStoragePersister({
+  storage: window.localStorage
+})
+
 const App = () => {
   const { theme } = useSettings()
   const navigate = useNavigate()
@@ -38,32 +40,6 @@ const App = () => {
   }, [dispatch])
 
   useInitializeThrottledClient()
-
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        refetchOnWindowFocus: false,
-        retryDelay: (attemptIndex) => Math.pow(2, attemptIndex) * 1000,
-        retry: (failureCount, error) => {
-          // TODO: We should account for 429 errors from other libraries other than web3
-          if (!error.message.includes('Status code: 429')) {
-            return false
-          } else if (failureCount > MAX_API_RETRIES) {
-            console.error(`API failed after ${MAX_API_RETRIES} retries, won't retry anymore`, error)
-            return false
-          }
-
-          return true
-        },
-        staleTime: 10000, // default ms before cache data is considered stale
-        gcTime: ONE_DAY_MS
-      }
-    }
-  })
-
-  const persister = createSyncStoragePersister({
-    storage: window.localStorage
-  })
 
   // Ensure that old HashRouter URLs get converted to BrowserRouter URLs
   useEffect(() => {

--- a/apps/explorer/src/api/queryClient.ts
+++ b/apps/explorer/src/api/queryClient.ts
@@ -1,0 +1,18 @@
+import { ONE_DAY_MS, ONE_SECOND_MS } from '@alephium/shared'
+import { queryClient, queryClientConfig } from '@alephium/shared-react'
+
+// shared-react's address queries are refreshed by invalidating this exact client, so the app must use it rather than
+// build its own, otherwise those invalidations land on a cache nothing here observes.
+queryClient.setDefaultOptions({
+  ...queryClientConfig.defaultOptions,
+  queries: {
+    ...queryClientConfig.defaultOptions?.queries,
+    staleTime: 10 * ONE_SECOND_MS,
+    // gcTime must outlive the localStorage persister's maxAge (24h) or restored queries get evicted too early
+    gcTime: ONE_DAY_MS,
+    // Off so the header refreshes on the same tick as the tx list; focus-refetch would heal them out of step
+    refetchOnWindowFocus: false
+  }
+})
+
+export { queryClient }

--- a/apps/explorer/src/pages/AddressPage/AddressPage.tsx
+++ b/apps/explorer/src/pages/AddressPage/AddressPage.tsx
@@ -18,6 +18,7 @@ import AddressTransactions from '@/pages/AddressPage/AddressTransactions'
 import AddressTransactionsCount from '@/pages/AddressPage/AddressTransactionsCount'
 import AddressTransactionsExportButton from '@/pages/AddressPage/AddressTransactionsExportButton'
 import AddressWorth from '@/pages/AddressPage/AddressWorth'
+import { useAddressDataPolling } from '@/pages/AddressPage/useAddressDataPolling'
 import { deviceBreakPoints } from '@/styles/globalStyles'
 
 interface AddressPageProps {
@@ -28,6 +29,8 @@ const AddressPage = ({ addressStr }: AddressPageProps) => {
   const { t } = useTranslation()
   const theme = useTheme()
   const dispatch = useAppDispatch()
+
+  useAddressDataPolling(addressStr)
 
   useEffect(() => {
     dispatch(initializeViewOnlyAddress(addressStr))

--- a/apps/explorer/src/pages/AddressPage/AddressTransactions.tsx
+++ b/apps/explorer/src/pages/AddressPage/AddressTransactions.tsx
@@ -12,6 +12,7 @@ import TableBody from '@/components/Table/TableBody'
 import TableHeader from '@/components/Table/TableHeader'
 import usePageNumber from '@/hooks/usePageNumber'
 import AddressTransactionRow from '@/pages/AddressInfoPage/AddressTransactionRow'
+import { ADDRESS_DATA_POLLING_INTERVAL } from '@/pages/AddressPage/useAddressDataPolling'
 import useIsContract from '@/pages/AddressPage/useIsContract'
 
 const numberOfTxsPerPage = 10
@@ -28,7 +29,7 @@ const AddressTransactions = ({ addressStr }: AddressTransactionsProps) => {
 
   const { data: txNumber } = useFetchAddressTransactionsCount(addressStr)
 
-  const refetchInterval = isAppVisible && pageNumber === 1 ? 10000 : undefined
+  const refetchInterval = isAppVisible && pageNumber === 1 ? ADDRESS_DATA_POLLING_INTERVAL : undefined
 
   const { data: txList, isLoading: txListLoading } = useQuery({
     ...queries.address.transactions.confirmed(addressStr, pageNumber, numberOfTxsPerPage),

--- a/apps/explorer/src/pages/AddressPage/useAddressDataPolling.test.ts
+++ b/apps/explorer/src/pages/AddressPage/useAddressDataPolling.test.ts
@@ -1,0 +1,115 @@
+import { throttledClient } from '@alephium/shared/api'
+import { addressAlphBalancesQuery, addressTransactionsCountQuery } from '@alephium/shared-react'
+import { explorer as e } from '@alephium/web3'
+import { QueryObserver, QueryObserverOptions } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { queryClient } from '@/api/queryClient'
+import { ADDRESS_DATA_POLLING_INTERVAL, addressDataPollingQuery } from '@/pages/AddressPage/useAddressDataPolling'
+
+const addressHash = '1DrDyTr9RpRsQnDnXo2YRiPzPW4ooHX5LLoqXrqfMrpQH'
+const networkId = 0
+
+const balanceQuery = () => addressAlphBalancesQuery({ addressHash, networkId, isNodeOnline: true })
+const txCountQuery = () => addressTransactionsCountQuery({ addressHash, networkId, isExplorerOnline: true })
+const pollingQuery = (isAppVisible = true) =>
+  addressDataPollingQuery({ addressHash, networkId, isExplorerOnline: true, isAppVisible })
+
+interface ChainState {
+  latestTxHash: string
+  balance: string
+  txCount: number
+}
+
+const setChainState = ({ latestTxHash, balance, txCount }: ChainState) => {
+  vi.spyOn(throttledClient.explorer.addresses, 'getAddressesAddressLatestTransaction').mockResolvedValue({
+    hash: latestTxHash,
+    blockHash: 'block-hash',
+    timestamp: 1,
+    coinbase: false
+  } satisfies e.TransactionInfo)
+  vi.spyOn(throttledClient.explorer.addresses, 'getAddressesAddressBalance').mockResolvedValue({
+    balance,
+    lockedBalance: '0'
+  } satisfies e.AddressBalance)
+  vi.spyOn(throttledClient.explorer.addresses, 'getAddressesAddressTotalTransactions').mockResolvedValue(txCount)
+}
+
+const unsubscribeFns: Array<() => void> = []
+
+// Simulates a mounted component observing a query, without rendering anything
+const mountQuery = <TQueryFnData, TError, TData>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options: QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, any>
+) => {
+  const observer = new QueryObserver(queryClient, options)
+
+  unsubscribeFns.push(observer.subscribe(() => null))
+
+  return observer
+}
+
+const runPendingWork = async () => {
+  for (let i = 0; i < 20; i++) await vi.advanceTimersByTimeAsync(1)
+}
+
+describe('address page data polling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    queryClient.clear()
+  })
+
+  afterEach(() => {
+    unsubscribeFns.forEach((unsubscribe) => unsubscribe())
+    unsubscribeFns.length = 0
+    queryClient.clear()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('polls the latest transaction of the address only while the page is visible', () => {
+    expect(pollingQuery(true).refetchInterval).toBe(ADDRESS_DATA_POLLING_INTERVAL)
+    expect(pollingQuery(false).refetchInterval).toBeUndefined()
+  })
+
+  it('refreshes the address header when a new transaction lands', async () => {
+    setChainState({ latestTxHash: 'tx-1', balance: '1000', txCount: 1 })
+
+    const balanceObserver = mountQuery(balanceQuery())
+    const txCountObserver = mountQuery(txCountQuery())
+    mountQuery(pollingQuery())
+
+    await runPendingWork()
+
+    expect(balanceObserver.getCurrentResult().data?.balances.totalBalance).toBe('1000')
+    expect(txCountObserver.getCurrentResult().data).toBe(1)
+
+    setChainState({ latestTxHash: 'tx-2', balance: '2000', txCount: 2 })
+
+    await vi.advanceTimersByTimeAsync(ADDRESS_DATA_POLLING_INTERVAL)
+    await runPendingWork()
+
+    expect(balanceObserver.getCurrentResult().data?.balances.totalBalance).toBe('2000')
+    expect(txCountObserver.getCurrentResult().data).toBe(2)
+  })
+
+  it('does not refetch the address header when no new transaction lands', async () => {
+    setChainState({ latestTxHash: 'tx-1', balance: '1000', txCount: 1 })
+
+    mountQuery(balanceQuery())
+    mountQuery(txCountQuery())
+    mountQuery(pollingQuery())
+
+    await runPendingWork()
+    vi.clearAllMocks()
+
+    for (let i = 0; i < 3; i++) {
+      await vi.advanceTimersByTimeAsync(ADDRESS_DATA_POLLING_INTERVAL)
+      await runPendingWork()
+    }
+
+    expect(throttledClient.explorer.addresses.getAddressesAddressLatestTransaction).toHaveBeenCalledTimes(3)
+    expect(throttledClient.explorer.addresses.getAddressesAddressBalance).not.toHaveBeenCalled()
+    expect(throttledClient.explorer.addresses.getAddressesAddressTotalTransactions).not.toHaveBeenCalled()
+  })
+})

--- a/apps/explorer/src/pages/AddressPage/useAddressDataPolling.ts
+++ b/apps/explorer/src/pages/AddressPage/useAddressDataPolling.ts
@@ -1,0 +1,33 @@
+import { AddressHash } from '@alephium/shared/types'
+import { addressLatestTransactionQuery, useIsExplorerOnline, useNetworkId } from '@alephium/shared-react'
+import { useQuery } from '@tanstack/react-query'
+import { usePageVisibility } from 'react-page-visibility'
+
+export const ADDRESS_DATA_POLLING_INTERVAL = 10000
+
+interface AddressDataPollingQueryProps {
+  addressHash: AddressHash
+  networkId: number
+  isExplorerOnline: boolean
+  isAppVisible: boolean
+}
+
+// Polling this one query drives the invalidation that refreshes the whole address page.
+export const addressDataPollingQuery = ({
+  addressHash,
+  networkId,
+  isExplorerOnline,
+  isAppVisible
+}: AddressDataPollingQueryProps) => ({
+  ...addressLatestTransactionQuery({ addressHash, networkId, isExplorerOnline }),
+  refetchInterval: isAppVisible ? ADDRESS_DATA_POLLING_INTERVAL : undefined,
+  notifyOnChangeProps: []
+})
+
+export const useAddressDataPolling = (addressHash: AddressHash) => {
+  const networkId = useNetworkId()
+  const isExplorerOnline = useIsExplorerOnline()
+  const isAppVisible = usePageVisibility()
+
+  useQuery(addressDataPollingQuery({ addressHash, networkId, isExplorerOnline, isAppVisible }))
+}

--- a/packages/shared-react/src/api/queries/transactionQueries.ts
+++ b/packages/shared-react/src/api/queries/transactionQueries.ts
@@ -240,7 +240,8 @@ export const addressTransactionsCountQuery = ({
   skip
 }: AddressLatestTransactionQueryProps) =>
   queryOptions({
-    queryKey: ['address', addressHash, 'transactions', 'count', { networkId }],
+    // The level: segment is what invalidateAddressQueries matches on to refresh this query.
+    queryKey: ['address', addressHash, 'level:0', 'transactions', 'count', { networkId }],
     ...getQueryConfig({ staleTime: Infinity, gcTime: Infinity, networkId }),
     queryFn: shouldSkip(isExplorerOnline, skip)
       ? skipToken

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -19,7 +19,9 @@ export enum WALLETCONNECT_ERRORS {
   TRANSACTION_DECODE_FAILED = -38000
 }
 
-export const ONE_MINUTE_MS = 1000 * 60
+export const ONE_SECOND_MS = 1000
+
+export const ONE_MINUTE_MS = 60 * ONE_SECOND_MS
 
 export const FIVE_MINUTES_MS = 5 * ONE_MINUTE_MS
 


### PR DESCRIPTION
- Fixes #350
- Fixes #351

The address page's transaction list refreshed every 10s but the header above it (balance, worth, tx count) never did, so the page contradicted itself until a reload. Three causes:

1. Nothing drove the invalidation cascade: the explorer never polled the latest-tx sentinel the wallets use.
2. The explorer built its own `QueryClient`, but the cascade invalidates shared-react's singleton - two separate caches, so invalidations landed on a cache the explorer never observed.
3. The tx-count query key lacked the `level:` segment the cascade matches on.

Fix: poll the address's sentinel while the page is visible, use the shared `QueryClient`, and add the `level:` segment. The one-line shared-react change was verified safe for both wallets.