### PR TITLE
Poll latest blocks faster and flash new rows

### DIFF
--- a/.changeset/warm-lions-blink.md
+++ b/.changeset/warm-lions-blink.md
@@ -1,0 +1,5 @@
+---
+'@alephium/explorer': patch
+---
+
+Refresh the homepage's latest blocks every 5s and briefly highlight newly-arrived ones

--- a/apps/explorer/src/components/Table/TableRow.tsx
+++ b/apps/explorer/src/components/Table/TableRow.tsx
@@ -1,17 +1,27 @@
 import { motion } from 'framer-motion'
 import { Children } from 'react'
 import { Link } from 'react-router-dom'
-import styled from 'styled-components'
+import styled, { css, keyframes } from 'styled-components'
 
 import { deviceBreakPoints } from '@/styles/globalStyles'
 
 interface RowProps {
   isActive?: boolean
   highlight?: boolean
+  isNew?: boolean
   onClick?: React.MouseEventHandler<HTMLTableRowElement>
   linkTo?: string
   className?: string
 }
+
+const newRowFlash = keyframes`
+  from {
+    background-color: var(--new-row-flash-color);
+  }
+  to {
+    background-color: transparent;
+  }
+`
 
 const rowVariants = {
   hidden: { opacity: 0 },
@@ -36,9 +46,18 @@ const TableRow: FC<RowProps> = ({ children, onClick, linkTo, className }) => (
 )
 
 export default styled(TableRow)`
+  --new-row-flash-color: ${({ theme }) => theme.bg.accent};
   background-color: ${({ theme, isActive }) => (isActive ? theme.bg.primary : '')};
   border: none;
   cursor: ${({ onClick }) => (onClick ? 'pointer' : 'auto')};
+
+  ${({ isNew }) =>
+    isNew &&
+    css`
+      @media (prefers-reduced-motion: no-preference) {
+        animation: ${newRowFlash} 1.6s ease-out;
+      }
+    `}
 
   td:first-child {
     display: flex;

--- a/apps/explorer/src/pages/HomePage/HomePage.tsx
+++ b/apps/explorer/src/pages/HomePage/HomePage.tsx
@@ -28,7 +28,7 @@ import { useWindowSize } from '@/hooks/useWindowSize'
 import { deviceBreakPoints, deviceSizes } from '@/styles/globalStyles'
 import { formatNumberForDisplay } from '@/utils/strings'
 
-import useBlockListData, { BLOCKS_PER_PAGE } from './useBlockListData'
+import useBlockListData, { BLOCKS_PER_PAGE, BLOCKS_REFRESH_INTERVAL } from './useBlockListData'
 import useStatisticsData from './useStatisticsData'
 
 type VectorStatisticsKey = keyof ReturnType<typeof useStatisticsData>['data']['vector']
@@ -46,7 +46,7 @@ const HomePage = () => {
   const {
     getBlocks,
     blockPageLoading,
-    data: { blockList }
+    data: { blockList, newBlockHashes }
   } = useBlockListData(currentPageNumber)
 
   const {
@@ -59,18 +59,10 @@ const HomePage = () => {
 
   const vectorData = vector
 
-  // Polling
-  useInterval(
-    () => {
-      refreshStatistics()
+  useInterval(refreshStatistics, 10 * 1000, !isAppVisible)
 
-      if (currentPageNumber === 1) {
-        getBlocks(currentPageNumber, false)
-      }
-    },
-    10 * 1000,
-    !isAppVisible
-  )
+  // Poll the latest blocks on their own faster cadence so the list keeps up with the chain's block rate.
+  useInterval(() => getBlocks(1, false), BLOCKS_REFRESH_INTERVAL, !isAppVisible || currentPageNumber !== 1)
 
   const [hashrateInteger, hashrateDecimal, hashrateSuffix] = formatNumberForDisplay(hashrate.value, '', 'hash')
 
@@ -179,7 +171,7 @@ const HomePage = () => {
               <TableBody tdStyles={TableBodyCustomStyles}>
                 {blockList &&
                   blockList.blocks?.map((b) => (
-                    <TableRow key={b.hash} linkTo={`blocks/${b.hash}`}>
+                    <TableRow key={b.hash} linkTo={`blocks/${b.hash}`} isNew={newBlockHashes.has(b.hash)}>
                       <BlockHeight>{b.height.toString()}</BlockHeight>
                       <Timestamp
                         timeInMs={b.timestamp}

--- a/apps/explorer/src/pages/HomePage/useBlockListData.ts
+++ b/apps/explorer/src/pages/HomePage/useBlockListData.ts
@@ -1,13 +1,18 @@
 import { explorer } from '@alephium/web3'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import client from '@/api/client'
 
 export const BLOCKS_PER_PAGE = 10
 
+// The backend indexes new blocks roughly every 5s, so polling faster would not surface fresher data.
+export const BLOCKS_REFRESH_INTERVAL = 5000
+
 const useBlockListData = (currentPageNumber: number) => {
   const [blockList, setBlockList] = useState<explorer.ListBlocks>()
   const [manualLoading, setManualLoading] = useState(false)
+  const [newBlockHashes, setNewBlockHashes] = useState<Set<string>>(new Set())
+  const seenBlockHashes = useRef<Set<string>>(new Set())
 
   const getBlocks = useCallback(async (pageNumber: number, manualFetch?: boolean) => {
     manualFetch && setManualLoading(true)
@@ -15,7 +20,15 @@ const useBlockListData = (currentPageNumber: number) => {
     try {
       const data = await client.explorer.blocks.getBlocks({ page: pageNumber, limit: BLOCKS_PER_PAGE })
 
-      if (data) setBlockList(data)
+      if (data) {
+        const hashes = data.blocks?.map((b) => b.hash) ?? []
+
+        // A manual fetch (initial load, page change) only sets a baseline; a poll flashes whatever arrived since.
+        setNewBlockHashes(manualFetch ? new Set() : new Set(hashes.filter((h) => !seenBlockHashes.current.has(h))))
+        seenBlockHashes.current = new Set(hashes)
+
+        setBlockList(data)
+      }
     } catch (e) {
       console.error(e)
     }
@@ -28,7 +41,7 @@ const useBlockListData = (currentPageNumber: number) => {
     getBlocks(currentPageNumber, true)
   }, [getBlocks, currentPageNumber])
 
-  return { getBlocks, blockPageLoading: manualLoading, data: { blockList } }
+  return { getBlocks, blockPageLoading: manualLoading, data: { blockList, newBlockHashes } }
 }
 
 export default useBlockListData


### PR DESCRIPTION
> **Stacked on #1664** (base is `fix/explorer-cacheable-chart-urls`). Merge #1664 first, then retarget this to `master`. The diff shown here is only this PR's changes.

The homepage polled the latest blocks on the same 10s interval as the slow-changing stat cards, which undersells how fast Alephium produces blocks.

- **Blocks now poll on their own 5s cadence**, matched to how often the backend indexes new blocks (~5s, per alephium/explorer-backend#353), and decoupled from the stats interval so the static supply/height numbers aren't fetched twice as often for no reason.
- **Newly-arrived rows briefly flash** on each poll so the churn is visible.

The flash is deliberately subtle: at the chain's block rate the whole top-10 turns over every few seconds, so a stronger highlight would strobe the entire table. Crisp per-block highlighting is what the live stream (#1667) unlocks, when blocks arrive one at a time instead of in a batch.

Verified against mainnet: block requests fire at a clean 5s cadence (decoupled from stats, and #1664's chart bucketing still intact), new rows flash, no console errors.

Related: #1667 (SSE live block feed - the next step that makes this genuinely real-time and the per-row flash crisp).