### PR TITLE
Pin invalidation cascade semantics with tests

### DIFF
--- a/packages/shared-react/src/api/queryInvalidation.ts
+++ b/packages/shared-react/src/api/queryInvalidation.ts
@@ -9,7 +9,11 @@ import { queryClient } from '../api/queryClient'
 
 export const ADDRESS_QUERY_LEVELS = ['level:-1', 'level:0', 'level:1', 'level:2', 'level:3', 'level:4'] as const
 
-// Queries need to be invalidated in order of dependency
+// Queries must be invalidated one dependency level at a time. A single unordered invalidateQueries call refetches in
+// cache insertion order, where consumers often precede their dependencies (their queryFns create the dependency
+// entries lazily via fetchQuery). The consumer's refetch then starts its dependency's fetch, and when the same batch
+// reaches the dependency's own entry, cancelRefetch silently cancels the fetch the consumer is awaiting, leaving the
+// consumer invalidated with stale data. See test/invalidationSinglePass.test.ts.
 export const invalidateAddressQueries = async (addressHash: AddressHash) => {
   for (const level of ADDRESS_QUERY_LEVELS) {
     await queryClient.invalidateQueries({ queryKey: ['address', addressHash, level] })

--- a/packages/shared-react/test/invalidationCascade.test.ts
+++ b/packages/shared-react/test/invalidationCascade.test.ts
@@ -1,0 +1,259 @@
+import { InfiniteData, InfiniteQueryObserver } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { walletTransactionsInfiniteQuery } from '../src/api/queries/transactionQueries'
+import { queryClient } from '../src/api/queryClient'
+import { invalidateWalletQueries } from '../src/api/queryInvalidation'
+import {
+  ADDRESS_HASH,
+  alphBalanceQuery,
+  balancesAllQuery,
+  balancesByListingQuery,
+  bumpServerBalance,
+  cleanUpQueryClient,
+  confirmedTx,
+  detectNewTxThroughGate,
+  ftsQuery,
+  getAlphL0BalanceMarker,
+  getAlphTotalBalanceMarker,
+  getListedFtsMarker,
+  getState,
+  installMockExplorer,
+  MockExplorer,
+  NETWORK_ID,
+  observe,
+  seedConsumersFirst,
+  seedDependenciesFirst,
+  seedGate,
+  tokensBalanceQuery,
+  tokensByTypeQuery,
+  trackFetchStarts,
+  trackSubscription,
+  txCountQuery
+} from './invalidationTestHarness'
+
+let mockExplorer: MockExplorer
+
+beforeEach(() => {
+  mockExplorer = installMockExplorer()
+})
+
+afterEach(async () => {
+  await cleanUpQueryClient()
+  vi.restoreAllMocks()
+})
+
+describe('invalidation cascade on new tx detection', () => {
+  it('refetches every active level exactly once and recomputes derived levels from fresh dependencies', async () => {
+    await seedGate()
+    await seedDependenciesFirst()
+
+    const observedQueries = [
+      alphBalanceQuery(),
+      tokensBalanceQuery(),
+      txCountQuery(),
+      balancesAllQuery(),
+      balancesByListingQuery(),
+      tokensByTypeQuery(),
+      ftsQuery()
+    ]
+    observedQueries.forEach(observe)
+
+    const fetchStarts = trackFetchStarts()
+
+    bumpServerBalance(mockExplorer, '2000')
+    await detectNewTxThroughGate(mockExplorer, 'tx-2')
+
+    for (const query of observedQueries) {
+      expect(fetchStarts.of(query), `fetch starts of ${JSON.stringify(query.queryKey)}`).toBe(1)
+      expect(getState(query).isInvalidated).toBe(false)
+      expect(getState(query).status).toBe('success')
+    }
+
+    expect(mockExplorer.mocks.alphBalance).toHaveBeenCalledTimes(2)
+    expect(mockExplorer.mocks.tokensBalance).toHaveBeenCalledTimes(2)
+    expect(mockExplorer.mocks.txCount).toHaveBeenCalledTimes(2)
+
+    expect(getAlphTotalBalanceMarker(getState(balancesAllQuery()).data)).toBe('2000')
+    expect(getListedFtsMarker(getState(balancesByListingQuery()).data)).toBe('2000')
+    expect(getListedFtsMarker(getState(tokensByTypeQuery()).data)).toBe('2000')
+    expect(getListedFtsMarker(getState(ftsQuery()).data)).toBe('2000')
+  })
+
+  it('only marks inactive levels invalidated, and the next mount recomputes them from fresh dependencies bottom-up', async () => {
+    await seedGate()
+    await seedDependenciesFirst()
+
+    const derivedQueries = [balancesAllQuery(), balancesByListingQuery(), tokensByTypeQuery(), ftsQuery()]
+
+    bumpServerBalance(mockExplorer, '2000')
+    await detectNewTxThroughGate(mockExplorer, 'tx-2')
+
+    for (const query of [alphBalanceQuery(), tokensBalanceQuery(), txCountQuery(), ...derivedQueries]) {
+      expect(getState(query).isInvalidated).toBe(true)
+      expect(getState(query).dataUpdateCount).toBe(1)
+    }
+    expect(getAlphTotalBalanceMarker(getState(balancesAllQuery()).data)).toBe('1000')
+    expect(mockExplorer.mocks.alphBalance).toHaveBeenCalledTimes(1)
+
+    const observer = observe(ftsQuery())
+    await vi.waitFor(() => expect(observer.getCurrentResult().isFetching).toBe(false))
+
+    expect(getListedFtsMarker(getState(ftsQuery()).data)).toBe('2000')
+    for (const query of derivedQueries) {
+      expect(getState(query).isInvalidated).toBe(false)
+      expect(getState(query).dataUpdateCount).toBe(2)
+    }
+    expect(mockExplorer.mocks.alphBalance).toHaveBeenCalledTimes(2)
+    expect(mockExplorer.mocks.tokensBalance).toHaveBeenCalledTimes(2)
+
+    // Nothing consumes the tx count query, so it stays invalidated until its own next mount
+    expect(getState(txCountQuery()).isInvalidated).toBe(true)
+  })
+
+  it('recomputes an active derived level from fresh data even when the intermediate levels are inactive', async () => {
+    await seedGate()
+    await seedDependenciesFirst()
+
+    observe(alphBalanceQuery())
+    observe(tokensByTypeQuery())
+
+    const fetchStarts = trackFetchStarts()
+
+    bumpServerBalance(mockExplorer, '2000')
+    await detectNewTxThroughGate(mockExplorer, 'tx-2')
+
+    expect(getListedFtsMarker(getState(tokensByTypeQuery()).data)).toBe('2000')
+    expect(fetchStarts.of(tokensByTypeQuery())).toBe(1)
+
+    for (const query of [balancesAllQuery(), balancesByListingQuery()]) {
+      expect(getState(query).isInvalidated).toBe(false)
+      expect(getState(query).dataUpdateCount).toBe(2)
+      expect(fetchStarts.of(query)).toBe(1)
+    }
+    expect(getAlphTotalBalanceMarker(getState(balancesAllQuery()).data)).toBe('2000')
+
+    expect(mockExplorer.mocks.alphBalance).toHaveBeenCalledTimes(2)
+    expect(mockExplorer.mocks.tokensBalance).toHaveBeenCalledTimes(2)
+    expect(fetchStarts.of(alphBalanceQuery())).toBe(1)
+  })
+
+  // Derived queries create their dependency cache entries lazily via fetchQuery inside their queryFns, so consumers
+  // often precede their dependencies in the query cache. The per-level ordering keeps the cascade correct regardless
+  // of cache insertion order; see invalidationSinglePass.test.ts for how an unordered pass breaks in this setup.
+  it('recomputes correctly even when consumers entered the cache before their dependencies', async () => {
+    await seedGate()
+    await seedConsumersFirst(ftsQuery())
+
+    observe(ftsQuery())
+    observe(alphBalanceQuery())
+
+    bumpServerBalance(mockExplorer, '2000')
+    await detectNewTxThroughGate(mockExplorer, 'tx-2')
+
+    expect(getListedFtsMarker(getState(ftsQuery()).data)).toBe('2000')
+    expect(getState(ftsQuery()).isInvalidated).toBe(false)
+    expect(getState(ftsQuery()).fetchStatus).toBe('idle')
+    expect(getAlphL0BalanceMarker(getState(alphBalanceQuery()).data)).toBe('2000')
+  })
+
+  it('retries a flaky level-0 fetch during the cascade and still recomputes derived levels from the fresh result', async () => {
+    await seedGate()
+    await seedDependenciesFirst()
+
+    const observedQueries = [alphBalanceQuery(), ftsQuery()]
+    observedQueries.forEach(observe)
+
+    bumpServerBalance(mockExplorer, '2000')
+    mockExplorer.mocks.alphBalance.mockRejectedValueOnce(new Error('Too many requests - Status code: 429'))
+
+    await detectNewTxThroughGate(mockExplorer, 'tx-2')
+
+    expect(getState(alphBalanceQuery()).status).toBe('success')
+    expect(getAlphTotalBalanceMarker(getState(balancesAllQuery()).data)).toBe('2000')
+    expect(getListedFtsMarker(getState(ftsQuery()).data)).toBe('2000')
+    expect(mockExplorer.mocks.alphBalance).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('gate first-data skip', () => {
+  it('does not fire the cascade when neither the gate cache nor the ALPH balance data exists', async () => {
+    queryClient.setQueryData(balancesAllQuery().queryKey, {
+      addressHash: ADDRESS_HASH,
+      balances: []
+    })
+
+    await seedGate()
+
+    expect(getState(balancesAllQuery()).isInvalidated).toBe(false)
+
+    await detectNewTxThroughGate(mockExplorer, 'tx-2')
+
+    expect(getState(balancesAllQuery()).isInvalidated).toBe(true)
+  })
+
+  it('fires the cascade on the first gate data when ALPH balance data already exists', async () => {
+    await queryClient.fetchQuery(alphBalanceQuery())
+
+    expect(getState(alphBalanceQuery()).isInvalidated).toBe(false)
+
+    await seedGate()
+
+    expect(getState(alphBalanceQuery()).isInvalidated).toBe(true)
+  })
+})
+
+describe('invalidateWalletQueries', () => {
+  const walletQuery = () =>
+    walletTransactionsInfiniteQuery({ addressHashes: [ADDRESS_HASH], networkId: NETWORK_ID, isExplorerOnline: true })
+
+  const seedThreePagesOnServer = () => {
+    mockExplorer.state.transactionsByPage = {
+      1: [confirmedTx('tx-page-1')],
+      2: [confirmedTx('tx-page-2')],
+      3: [confirmedTx('tx-page-3')]
+    }
+  }
+
+  it('trims the cached pages to the first one before invalidating', async () => {
+    seedThreePagesOnServer()
+    await queryClient.fetchInfiniteQuery({ ...walletQuery(), pages: 3 })
+
+    const stateBefore = getState(walletQuery())
+    expect((stateBefore.data as InfiniteData<unknown>).pages).toHaveLength(3)
+
+    const transactionsCallsBefore = mockExplorer.mocks.transactions.mock.calls.length
+
+    await invalidateWalletQueries()
+
+    const stateAfter = getState(walletQuery())
+    expect((stateAfter.data as InfiniteData<unknown>).pages).toHaveLength(1)
+    expect((stateAfter.data as InfiniteData<unknown>).pageParams).toHaveLength(1)
+    expect(stateAfter.isInvalidated).toBe(true)
+    expect(mockExplorer.mocks.transactions.mock.calls.length).toBe(transactionsCallsBefore)
+  })
+
+  it('refetches only the first page for an active observer, not every loaded page', async () => {
+    seedThreePagesOnServer()
+
+    const observer = new InfiniteQueryObserver(queryClient, walletQuery())
+    trackSubscription(observer.subscribe(() => {}))
+    await vi.waitFor(() => expect(observer.getCurrentResult().isFetching).toBe(false))
+    await observer.fetchNextPage()
+    await observer.fetchNextPage()
+
+    expect((getState(walletQuery()).data as InfiniteData<unknown>).pages).toHaveLength(3)
+
+    mockExplorer.state.transactionsByPage = { ...mockExplorer.state.transactionsByPage, 1: [confirmedTx('tx-new')] }
+    const transactionsCallsBefore = mockExplorer.mocks.transactions.mock.calls.length
+
+    await invalidateWalletQueries()
+
+    expect(mockExplorer.mocks.transactions.mock.calls.length).toBe(transactionsCallsBefore + 1)
+
+    const data = getState(walletQuery()).data as InfiniteData<{ pageTransactions: Array<{ hash: string }> }>
+    expect(data.pages).toHaveLength(1)
+    expect(data.pages[0].pageTransactions.map(({ hash }) => hash)).toEqual(['tx-new'])
+    expect(getState(walletQuery()).isInvalidated).toBe(false)
+  })
+})

--- a/packages/shared-react/test/invalidationSinglePass.test.ts
+++ b/packages/shared-react/test/invalidationSinglePass.test.ts
@@ -1,0 +1,233 @@
+import { AddressHash } from '@alephium/shared/types'
+import { CancelledError } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { queryClient } from '../src/api/queryClient'
+import { invalidateAddressQueries } from '../src/api/queryInvalidation'
+import {
+  ADDRESS_HASH,
+  alphBalanceQuery,
+  balancesAllQuery,
+  balancesByListingQuery,
+  bumpServerBalance,
+  cleanUpQueryClient,
+  ftsQuery,
+  getAlphL0BalanceMarker,
+  getAlphTotalBalanceMarker,
+  getListedFtsMarker,
+  getState,
+  installMockExplorer,
+  MockExplorer,
+  observe,
+  seedConsumersFirst,
+  seedDependenciesFirst,
+  tokensBalanceQuery,
+  tokensByTypeQuery,
+  txCountQuery
+} from './invalidationTestHarness'
+
+// The proposed replacement for the ordered cascade: one invalidateQueries call covering all levels at once
+const invalidateAddressQueriesSinglePass = (addressHash: AddressHash) =>
+  queryClient.invalidateQueries({
+    predicate: (query) =>
+      query.queryKey[0] === 'address' &&
+      query.queryKey[1] === addressHash &&
+      typeof query.queryKey[2] === 'string' &&
+      query.queryKey[2].startsWith('level:')
+  })
+
+let mockExplorer: MockExplorer
+
+beforeEach(() => {
+  mockExplorer = installMockExplorer()
+})
+
+afterEach(async () => {
+  await cleanUpQueryClient()
+  vi.restoreAllMocks()
+})
+
+describe('single-pass invalidation when dependencies entered the cache before their consumers', () => {
+  it('converges like the cascade: refetches initiated bottom-up deduplicate into fresh results', async () => {
+    await seedDependenciesFirst()
+
+    const observedQueries = [
+      alphBalanceQuery(),
+      tokensBalanceQuery(),
+      txCountQuery(),
+      balancesAllQuery(),
+      balancesByListingQuery(),
+      tokensByTypeQuery(),
+      ftsQuery()
+    ]
+    observedQueries.forEach(observe)
+
+    bumpServerBalance(mockExplorer, '2000')
+    await invalidateAddressQueriesSinglePass(ADDRESS_HASH)
+
+    for (const query of observedQueries) {
+      expect(getState(query).isInvalidated).toBe(false)
+      expect(getState(query).status).toBe('success')
+    }
+    expect(mockExplorer.mocks.alphBalance).toHaveBeenCalledTimes(2)
+    expect(mockExplorer.mocks.tokensBalance).toHaveBeenCalledTimes(2)
+    expect(getAlphTotalBalanceMarker(getState(balancesAllQuery()).data)).toBe('2000')
+    expect(getListedFtsMarker(getState(ftsQuery()).data)).toBe('2000')
+  })
+})
+
+describe('single-pass invalidation when a consumer entered the cache before its dependencies', () => {
+  // Derived queries create their dependency cache entries lazily via fetchQuery inside their queryFns, so whenever a
+  // derived hook mounts before any component observes level 0 directly, the consumer precedes its dependencies in the
+  // query cache. refetchQueries walks the cache in insertion order, so it starts the consumer's refetch first. The
+  // consumer's queryFn synchronously starts its dependency's fetch through fetchQuery, and when refetchQueries then
+  // reaches the dependency itself, cancelRefetch (default true) silently cancels that exact in-flight fetch out from
+  // under the consumer. The consumer's queryFn rejects with a silent CancelledError and never recovers.
+  it('leaves the consumer with stale data, still marked invalidated, and a poisoned fetch promise', async () => {
+    await seedConsumersFirst(balancesAllQuery())
+
+    observe(balancesAllQuery())
+    observe(alphBalanceQuery())
+
+    bumpServerBalance(mockExplorer, '2000')
+    await invalidateAddressQueriesSinglePass(ADDRESS_HASH)
+
+    expect(getAlphL0BalanceMarker(getState(alphBalanceQuery()).data)).toBe('2000')
+    expect(getState(alphBalanceQuery()).isInvalidated).toBe(false)
+
+    const consumerState = getState(balancesAllQuery())
+    expect(getAlphTotalBalanceMarker(consumerState.data)).toBe('1000')
+    expect(consumerState.isInvalidated).toBe(true)
+    expect(consumerState.fetchStatus).toBe('fetching')
+
+    // The CancelledError is silent, so the failure surfaces neither as an error state nor through observers
+    expect(consumerState.status).toBe('success')
+    expect(consumerState.error).toBeNull()
+
+    // The consumer's queryFn was aborted before it could pull its second dependency
+    expect(getState(tokensBalanceQuery()).isInvalidated).toBe(true)
+    expect(getState(tokensBalanceQuery()).dataUpdateCount).toBe(1)
+
+    // The rejected retryer promise is returned to any subsequent fetchQuery, so even manual fetching cannot recover
+    await expect(queryClient.fetchQuery(balancesAllQuery())).rejects.toThrow(CancelledError)
+    expect(getAlphTotalBalanceMarker(getState(balancesAllQuery()).data)).toBe('1000')
+  })
+
+  it('cancels the whole dependency chain when the consumer is at the top and intermediates are inactive', async () => {
+    await seedConsumersFirst(ftsQuery())
+
+    observe(ftsQuery())
+    observe(alphBalanceQuery())
+
+    bumpServerBalance(mockExplorer, '2000')
+    await invalidateAddressQueriesSinglePass(ADDRESS_HASH)
+
+    expect(getState(alphBalanceQuery()).isInvalidated).toBe(false)
+
+    expect(getListedFtsMarker(getState(ftsQuery()).data)).toBe('1000')
+    expect(getState(ftsQuery()).isInvalidated).toBe(true)
+
+    for (const query of [tokensByTypeQuery(), balancesByListingQuery(), balancesAllQuery()]) {
+      expect(getState(query).isInvalidated).toBe(true)
+      expect(getState(query).dataUpdateCount).toBe(1)
+    }
+  })
+
+  it('is healed by the ordered cascade, which refetches each level only after its dependencies completed', async () => {
+    await seedConsumersFirst(balancesAllQuery())
+
+    observe(balancesAllQuery())
+    observe(alphBalanceQuery())
+
+    bumpServerBalance(mockExplorer, '2000')
+    await invalidateAddressQueriesSinglePass(ADDRESS_HASH)
+
+    expect(getAlphTotalBalanceMarker(getState(balancesAllQuery()).data)).toBe('1000')
+
+    await invalidateAddressQueries(ADDRESS_HASH)
+
+    const consumerState = getState(balancesAllQuery())
+    expect(getAlphTotalBalanceMarker(consumerState.data)).toBe('2000')
+    expect(consumerState.isInvalidated).toBe(false)
+    expect(consumerState.fetchStatus).toBe('idle')
+  })
+
+  it('does not diverge from the cascade in this order: the ordered cascade recomputes everything correctly', async () => {
+    await seedConsumersFirst(ftsQuery())
+
+    observe(ftsQuery())
+    observe(alphBalanceQuery())
+
+    bumpServerBalance(mockExplorer, '2000')
+    await invalidateAddressQueries(ADDRESS_HASH)
+
+    expect(getListedFtsMarker(getState(ftsQuery()).data)).toBe('2000')
+    expect(getState(ftsQuery()).isInvalidated).toBe(false)
+    expect(getAlphTotalBalanceMarker(getState(balancesAllQuery()).data)).toBe('2000')
+    expect(getState(alphBalanceQuery()).isInvalidated).toBe(false)
+  })
+})
+
+describe('shared semantics of both variants', () => {
+  it('fetchQuery refetches an invalidated inactive dependency despite staleTime Infinity', async () => {
+    await seedDependenciesFirst()
+
+    bumpServerBalance(mockExplorer, '2000')
+    await invalidateAddressQueriesSinglePass(ADDRESS_HASH)
+
+    for (const query of [alphBalanceQuery(), balancesAllQuery(), ftsQuery()]) {
+      expect(getState(query).isInvalidated).toBe(true)
+      expect(getState(query).dataUpdateCount).toBe(1)
+    }
+
+    const result = await queryClient.fetchQuery(ftsQuery())
+
+    expect(getListedFtsMarker(result)).toBe('2000')
+    expect(mockExplorer.mocks.alphBalance).toHaveBeenCalledTimes(2)
+    expect(getState(balancesAllQuery()).isInvalidated).toBe(false)
+    expect(getAlphTotalBalanceMarker(getState(balancesAllQuery()).data)).toBe('2000')
+  })
+
+  it('retries a flaky level-0 fetch under the single pass exactly like under the cascade', async () => {
+    await seedDependenciesFirst()
+
+    const observedQueries = [alphBalanceQuery(), tokensBalanceQuery(), balancesAllQuery(), ftsQuery()]
+    observedQueries.forEach(observe)
+
+    bumpServerBalance(mockExplorer, '2000')
+    mockExplorer.mocks.alphBalance.mockRejectedValueOnce(new Error('Too many requests - Status code: 429'))
+
+    await invalidateAddressQueriesSinglePass(ADDRESS_HASH)
+
+    expect(getState(alphBalanceQuery()).status).toBe('success')
+    expect(getAlphTotalBalanceMarker(getState(balancesAllQuery()).data)).toBe('2000')
+    expect(getListedFtsMarker(getState(ftsQuery()).data)).toBe('2000')
+    expect(mockExplorer.mocks.alphBalance).toHaveBeenCalledTimes(3)
+  })
+
+  it('serves pre-invalidation data when a dependency fetch was already in flight, under both variants', async () => {
+    await seedDependenciesFirst()
+
+    let resolveInFlightFetch: (value: { balance: string; lockedBalance: string }) => void = () => undefined
+    mockExplorer.mocks.alphBalance.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveInFlightFetch = resolve))
+    )
+
+    const inFlightFetch = queryClient.fetchQuery({ ...alphBalanceQuery(), staleTime: 0 })
+
+    bumpServerBalance(mockExplorer, '2000')
+    await invalidateAddressQueries(ADDRESS_HASH)
+
+    expect(getState(alphBalanceQuery()).isInvalidated).toBe(true)
+
+    resolveInFlightFetch({ balance: '1000', lockedBalance: '0' })
+    await inFlightFetch
+
+    // The success of the pre-invalidation fetch clears the invalidation flag with pre-invalidation data
+    expect(getState(alphBalanceQuery()).isInvalidated).toBe(false)
+
+    const result = await queryClient.fetchQuery(balancesAllQuery())
+
+    expect(getAlphTotalBalanceMarker(result)).toBe('1000')
+  })
+})

--- a/packages/shared-react/test/invalidationTestHarness.ts
+++ b/packages/shared-react/test/invalidationTestHarness.ts
@@ -1,0 +1,204 @@
+import { throttledClient } from '@alephium/shared/api'
+import { AddressHash } from '@alephium/shared/types'
+import { ALPH } from '@alephium/token-list'
+import { ExplorerProvider, NodeProvider } from '@alephium/web3'
+import { QueryObserver } from '@tanstack/react-query'
+import { expect, vi } from 'vitest'
+
+import {
+  addressAlphBalancesQuery,
+  addressBalancesByListingQuery,
+  addressBalancesQuery,
+  addressFtsQuery,
+  addressTokensBalancesQuery,
+  addressTokensByTypeQuery
+} from '../src/api/queries/addressQueries'
+import { addressLatestTransactionQuery, addressTransactionsCountQuery } from '../src/api/queries/transactionQueries'
+import { queryClient } from '../src/api/queryClient'
+
+export const ADDRESS_HASH: AddressHash = 'test-address'
+
+// Devnet resolves the token list locally, keeping the mocked network surface minimal
+export const NETWORK_ID = 4
+
+const addressProps = { addressHash: ADDRESS_HASH, networkId: NETWORK_ID, isNodeOnline: true }
+const explorerProps = { addressHash: ADDRESS_HASH, networkId: NETWORK_ID, isExplorerOnline: true }
+
+export const gateQuery = () => addressLatestTransactionQuery(explorerProps)
+export const alphBalanceQuery = () => addressAlphBalancesQuery(addressProps)
+export const tokensBalanceQuery = () => addressTokensBalancesQuery(addressProps)
+export const txCountQuery = () => addressTransactionsCountQuery(explorerProps)
+export const balancesAllQuery = () => addressBalancesQuery(addressProps)
+export const balancesByListingQuery = () => addressBalancesByListingQuery(addressProps)
+export const tokensByTypeQuery = () => addressTokensByTypeQuery(addressProps)
+export const ftsQuery = () => addressFtsQuery(addressProps)
+
+interface ConfirmedTx {
+  hash: string
+  blockHash: string
+  timestamp: number
+  inputs: never[]
+  outputs: never[]
+}
+
+export const confirmedTx = (hash: string): ConfirmedTx => ({
+  hash,
+  blockHash: `block-of-${hash}`,
+  timestamp: 1,
+  inputs: [],
+  outputs: []
+})
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+export const installMockExplorer = () => {
+  const state = {
+    latestTxHash: 'tx-1',
+    alphBalance: { balance: '1000', lockedBalance: '0' },
+    totalTransactions: 1,
+    transactionsByPage: { 1: [confirmedTx('tx-1')] } as Record<number, ConfirmedTx[]>
+  }
+
+  const mocks = {
+    latestTx: vi.fn(async () => {
+      await tick()
+      return { hash: state.latestTxHash, timestamp: 1 }
+    }),
+    alphBalance: vi.fn(async () => {
+      await tick()
+      return { ...state.alphBalance }
+    }),
+    tokensBalance: vi.fn(async () => {
+      await tick()
+      return []
+    }),
+    txCount: vi.fn(async () => {
+      await tick()
+      return state.totalTransactions
+    }),
+    transactions: vi.fn(async (_addressHash: string, { page }: { page: number }) => {
+      await tick()
+      return state.transactionsByPage[page] ?? []
+    })
+  }
+
+  const explorer = {
+    addresses: {
+      getAddressesAddressLatestTransaction: mocks.latestTx,
+      getAddressesAddressBalance: mocks.alphBalance,
+      getAddressesAddressTokensBalance: mocks.tokensBalance,
+      getAddressesAddressTotalTransactions: mocks.txCount,
+      getAddressesAddressTransactions: mocks.transactions
+    }
+  }
+
+  const node = {
+    addresses: {
+      getAddressesAddressBalance: vi.fn(async () => {
+        throw new Error('The node fallback endpoint should not be reached in these tests')
+      })
+    }
+  }
+
+  vi.spyOn(throttledClient, 'explorer', 'get').mockReturnValue(explorer as unknown as ExplorerProvider)
+  vi.spyOn(throttledClient, 'node', 'get').mockReturnValue(node as unknown as NodeProvider)
+
+  return { state, mocks }
+}
+
+export type MockExplorer = ReturnType<typeof installMockExplorer>
+
+const subscriptions: Array<() => void> = []
+
+// Mirrors useQuery mounting: a subscribed QueryObserver makes the query active
+export const observe = <TOptions extends { queryKey: readonly unknown[] }>(options: TOptions) => {
+  const observer = new QueryObserver(queryClient, queryClient.defaultQueryOptions(options as never))
+
+  subscriptions.push(observer.subscribe(() => {}))
+
+  return observer
+}
+
+export const trackSubscription = (unsubscribe: () => void) => {
+  subscriptions.push(unsubscribe)
+}
+
+export const cleanUpQueryClient = async () => {
+  subscriptions.splice(0).forEach((unsubscribe) => unsubscribe())
+  await queryClient.cancelQueries()
+  queryClient.clear()
+}
+
+export const getState = ({ queryKey }: { queryKey: readonly unknown[] }) => {
+  const state = queryClient.getQueryState(queryKey as unknown[])
+
+  expect(state).toBeDefined()
+
+  return state as NonNullable<typeof state>
+}
+
+// Counts 'fetch' dispatches per query, i.e. actual queryFn executions started (deduplicated calls don't dispatch)
+export const trackFetchStarts = () => {
+  const counts = new Map<string, number>()
+
+  const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+    if (event.type === 'updated' && event.action.type === 'fetch') {
+      counts.set(event.query.queryHash, (counts.get(event.query.queryHash) ?? 0) + 1)
+    }
+  })
+
+  trackSubscription(unsubscribe)
+
+  return {
+    of: ({ queryKey }: { queryKey: readonly unknown[] }) => {
+      const query = queryClient.getQueryCache().find({ queryKey: queryKey as unknown[] })
+
+      return query ? counts.get(query.queryHash) ?? 0 : 0
+    }
+  }
+}
+
+// The gate skips the cascade on its very first data (cold cache), making it a safe way to seed its cache
+export const seedGate = async () => {
+  await queryClient.fetchQuery(gateQuery())
+}
+
+// Creates cache entries bottom-up: dependencies enter the query cache before the queries that consume them
+export const seedDependenciesFirst = async () => {
+  await queryClient.fetchQuery(alphBalanceQuery())
+  await queryClient.fetchQuery(tokensBalanceQuery())
+  await queryClient.fetchQuery(txCountQuery())
+  await queryClient.fetchQuery(balancesAllQuery())
+  await queryClient.fetchQuery(balancesByListingQuery())
+  await queryClient.fetchQuery(tokensByTypeQuery())
+  await queryClient.fetchQuery(ftsQuery())
+}
+
+// Creates cache entries top-down, the natural order when only derived hooks mount: each queryFn lazily creates its
+// dependencies via fetchQuery, so consumers enter the query cache before their dependencies
+export const seedConsumersFirst = async (topLevelOptions: { queryKey: readonly unknown[] } = ftsQuery()) => {
+  await queryClient.fetchQuery(topLevelOptions as never)
+}
+
+export const detectNewTxThroughGate = async (mockExplorer: MockExplorer, newTxHash: string) => {
+  mockExplorer.state.latestTxHash = newTxHash
+
+  await queryClient.refetchQueries({ queryKey: gateQuery().queryKey })
+}
+
+export const bumpServerBalance = (mockExplorer: MockExplorer, balance: string) => {
+  mockExplorer.state.alphBalance = { balance, lockedBalance: '0' }
+}
+
+export const getAlphL0BalanceMarker = (data: unknown): string | undefined =>
+  (data as { balances?: { totalBalance: string } })?.balances?.totalBalance
+
+export const getAlphTotalBalanceMarker = (data: unknown): string | undefined => {
+  const balances = (data as { balances?: Array<{ id: string; totalBalance: string }> })?.balances
+
+  return Array.isArray(balances) ? balances.find(({ id }) => id === ALPH.id)?.totalBalance : undefined
+}
+
+export const getListedFtsMarker = (data: unknown): string | undefined =>
+  (data as { listedFts?: Array<{ id: string; totalBalance: string }> })?.listedFts?.find(({ id }) => id === ALPH.id)
+    ?.totalBalance


### PR DESCRIPTION
Stacked on #1674. Tests only, plus one comment. Answers "is the ordered level:N cascade actually necessary?" with evidence: yes.

A single unordered `invalidateQueries` breaks because `refetchQueries` uses `cancelRefetch: true` and iterates in cache insertion order: a consumer's refetch starts its dependency's fetch via `fetchQuery`, then the loop reaches the dependency's own entry and silently cancels the fetch the consumer is awaiting, leaving stale data with `fetchStatus` stuck on fetching. That is #1417, which the cascade fixed in #1422.

17 tests pin the current semantics (exactly-once ordered refetch with fresh dependencies, inactive-level behavior, the first-data skip, #1475 first-page trimming) and document the single-pass failure mode. The vague ordering comment is replaced with the mechanism.
