### PR TITLE
Hide zero-availability tokens from send picker

### DIFF
--- a/.changeset/silver-lions-drift.md
+++ b/.changeset/silver-lions-drift.md
@@ -1,0 +1,5 @@
+---
+'alephium-desktop-wallet': patch
+---
+
+Hide assets with no available balance from the token picker when sending

--- a/apps/desktop-wallet/src/features/send/sendModal/TokensAmountInputs.tsx
+++ b/apps/desktop-wallet/src/features/send/sendModal/TokensAmountInputs.tsx
@@ -1,5 +1,5 @@
 import { fromHumanReadableAmount, getNumberOfDecimals, toHumanReadableAmount } from '@alephium/shared/numbers'
-import { Address, AddressHash } from '@alephium/shared/types'
+import { Address, AddressHash, TokenApiBalances } from '@alephium/shared/types'
 import {
   addressTokensSearchStringsQuery,
   useFetchAddressBalances,
@@ -282,6 +282,9 @@ const TokensAmountInputs = ({
 
 export default TokensAmountInputs
 
+const hasAvailableBalance = (balance: TokenApiBalances | undefined) =>
+  balance !== undefined && BigInt(balance.availableBalance) > 0n
+
 const useAddressTokensSelectOptions = (addressHash: AddressHash) => {
   const networkId = useNetworkId()
   const isNodeOnline = useIsNodeOnline()
@@ -289,6 +292,7 @@ const useAddressTokensSelectOptions = (addressHash: AddressHash) => {
   const {
     data: { nftIds, nstIds }
   } = useFetchAddressTokensByType(addressHash)
+  const { data: tokensBalances } = useFetchAddressBalances(addressHash)
   const sortedTokenIds = useSortedTokenIds({ sortedFts, nftIds, nstIds })
 
   const { data: tokensSearchStrings } = useQuery(
@@ -297,12 +301,14 @@ const useAddressTokensSelectOptions = (addressHash: AddressHash) => {
 
   const allTokensOptions = useMemo(
     () =>
-      sortedTokenIds.map((id) => ({
-        value: id,
-        label: id,
-        searchString: tokensSearchStrings?.[id] ?? ''
-      })),
-    [sortedTokenIds, tokensSearchStrings]
+      sortedTokenIds
+        .filter((id) => hasAvailableBalance(tokensBalances?.find((balance) => balance.id === id)))
+        .map((id) => ({
+          value: id,
+          label: id,
+          searchString: tokensSearchStrings?.[id] ?? ''
+        })),
+    [sortedTokenIds, tokensBalances, tokensSearchStrings]
   )
 
   return allTokensOptions


### PR DESCRIPTION
Closes #1428.

Filters the send picker in `apps/desktop-wallet/src/features/send/sendModal/TokensAmountInputs.tsx` so it only shows assets the address can actually spend. The picker options come from `useAddressTokensSelectOptions`, which was mapping `sortedTokenIds` (all tokens the address holds) straight to select options without consulting balance state. I added `useFetchAddressBalances(addressHash)` inside the hook and filter each token id through a small `hasAvailableBalance` predicate: `BigInt(balance.availableBalance) > 0n`. Tokens with a locked-only balance (the "all EX are locked" case from the issue) no longer appear in the picker, and NFTs pass through naturally because their `availableBalance` is `"1"` when owned.

One small side effect worth flagging. If the address opens the send flow before `useFetchAddressBalances` has resolved for the first time, the picker will render empty for that brief moment rather than showing the pre-filter list. In practice the query is already warm from the parent component (`tokensBalances` is fetched at the top of `TokensAmountInputs` for the amount inputs), so the cache hit is instant on any subsequent open. The alternative was to fall back to the unfiltered list during load, but that would flash a locked-only token in for a moment which felt worse. Happy to swap the default if you'd prefer the other tradeoff.

Also flagging: the mobile wallet has an equivalent picker in `apps/mobile-wallet/src/features/send/screens/addressTokensScreen/AddressTokensScreen.tsx:108` using the same `useSortedTokenIds` primitive without filtering. Left it out of this PR since the original scope was DW-only and the issue screenshots are all DW, but happy to fold the same filter in here if you'd like parity.

I ran `pnpm --filter alephium-desktop-wallet lint` and `pnpm --filter alephium-desktop-wallet exec tsc --noEmit`, both green. No existing tests reference `useAddressTokensSelectOptions`. Changeset included, patch bump on `alephium-desktop-wallet`.