### PR TITLE
Make explorer homepage chart requests cacheable

### DIFF
--- a/.changeset/lucky-bats-cache.md
+++ b/.changeset/lucky-bats-cache.md
@@ -1,0 +1,5 @@
+---
+'@alephium/explorer': patch
+---
+
+Reduce the number of requests the homepage makes and let its chart data be cached

--- a/.changeset/warm-lions-blink.md
+++ b/.changeset/warm-lions-blink.md
@@ -1,0 +1,5 @@
+---
+'@alephium/explorer': patch
+---
+
+Refresh the homepage's latest blocks every 5s and briefly highlight newly-arrived ones

--- a/apps/explorer/src/components/Table/TableRow.tsx
+++ b/apps/explorer/src/components/Table/TableRow.tsx
@@ -1,17 +1,27 @@
 import { motion } from 'framer-motion'
 import { Children } from 'react'
 import { Link } from 'react-router-dom'
-import styled from 'styled-components'
+import styled, { css, keyframes } from 'styled-components'
 
 import { deviceBreakPoints } from '@/styles/globalStyles'
 
 interface RowProps {
   isActive?: boolean
   highlight?: boolean
+  isNew?: boolean
   onClick?: React.MouseEventHandler<HTMLTableRowElement>
   linkTo?: string
   className?: string
 }
+
+const newRowFlash = keyframes`
+  from {
+    background-color: var(--new-row-flash-color);
+  }
+  to {
+    background-color: transparent;
+  }
+`
 
 const rowVariants = {
   hidden: { opacity: 0 },
@@ -36,9 +46,18 @@ const TableRow: FC<RowProps> = ({ children, onClick, linkTo, className }) => (
 )
 
 export default styled(TableRow)`
+  --new-row-flash-color: ${({ theme }) => theme.bg.accent};
   background-color: ${({ theme, isActive }) => (isActive ? theme.bg.primary : '')};
   border: none;
   cursor: ${({ onClick }) => (onClick ? 'pointer' : 'auto')};
+
+  ${({ isNew }) =>
+    isNew &&
+    css`
+      @media (prefers-reduced-motion: no-preference) {
+        animation: ${newRowFlash} 1.6s ease-out;
+      }
+    `}
 
   td:first-child {
     display: flex;

--- a/apps/explorer/src/pages/HomePage/HomePage.tsx
+++ b/apps/explorer/src/pages/HomePage/HomePage.tsx
@@ -28,7 +28,7 @@ import { useWindowSize } from '@/hooks/useWindowSize'
 import { deviceBreakPoints, deviceSizes } from '@/styles/globalStyles'
 import { formatNumberForDisplay } from '@/utils/strings'
 
-import useBlockListData, { BLOCKS_PER_PAGE } from './useBlockListData'
+import useBlockListData, { BLOCKS_PER_PAGE, BLOCKS_REFRESH_INTERVAL } from './useBlockListData'
 import useStatisticsData from './useStatisticsData'
 
 type VectorStatisticsKey = keyof ReturnType<typeof useStatisticsData>['data']['vector']
@@ -46,7 +46,7 @@ const HomePage = () => {
   const {
     getBlocks,
     blockPageLoading,
-    data: { blockList }
+    data: { blockList, newBlockHashes }
   } = useBlockListData(currentPageNumber)
 
   const {
@@ -59,18 +59,10 @@ const HomePage = () => {
 
   const vectorData = vector
 
-  // Polling
-  useInterval(
-    () => {
-      refreshStatistics()
+  useInterval(refreshStatistics, 10 * 1000, !isAppVisible)
 
-      if (currentPageNumber === 1) {
-        getBlocks(currentPageNumber, false)
-      }
-    },
-    10 * 1000,
-    !isAppVisible
-  )
+  // Poll the latest blocks on their own faster cadence so the list keeps up with the chain's block rate.
+  useInterval(() => getBlocks(1, false), BLOCKS_REFRESH_INTERVAL, !isAppVisible || currentPageNumber !== 1)
 
   const [hashrateInteger, hashrateDecimal, hashrateSuffix] = formatNumberForDisplay(hashrate.value, '', 'hash')
 
@@ -179,7 +171,7 @@ const HomePage = () => {
               <TableBody tdStyles={TableBodyCustomStyles}>
                 {blockList &&
                   blockList.blocks?.map((b) => (
-                    <TableRow key={b.hash} linkTo={`blocks/${b.hash}`}>
+                    <TableRow key={b.hash} linkTo={`blocks/${b.hash}`} isNew={newBlockHashes.has(b.hash)}>
                       <BlockHeight>{b.height.toString()}</BlockHeight>
                       <Timestamp
                         timeInMs={b.timestamp}

--- a/apps/explorer/src/pages/HomePage/HomePage.tsx
+++ b/apps/explorer/src/pages/HomePage/HomePage.tsx
@@ -28,7 +28,7 @@ import { useWindowSize } from '@/hooks/useWindowSize'
 import { deviceBreakPoints, deviceSizes } from '@/styles/globalStyles'
 import { formatNumberForDisplay } from '@/utils/strings'
 
-import useBlockListData from './useBlockListData'
+import useBlockListData, { BLOCKS_PER_PAGE } from './useBlockListData'
 import useStatisticsData from './useStatisticsData'
 
 type VectorStatisticsKey = keyof ReturnType<typeof useStatisticsData>['data']['vector']
@@ -50,7 +50,7 @@ const HomePage = () => {
   } = useBlockListData(currentPageNumber)
 
   const {
-    fetchStatistics,
+    refreshStatistics,
     data: {
       scalar: { hashrate, totalSupply, circulatingSupply, totalTransactions, totalBlocks, avgBlockTime },
       vector
@@ -62,7 +62,7 @@ const HomePage = () => {
   // Polling
   useInterval(
     () => {
-      fetchStatistics()
+      refreshStatistics()
 
       if (currentPageNumber === 1) {
         getBlocks(currentPageNumber, false)
@@ -198,7 +198,7 @@ const HomePage = () => {
               </TableBody>
             </BlockListTable>
           </Content>
-          {blockList?.total && <PageSwitch totalNumberOfElements={blockList.total} elementsPerPage={8} />}
+          {blockList?.total && <PageSwitch totalNumberOfElements={blockList.total} elementsPerPage={BLOCKS_PER_PAGE} />}
         </LatestsBlocks>
       </MainContent>
       <Waves />

--- a/apps/explorer/src/pages/HomePage/timeIntervals.test.ts
+++ b/apps/explorer/src/pages/HomePage/timeIntervals.test.ts
@@ -1,0 +1,73 @@
+import { ONE_DAY_MS, ONE_MINUTE_MS } from '@alephium/shared'
+import { explorer } from '@alephium/web3'
+
+import { getHashrateTimeInterval, getTimeIntervals } from './timeIntervals'
+
+const { Daily, Hourly } = explorer.IntervalType
+
+const now = Date.UTC(2024, 4, 15, 8, 12, 3, 456)
+const oneSecondLater = now + 1000
+const endOfSameMinute = Date.UTC(2024, 4, 15, 8, 12, 59, 999)
+const oneMinuteLater = now + ONE_MINUTE_MS
+const laterInTheSameHour = Date.UTC(2024, 4, 15, 8, 47, 0, 0)
+const laterInTheSameDay = Date.UTC(2024, 4, 15, 21, 47, 0, 0)
+
+const allIntervalsAt = (timestamp: number) => [
+  getTimeIntervals(Daily, timestamp),
+  getTimeIntervals(Hourly, timestamp),
+  getHashrateTimeInterval(timestamp)
+]
+
+it('Should return identical intervals for two viewers polling one second apart', () => {
+  expect(allIntervalsAt(now)).toEqual(allIntervalsAt(oneSecondLater))
+})
+
+it('Should return identical intervals for two moments of the same minute', () => {
+  expect(allIntervalsAt(now)).toEqual(allIntervalsAt(endOfSameMinute))
+})
+
+it('Should return fresh intervals one minute later', () => {
+  expect(getTimeIntervals(Daily, now)).not.toEqual(getTimeIntervals(Daily, oneMinuteLater))
+  expect(getTimeIntervals(Hourly, now)).not.toEqual(getTimeIntervals(Hourly, oneMinuteLater))
+  expect(getHashrateTimeInterval(now)).not.toEqual(getHashrateTimeInterval(oneMinuteLater))
+})
+
+it('Should move the end of the interval forward by exactly one minute', () => {
+  expect(getHashrateTimeInterval(oneMinuteLater).to - getHashrateTimeInterval(now).to).toEqual(ONE_MINUTE_MS)
+})
+
+// The hashrate is a headline number on the homepage: bucketing it to the hour, or the chart series to the day, would
+// leave them sitting on a stale value for far longer than anyone would fail to notice.
+it('Should not hold on to the same interval for a whole hour', () => {
+  expect(getHashrateTimeInterval(now)).not.toEqual(getHashrateTimeInterval(laterInTheSameHour))
+  expect(getTimeIntervals(Hourly, now)).not.toEqual(getTimeIntervals(Hourly, laterInTheSameHour))
+})
+
+it('Should not hold on to the same interval for a whole day', () => {
+  expect(getTimeIntervals(Daily, now)).not.toEqual(getTimeIntervals(Daily, laterInTheSameDay))
+})
+
+it('Should floor both boundaries to the current minute', () => {
+  const flooredNow = Date.UTC(2024, 4, 15, 8, 12)
+  const oneMonthEarlier = Date.UTC(2024, 3, 15, 8, 12)
+
+  expect(getTimeIntervals(Daily, now)).toEqual({ from: oneMonthEarlier, to: flooredNow })
+  expect(getTimeIntervals(Hourly, now)).toEqual({ from: flooredNow - 2 * ONE_DAY_MS, to: flooredNow })
+  expect(getHashrateTimeInterval(now)).toEqual({ from: flooredNow - ONE_DAY_MS, to: flooredNow })
+})
+
+it('Should never end the interval more than a minute in the past', () => {
+  for (const { to } of allIntervalsAt(now)) {
+    expect(now - to).toBeGreaterThanOrEqual(0)
+    expect(now - to).toBeLessThan(ONE_MINUTE_MS)
+  }
+})
+
+it('Should default to the current time', () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(oneSecondLater)
+
+  expect([getTimeIntervals(Daily), getTimeIntervals(Hourly), getHashrateTimeInterval()]).toEqual(allIntervalsAt(now))
+
+  vi.useRealTimers()
+})

--- a/apps/explorer/src/pages/HomePage/timeIntervals.ts
+++ b/apps/explorer/src/pages/HomePage/timeIntervals.ts
@@ -1,0 +1,32 @@
+import { ONE_DAY_MS, ONE_MINUTE_MS } from '@alephium/shared'
+import { explorer } from '@alephium/web3'
+
+export interface TimeInterval {
+  from: number
+  to: number
+}
+
+// Raw Date.now() boundaries make every poll and every viewer request a unique, uncacheable URL. Flooring to the minute
+// gives all viewers one shared URL an edge cache can collapse, while keeping the data at most a minute stale.
+const BUCKET_SIZE_MS = ONE_MINUTE_MS
+
+const floorToBucket = (timestamp: number) => timestamp - (timestamp % BUCKET_SIZE_MS)
+
+export const getTimeIntervals = (timeInterval: explorer.IntervalType, now: number = Date.now()): TimeInterval => {
+  const to = floorToBucket(now)
+
+  if (timeInterval === explorer.IntervalType.Daily) {
+    const from = new Date(to)
+    from.setUTCMonth(from.getUTCMonth() - 1)
+
+    return { from: from.getTime(), to }
+  }
+
+  return { from: to - 2 * ONE_DAY_MS, to }
+}
+
+export const getHashrateTimeInterval = (now: number = Date.now()): TimeInterval => {
+  const to = floorToBucket(now)
+
+  return { from: to - ONE_DAY_MS, to }
+}

--- a/apps/explorer/src/pages/HomePage/useBlockListData.ts
+++ b/apps/explorer/src/pages/HomePage/useBlockListData.ts
@@ -1,13 +1,18 @@
 import { explorer } from '@alephium/web3'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import client from '@/api/client'
 
 export const BLOCKS_PER_PAGE = 10
 
+// The backend indexes new blocks roughly every 5s, so polling faster would not surface fresher data.
+export const BLOCKS_REFRESH_INTERVAL = 5000
+
 const useBlockListData = (currentPageNumber: number) => {
   const [blockList, setBlockList] = useState<explorer.ListBlocks>()
   const [manualLoading, setManualLoading] = useState(false)
+  const [newBlockHashes, setNewBlockHashes] = useState<Set<string>>(new Set())
+  const seenBlockHashes = useRef<Set<string>>(new Set())
 
   const getBlocks = useCallback(async (pageNumber: number, manualFetch?: boolean) => {
     manualFetch && setManualLoading(true)
@@ -15,7 +20,15 @@ const useBlockListData = (currentPageNumber: number) => {
     try {
       const data = await client.explorer.blocks.getBlocks({ page: pageNumber, limit: BLOCKS_PER_PAGE })
 
-      if (data) setBlockList(data)
+      if (data) {
+        const hashes = data.blocks?.map((b) => b.hash) ?? []
+
+        // A manual fetch (initial load, page change) only sets a baseline; a poll flashes whatever arrived since.
+        setNewBlockHashes(manualFetch ? new Set() : new Set(hashes.filter((h) => !seenBlockHashes.current.has(h))))
+        seenBlockHashes.current = new Set(hashes)
+
+        setBlockList(data)
+      }
     } catch (e) {
       console.error(e)
     }
@@ -28,7 +41,7 @@ const useBlockListData = (currentPageNumber: number) => {
     getBlocks(currentPageNumber, true)
   }, [getBlocks, currentPageNumber])
 
-  return { getBlocks, blockPageLoading: manualLoading, data: { blockList } }
+  return { getBlocks, blockPageLoading: manualLoading, data: { blockList, newBlockHashes } }
 }
 
 export default useBlockListData

--- a/apps/explorer/src/pages/HomePage/useBlockListData.ts
+++ b/apps/explorer/src/pages/HomePage/useBlockListData.ts
@@ -3,22 +3,19 @@ import { useCallback, useEffect, useState } from 'react'
 
 import client from '@/api/client'
 
+export const BLOCKS_PER_PAGE = 10
+
 const useBlockListData = (currentPageNumber: number) => {
   const [blockList, setBlockList] = useState<explorer.ListBlocks>()
   const [manualLoading, setManualLoading] = useState(false)
 
   const getBlocks = useCallback(async (pageNumber: number, manualFetch?: boolean) => {
-    console.log('Fetching blocks...')
-
     manualFetch && setManualLoading(true)
 
     try {
-      const data = await client.explorer.blocks.getBlocks({ page: pageNumber, limit: 10 })
+      const data = await client.explorer.blocks.getBlocks({ page: pageNumber, limit: BLOCKS_PER_PAGE })
 
-      if (data) {
-        console.log('Number of block fetched: ' + data.blocks?.length)
-        setBlockList(data)
-      }
+      if (data) setBlockList(data)
     } catch (e) {
       console.error(e)
     }

--- a/apps/explorer/src/pages/HomePage/useStatisticsData.ts
+++ b/apps/explorer/src/pages/HomePage/useStatisticsData.ts
@@ -1,8 +1,9 @@
-import { ONE_DAY_MS } from '@alephium/shared'
 import { explorer } from '@alephium/web3'
 import { useCallback, useEffect, useState } from 'react'
 
 import client from '@/api/client'
+
+import { getHashrateTimeInterval, getTimeIntervals } from './timeIntervals'
 
 interface Stat<T> {
   value: T
@@ -27,18 +28,6 @@ type StatsVectorData = { [key in StatVectorKeys]: StatVector }
 const statScalarDefault = { value: 0, isLoading: true }
 const statVectorDefault = { value: { categories: [], series: [] }, isLoading: true }
 
-const getTimeIntervals = (timeInterval: explorer.IntervalType) => {
-  const now = Date.now()
-
-  if (timeInterval === explorer.IntervalType.Daily) {
-    const oneMonthAgo = new Date()
-    oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1)
-    return { from: oneMonthAgo.getTime(), to: now }
-  }
-
-  return { from: now - 2 * ONE_DAY_MS, to: now }
-}
-
 const useStatisticsData = (timeInterval: explorer.IntervalType) => {
   const [statsScalarData, setStatsScalarData] = useState<StatsScalarData>({
     hashrate: statScalarDefault,
@@ -54,6 +43,11 @@ const useStatisticsData = (timeInterval: explorer.IntervalType) => {
     hashrateVector: statVectorDefault
   })
 
+  const [now, setNow] = useState(() => Date.now())
+
+  const { from: hashrateFrom, to: hashrateTo } = getHashrateTimeInterval(now)
+  const { from: chartFrom, to: chartTo } = getTimeIntervals(timeInterval, now)
+
   const updateStatsScalar = (key: StatScalarKeys, value: StatScalar['value']) => {
     setStatsScalarData((prevState) => ({ ...prevState, [key]: { value, isLoading: false } }))
   }
@@ -62,25 +56,10 @@ const useStatisticsData = (timeInterval: explorer.IntervalType) => {
     setStatsVectorData((prevState) => ({ ...prevState, [key]: { value, isLoading: false } }))
   }
 
-  const fetchStatistics = useCallback(() => {
-    if (!client) return
-
+  const fetchScalarStats = useCallback(() => {
     const fetchAndUpdateStatsScalar = async (key: StatScalarKeys, fetchCall: () => Promise<number>) => {
       const result = await fetchCall()
       if (result) updateStatsScalar(key, typeof result === 'string' ? parseInt(result) : result)
-    }
-
-    const fetchHashrateData = async () => {
-      const now = new Date().getTime()
-      const yesterday = now - ONE_DAY_MS
-
-      const data = await client.explorer.charts.getChartsHashrates({
-        fromTs: yesterday,
-        toTs: now,
-        'interval-type': explorer.IntervalType.Hourly
-      })
-
-      if (data && data.length > 0) updateStatsScalar('hashrate', Number(data[data.length - 1].value))
     }
 
     const fetchBlocksData = async () => {
@@ -98,11 +77,28 @@ const useStatisticsData = (timeInterval: explorer.IntervalType) => {
         updateStatsScalar('avgBlockTime', data.reduce((acc: number, { value }) => acc + value, 0.0) / data.length)
     }
 
+    fetchBlocksData()
+    fetchAvgBlockTimeData()
+    fetchAndUpdateStatsScalar('totalSupply', client.explorer.infos.getInfosSupplyTotalAlph)
+    fetchAndUpdateStatsScalar('circulatingSupply', client.explorer.infos.getInfosSupplyCirculatingAlph)
+    fetchAndUpdateStatsScalar('totalTransactions', client.explorer.infos.getInfosTotalTransactions)
+  }, [])
+
+  const fetchHashrateStat = useCallback(async () => {
+    const data = await client.explorer.charts.getChartsHashrates({
+      fromTs: hashrateFrom,
+      toTs: hashrateTo,
+      'interval-type': explorer.IntervalType.Hourly
+    })
+
+    if (data && data.length > 0) updateStatsScalar('hashrate', Number(data[data.length - 1].value))
+  }, [hashrateFrom, hashrateTo])
+
+  const fetchChartStats = useCallback(async () => {
     const fetchTxVectorData = async () => {
-      const timeIntervals = getTimeIntervals(timeInterval)
       const data = await client.explorer.charts.getChartsTransactionsCount({
-        fromTs: timeIntervals.from,
-        toTs: timeIntervals.to,
+        fromTs: chartFrom,
+        toTs: chartTo,
         'interval-type': timeInterval
       })
       if (data && data.length > 0)
@@ -123,11 +119,9 @@ const useStatisticsData = (timeInterval: explorer.IntervalType) => {
     }
 
     const fetchHashrateVectorData = async () => {
-      const timeIntervals = getTimeIntervals(timeInterval)
-
       const data = await client.explorer.charts.getChartsHashrates({
-        fromTs: timeIntervals.from,
-        toTs: timeIntervals.to,
+        fromTs: chartFrom,
+        toTs: chartTo,
         'interval-type': timeInterval
       })
       if (data && data.length > 0)
@@ -147,26 +141,35 @@ const useStatisticsData = (timeInterval: explorer.IntervalType) => {
         )
     }
 
-    fetchHashrateData()
-    fetchBlocksData()
-    fetchAvgBlockTimeData()
     fetchTxVectorData()
     fetchHashrateVectorData()
-    fetchAndUpdateStatsScalar('totalSupply', client.explorer.infos.getInfosSupplyTotalAlph)
-    fetchAndUpdateStatsScalar('circulatingSupply', client.explorer.infos.getInfosSupplyCirculatingAlph)
-    fetchAndUpdateStatsScalar('totalTransactions', client.explorer.infos.getInfosTotalTransactions)
-  }, [timeInterval])
+  }, [chartFrom, chartTo, timeInterval])
 
   useEffect(() => {
-    fetchStatistics()
-  }, [fetchStatistics])
+    fetchScalarStats()
+  }, [fetchScalarStats])
+
+  // These two effects are keyed on the bucketed boundaries rather than on the poll, so the chart endpoints are hit
+  // once per bucket instead of on every tick, and always on a URL that is shared with every other viewer.
+  useEffect(() => {
+    fetchHashrateStat()
+  }, [fetchHashrateStat])
+
+  useEffect(() => {
+    fetchChartStats()
+  }, [fetchChartStats])
+
+  const refreshStatistics = useCallback(() => {
+    fetchScalarStats()
+    setNow(Date.now())
+  }, [fetchScalarStats])
 
   const { hashrate, totalSupply, circulatingSupply, totalTransactions, totalBlocks, avgBlockTime } = statsScalarData
 
   const { txVector, hashrateVector } = statsVectorData
 
   return {
-    fetchStatistics,
+    refreshStatistics,
     data: {
       scalar: {
         hashrate,


### PR DESCRIPTION
- Fixes #1656

The homepage fired 9 requests every 10s per viewer, and `getTimeIntervals` used `Date.now()` on every poll, so every chart URL was unique and uncacheable. At ~1k viewers that is ~900 req/s of origin work serving byte-identical data.

Fix: floor the chart timestamps to a 60s bucket, so every viewer within the same minute emits an identical URL. An edge cache then collapses them to one origin request per minute regardless of viewer count, and nothing is ever more than ~70s stale. Also drops a debug log and fixes a pagination off-by-two.

Note that the edge cache only kicks in once explorer-backend adds `Cache-Control` to these endpoints (tracked in alephium/explorer-backend#670). This PR makes the URLs cacheable; it does not add the caching itself.

