### PR TITLE
Speed up wallet unlock and cut query cache overhead

### DIFF
--- a/.changeset/fix-lock-quit-cache-wipe.md
+++ b/.changeset/fix-lock-quit-cache-wipe.md
@@ -1,0 +1,5 @@
+---
+'alephium-desktop-wallet': patch
+---
+
+Fix wallet data being refetched from scratch when relaunching after locking

--- a/.changeset/perf-query-cache-hotspots.md
+++ b/.changeset/perf-query-cache-hotspots.md
@@ -1,0 +1,6 @@
+---
+'alephium-desktop-wallet': patch
+'@alephium/mobile-wallet': patch
+---
+
+Speed up wallet unlock and reduce CPU and network usage

--- a/apps/desktop-wallet/electron/main.ts
+++ b/apps/desktop-wallet/electron/main.ts
@@ -28,6 +28,8 @@ app.setName(OLD_APP_NAME)
 // Expose Garbage Collector flag for manual trigger
 app.commandLine.appendSwitch('js-flags', '--expose-gc')
 
+if (process.env.REMOTE_DEBUG_PORT) app.commandLine.appendSwitch('remote-debugging-port', process.env.REMOTE_DEBUG_PORT)
+
 registerAppProtocol()
 
 contextMenu()

--- a/apps/desktop-wallet/src/hooks/useWalletLock.ts
+++ b/apps/desktop-wallet/src/hooks/useWalletLock.ts
@@ -161,10 +161,10 @@ const useWalletLock = () => {
 
     afterUnlock()
 
-    // Navigating to the Overview screen freezes the app. This is because the React components need some time to load.
-    // We could use Suspence to display some placeholder content until all components of the Overview page have been
-    // rendered instead of freezing the app. For now, by delaying the hiding of the loader, we achieve a similar effect.
-    sleep(2000).then(() => dispatch(toggleAppLoading(false)))
+    // Rendering the Overview screen blocks the main thread while the components mount, so we keep the loader up until
+    // the first frame after that work has shipped. The sleep is a fallback ceiling for when frames are not being
+    // produced, e.g. when the window is in the background.
+    Promise.race([nextFramePainted(), sleep(2000)]).then(() => dispatch(toggleAppLoading(false)))
 
     encryptedWallet = null
     passphrase = ''
@@ -179,3 +179,6 @@ const useWalletLock = () => {
 }
 
 export default useWalletLock
+
+const nextFramePainted = () =>
+  new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))

--- a/apps/desktop-wallet/src/storage/tanstackQueryCache/usePersistQueryCacheBeforeQuit.ts
+++ b/apps/desktop-wallet/src/storage/tanstackQueryCache/usePersistQueryCacheBeforeQuit.ts
@@ -24,6 +24,10 @@ const usePersistQueryCacheBeforeQuit = () => {
         window.electron?.window.close()
         window.close()
       }
+    } else {
+      // Without this, closing the app while the wallet is locked runs the handler of the previously active wallet,
+      // persisting the cleared query cache over the one that was saved when the wallet got locked.
+      window.onbeforeunload = null
     }
 
     const removeBeforeQuitListener = window.electron?.app.onBeforeQuit(async () => {

--- a/packages/shared-react/src/api/fetchUtils.ts
+++ b/packages/shared-react/src/api/fetchUtils.ts
@@ -39,7 +39,47 @@ export const fetchContentType = async (url: string): Promise<string> => {
     return url.slice(5, mimeEnd)
   }
 
+  const inferredContentType = inferContentTypeFromExtension(url)
+
+  if (inferredContentType) return inferredContentType
+
   const res = await fetch(url, { method: 'HEAD' })
 
   return res.headers.get('content-type') || ''
+}
+
+const MIME_TYPE_BY_EXTENSION: Record<string, string> = {
+  apng: 'image/apng',
+  avif: 'image/avif',
+  bmp: 'image/bmp',
+  gif: 'image/gif',
+  ico: 'image/x-icon',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  png: 'image/png',
+  svg: 'image/svg+xml',
+  webp: 'image/webp',
+  m4v: 'video/mp4',
+  mov: 'video/quicktime',
+  mp4: 'video/mp4',
+  ogv: 'video/ogg',
+  webm: 'video/webm',
+  aac: 'audio/aac',
+  flac: 'audio/flac',
+  m4a: 'audio/mp4',
+  mp3: 'audio/mpeg',
+  oga: 'audio/ogg',
+  ogg: 'audio/ogg',
+  opus: 'audio/opus',
+  wav: 'audio/wav'
+}
+
+const inferContentTypeFromExtension = (url: string): string | undefined => {
+  try {
+    const extension = new URL(url).pathname.split('.').pop()?.toLowerCase()
+
+    return extension ? MIME_TYPE_BY_EXTENSION[extension] : undefined
+  } catch {
+    return undefined
+  }
 }

--- a/packages/shared-react/src/api/persistQueryClientContext.tsx
+++ b/packages/shared-react/src/api/persistQueryClientContext.tsx
@@ -1,11 +1,8 @@
 import { sleep } from '@alephium/web3'
-import {
-  PersistQueryClientOptions,
-  persistQueryClientRestore,
-  persistQueryClientSave
-} from '@tanstack/query-persist-client-core'
+import { PersistQueryClientOptions, persistQueryClientSave } from '@tanstack/query-persist-client-core'
 import {
   defaultShouldDehydrateQuery,
+  hydrate,
   IsRestoringProvider,
   OmitKeyof,
   QueryClientProvider,
@@ -85,16 +82,9 @@ export const PersistQueryClientContextProvider = ({
       setIsRestoring(true)
 
       if (!isPassphraseUsed) {
-        const options: PersistQueryClientOptions = {
-          queryClient,
-          maxAge: Infinity,
-          persister: createPersister(getPersisterKey(walletId)),
-          dehydrateOptions: undefined
-          // TODO: Add buster: CACHE_SCHEMA_VERSION (global variable) for when I want to force a cache refresh to
-          // everyone who updates. Useful for when the API schema or the cached query shapes change.
-        }
-
-        await persistQueryClientRestore(options)
+        // TODO: Add buster: CACHE_SCHEMA_VERSION (global variable) for when I want to force a cache refresh to
+        // everyone who updates. Useful for when the API schema or the cached query shapes change.
+        await restoreQueryCacheInChunks(createPersister(getPersisterKey(walletId)))
       } else {
         // Even when we don't restore data in the case of passphrase wallet, we need to set `isRestoring` to `true` and
         // then to `false` to make sure the useQuery instances are reset.
@@ -127,3 +117,30 @@ export const PersistQueryClientContextProvider = ({
 export const usePersistQueryClientContext = () => useContext(PersistQueryClientContext)
 
 export const getPersisterKey = (walletId: string) => 'tanstack-cache-for-wallet-' + walletId
+
+const RESTORE_CHUNK_SIZE = 250
+
+// Equivalent to persistQueryClientRestore but hydrating in chunks that yield to the event loop, so that restoring
+// thousands of queries (and scheduling their gc timers) does not block the main thread in one long task at unlock.
+const restoreQueryCacheInChunks = async (persister: Persister) => {
+  try {
+    const persistedClient = await persister.restoreClient()
+
+    if (!persistedClient) return
+
+    const { queries, mutations } = persistedClient.clientState
+
+    hydrate(queryClient, { queries: [], mutations })
+
+    for (let i = 0; i < queries.length; i += RESTORE_CHUNK_SIZE) {
+      hydrate(queryClient, { queries: queries.slice(i, i + RESTORE_CHUNK_SIZE), mutations: [] })
+
+      if (i + RESTORE_CHUNK_SIZE < queries.length) await yieldToEventLoop()
+    }
+  } catch (error) {
+    console.error('Error restoring query client', error)
+    persister.removeClient()
+  }
+}
+
+const yieldToEventLoop = () => new Promise((resolve) => setTimeout(resolve))

--- a/packages/shared-react/src/api/queries/addressQueries.ts
+++ b/packages/shared-react/src/api/queries/addressQueries.ts
@@ -42,10 +42,16 @@ const nodeAddressBalancesQuery = ({ addressHash, networkId, isNodeOnline, skip }
       : () => throttledClient.node.addresses.getAddressesAddressBalance(addressHash)
   })
 
+export const addressAlphBalancesQueryKey = ({
+  addressHash,
+  networkId
+}: Pick<AddressNodeQueryProps, 'addressHash' | 'networkId'>) =>
+  ['address', addressHash, 'level:0', 'balance', 'ALPH', { networkId }] as const
+
 // Adding networkId in queryKey ensures that switching the network we get different data.
 export const addressAlphBalancesQuery = ({ addressHash, networkId, isNodeOnline, skip }: AddressNodeQueryProps) =>
   queryOptions({
-    queryKey: ['address', addressHash, 'level:0', 'balance', 'ALPH', { networkId }],
+    queryKey: addressAlphBalancesQueryKey({ addressHash, networkId }),
     // We don't want address data to be deleted when the user navigates away from components that need them since these
     // data are essential for the major parts of the app. We manually remove cached data when the user deletes an
     // address.

--- a/packages/shared-react/src/api/queries/transactionQueries.ts
+++ b/packages/shared-react/src/api/queries/transactionQueries.ts
@@ -9,6 +9,7 @@ import { SkipProp } from '../../api/apiDataHooks/apiDataHooksTypes'
 import { getQueryConfig } from '../../api/apiUtils'
 import { queryClient } from '../../api/queryClient'
 import { invalidateAddressQueries, invalidateTokenPrices, invalidateWalletQueries } from '../../api/queryInvalidation'
+import { addressAlphBalancesQueryKey } from './addressQueries'
 import { shouldSkip } from './queriesUtils'
 
 export interface AddressLatestTransactionQueryProps {
@@ -54,9 +55,18 @@ export const addressLatestTransactionQuery = ({
           // The following block invalidates queries that need to refetch data if a new transaction hash has been
           // detected. This way, we don't need to use the latest tx hash in the queryKey of each of those queries.
           if (latestTx !== undefined && latestTx.hash !== cachedLatestTx?.hash) {
-            await invalidateAddressQueries(addressHash)
-            await invalidateWalletQueries()
-            await invalidateTokenPrices()
+            const isFirstAddressData =
+              cachedData === undefined &&
+              queryClient.getQueryData(addressAlphBalancesQueryKey({ addressHash, networkId })) === undefined
+
+            // On the very first fetch (cold start, new address) dependent queries have no data to refresh and are
+            // being fetched on their own as they mount, so invalidating them would only cancel and restart their
+            // in-flight requests.
+            if (!isFirstAddressData) {
+              await invalidateAddressQueries(addressHash)
+              await invalidateWalletQueries()
+              await invalidateTokenPrices()
+            }
           }
 
           return {

--- a/packages/shared-react/src/api/queryInvalidation.ts
+++ b/packages/shared-react/src/api/queryInvalidation.ts
@@ -7,14 +7,13 @@ import {
 } from '../api/queries/transactionQueries'
 import { queryClient } from '../api/queryClient'
 
+export const ADDRESS_QUERY_LEVELS = ['level:-1', 'level:0', 'level:1', 'level:2', 'level:3', 'level:4'] as const
+
 // Queries need to be invalidated in order of dependency
 export const invalidateAddressQueries = async (addressHash: AddressHash) => {
-  await queryClient.invalidateQueries({ queryKey: ['address', addressHash, 'level:-1'] })
-  await queryClient.invalidateQueries({ queryKey: ['address', addressHash, 'level:0'] })
-  await queryClient.invalidateQueries({ queryKey: ['address', addressHash, 'level:1'] })
-  await queryClient.invalidateQueries({ queryKey: ['address', addressHash, 'level:2'] })
-  await queryClient.invalidateQueries({ queryKey: ['address', addressHash, 'level:3'] })
-  await queryClient.invalidateQueries({ queryKey: ['address', addressHash, 'level:4'] })
+  for (const level of ADDRESS_QUERY_LEVELS) {
+    await queryClient.invalidateQueries({ queryKey: ['address', addressHash, level] })
+  }
 }
 
 export const invalidateWalletQueries = async () => {

--- a/packages/shared-react/src/hooks/addresses/useRefreshAddressesBalances.ts
+++ b/packages/shared-react/src/hooks/addresses/useRefreshAddressesBalances.ts
@@ -1,31 +1,86 @@
-import { useIsFetching } from '@tanstack/react-query'
-import { useCallback } from 'react'
+import { AddressHash } from '@alephium/shared/types'
+import { notifyManager, Query } from '@tanstack/react-query'
+import { useCallback, useMemo, useSyncExternalStore } from 'react'
 
-import { invalidateAddressQueries, invalidateTokenPrices } from '../../api/queryInvalidation'
-import { useUnsortedAddressesHashes } from '../../hooks/addresses/useUnsortedAddresses'
+import { queryClient } from '../../api/queryClient'
+import { ADDRESS_QUERY_LEVELS, invalidateTokenPrices } from '../../api/queryInvalidation'
+import { useUnsortedAddressesHashesSet } from '../../hooks/addresses/useUnsortedAddresses'
 
 export const useRefreshAddressesBalances = () => {
-  const addressHashes = useUnsortedAddressesHashes()
-  const isFetchingBalances =
-    useIsFetching({
-      queryKey: ['address'],
-      predicate: (query) => {
-        const secondSegment = query.queryKey[1]?.toString() ?? ''
-        const thirdSegment = query.queryKey[2]?.toString() ?? ''
+  const addressHashesSet = useUnsortedAddressesHashesSet()
+  const isFetchingBalances = useIsFetchingAddressesBalances(addressHashesSet)
 
-        return addressHashes.includes(secondSegment) && thirdSegment === 'level:0'
-      }
-    }) > 0
-
-  const refreshBalances = useCallback(() => {
+  const refreshBalances = useCallback(async () => {
     if (isFetchingBalances) return
 
-    addressHashes.forEach(invalidateAddressQueries)
-    invalidateTokenPrices()
-  }, [addressHashes, isFetchingBalances])
+    // One cache pass per level instead of one per level per address. Queries need to be invalidated in order of
+    // dependency, see queryInvalidation.ts.
+    for (const level of ADDRESS_QUERY_LEVELS) {
+      await queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === 'address' &&
+          query.queryKey[2] === level &&
+          addressHashesSet.has(query.queryKey[1] as AddressHash)
+      })
+    }
+
+    await invalidateTokenPrices()
+  }, [addressHashesSet, isFetchingBalances])
 
   return {
     refreshBalances,
     isFetchingBalances
   }
+}
+
+// Equivalent to useIsFetching({ predicate }) but with O(1) work per query cache event instead of a full cache scan,
+// which is what useIsFetching does on every event for the lifetime of the subscribed component.
+const useIsFetchingAddressesBalances = (addressHashesSet: Set<AddressHash>) => {
+  const store = useMemo(() => {
+    const fetchingQueryHashes = new Set<string>()
+
+    const isBalanceQuery = (query: Query) =>
+      query.queryKey[0] === 'address' &&
+      query.queryKey[2] === 'level:0' &&
+      addressHashesSet.has(query.queryKey[1] as AddressHash)
+
+    const compute = () => {
+      fetchingQueryHashes.clear()
+
+      for (const query of queryClient.getQueryCache().getAll()) {
+        if (isBalanceQuery(query) && query.state.fetchStatus === 'fetching') fetchingQueryHashes.add(query.queryHash)
+      }
+    }
+
+    compute()
+
+    return {
+      subscribe: (onStoreChange: () => void) => {
+        const wasFetching = fetchingQueryHashes.size > 0
+        compute()
+
+        const notify = notifyManager.batchCalls(onStoreChange)
+        const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+          if (!isBalanceQuery(event.query)) return
+
+          const wasEmpty = fetchingQueryHashes.size === 0
+
+          if (event.type !== 'removed' && event.query.state.fetchStatus === 'fetching') {
+            fetchingQueryHashes.add(event.query.queryHash)
+          } else {
+            fetchingQueryHashes.delete(event.query.queryHash)
+          }
+
+          if (wasEmpty !== (fetchingQueryHashes.size === 0)) notify()
+        })
+
+        if (wasFetching !== fetchingQueryHashes.size > 0) onStoreChange()
+
+        return unsubscribe
+      },
+      getSnapshot: () => fetchingQueryHashes.size > 0
+    }
+  }, [addressHashesSet])
+
+  return useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot)
 }

--- a/packages/shared-react/src/hooks/addresses/useUnsortedAddresses.ts
+++ b/packages/shared-react/src/hooks/addresses/useUnsortedAddresses.ts
@@ -1,8 +1,14 @@
 import { selectAllAddresses, selectAllAddressHashes } from '@alephium/shared/store'
 import { Address, AddressHash } from '@alephium/shared/types'
+import { useMemo } from 'react'
 
 import { useSharedSelector } from '../../redux'
 
 export const useUnsortedAddressesHashes = (): AddressHash[] => useSharedSelector(selectAllAddressHashes)
+
+export const useUnsortedAddressesHashesSet = (): Set<AddressHash> => {
+  const addresses = useUnsortedAddressesHashes()
+  return useMemo(() => new Set(addresses), [addresses])
+}
 
 export const useUnsortedAddresses = (): Address[] => useSharedSelector(selectAllAddresses)

--- a/packages/shared-react/test/fetchUtils.test.ts
+++ b/packages/shared-react/test/fetchUtils.test.ts
@@ -110,14 +110,22 @@ describe('fetchContentType', () => {
     expect(result).toBe('application/json')
   })
 
-  it('sends HEAD request for HTTP URLs', async () => {
+  it('infers content type from the URL file extension without a network request', async () => {
+    expect(await fetchContentType('https://example.com/image.png')).toBe('image/png')
+    expect(await fetchContentType('https://example.com/path/video.MP4')).toBe('video/mp4')
+    expect(await fetchContentType('https://example.com/sound.ogg?query=1')).toBe('audio/ogg')
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('sends HEAD request for HTTP URLs without a known file extension', async () => {
     mockFetch.mockResolvedValueOnce({
       headers: new Headers({ 'content-type': 'image/png' })
     })
 
-    const result = await fetchContentType('https://example.com/image.png')
+    const result = await fetchContentType('https://example.com/token/42')
 
-    expect(mockFetch).toHaveBeenCalledWith('https://example.com/image.png', { method: 'HEAD' })
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/token/42', { method: 'HEAD' })
     expect(result).toBe('image/png')
   })
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local", "tsconfig.json"],
+  "globalPassThroughEnv": ["REMOTE_DEBUG_PORT"],
   "tasks": {
     "lint": {},
     "lint:fix": { "cache": false },


### PR DESCRIPTION
Profiling a 42-address wallet showed the biggest remaining TanStack cost was `useIsFetching({ predicate })` in the refresh button, which rescans the whole query cache on every cache event (3.2s of a cold start), plus a few smaller drains.

- Replace `useIsFetching` with an incremental cache subscription (O(1) per event); reduce the refresh click from 252 cache scans to 6
- Skip the gate's invalidation cascade on first-ever address data (cold start / new address)
- Hydrate the persisted cache in 250-query chunks so restore stays out of the unlock long task
- Hide the unlock loader on first paint instead of a fixed 2s sleep
- Infer NFT media type from the URL extension; HEAD probe only when extensionless
- Fix quitting a locked wallet persisting an empty cache over the good snapshot (every lock-then-quit relaunch was silently a full cold start)

Measured on the same protocol (dev build):
- warm TBT (total blocked time) 3.0s -> 1.9s
- cold 5.6s -> 3.8s
- worst unlock task 1.19s -> 0.76s
- query-cache scan time to zero samples
- NFT HEAD probes 168 -> 27