### PR TITLE
Fix wallet worth flashing a wrong value while loading

### DIFF
--- a/.changeset/wallet-worth-flicker.md
+++ b/.changeset/wallet-worth-flicker.md
@@ -1,0 +1,6 @@
+---
+'alephium-desktop-wallet': patch
+'@alephium/mobile-wallet': patch
+---
+
+Fix wallet worth flashing a wrong value while loading

--- a/packages/shared-react/package.json
+++ b/packages/shared-react/package.json
@@ -39,8 +39,11 @@
     "@reduxjs/toolkit": "^1.9.1",
     "@tanstack/react-query": "^5.81.2",
     "@tanstack/react-query-persist-client": "^5.81.2",
+    "@testing-library/react": "^14.0.0",
     "@types/react": "~19.1.10",
+    "happy-dom": "^20.8.9",
     "react": "^19.2.0",
+    "react-dom": "^19.2.0",
     "react-redux": "^9.2.0",
     "typescript": "~5.9.2",
     "vitest": "^4.0.0"

--- a/packages/shared-react/src/api/apiDataHooks/utils/useFetchListedFtsWorth.ts
+++ b/packages/shared-react/src/api/apiDataHooks/utils/useFetchListedFtsWorth.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 
 import { useFetchTokenPrices } from '../../../api/apiDataHooks/market/useFetchTokenPrices'
 import { getTokenWorth } from '../../../api/apiDataHooks/utils/getTokenWorth'
+import { TokenPrice } from '../../../api/queries/priceQueries'
 
 export const useFetchListedFtsWorth = (listedFts: (ListedFT & ApiBalances)[]) => {
   const { data: tokenPrices, isLoading: isLoadingTokenPrices, error } = useFetchTokenPrices()
@@ -15,6 +16,13 @@ export const useFetchListedFtsWorth = (listedFts: (ListedFT & ApiBalances)[]) =>
   return {
     data: worth,
     error,
-    isLoading: isLoadingTokenPrices
+    isLoading: isLoadingTokenPrices || (!error && hasMissingTokenPrices(listedFts, tokenPrices))
   }
 }
+
+// The tokenPrices query key omits the symbols on purpose, so while token discovery is still growing the symbol set the
+// cached price array can be a settled response for an older, smaller set. Computing worth from it flashes a wrong
+// value, so incomplete coverage must count as loading. An entry with a 0 or null price still counts as covered since
+// the API returns one entry per requested symbol.
+export const hasMissingTokenPrices = (listedFts: Pick<ListedFT, 'symbol'>[], tokenPrices?: TokenPrice[]) =>
+  listedFts.some(({ symbol }) => !tokenPrices?.some((tokenPrice) => tokenPrice.symbol === symbol))

--- a/packages/shared-react/src/api/queries/priceQueries.ts
+++ b/packages/shared-react/src/api/queries/priceQueries.ts
@@ -20,6 +20,12 @@ export type TokenPrice = {
 
 export const tokensPriceQuery = ({ symbols, currency, networkId, skip }: TokensPriceQueryProps) =>
   queryOptions<TokenPrice[]>({
+    // The symbols are intentionally left out of the query key so every price fetch shares one cache slot per
+    // (currency, networkId). That buys three things: the persisted cache is restored on launch regardless of which
+    // tokens have been discovered yet (no loader on every cold start), a growing symbol set is a cache hit refetched in
+    // place rather than a miss that reloads, and invalidateTokenPrices() can target the slot by prefix after a tx. The
+    // trade-off is that the cached array can lag the current symbol set, which is why worth loading is derived from data
+    // completeness in useFetchListedFtsWorth instead of from this query's settled state.
     queryKey: ['tokenPrices', 'currentPrice', { currency, networkId }],
     refetchInterval: PRICES_REFRESH_INTERVAL,
     // When the user changes currency settings we don't want to keep the previous cache for too long.
@@ -30,7 +36,10 @@ export const tokensPriceQuery = ({ symbols, currency, networkId, skip }: TokensP
           try {
             const prices = await throttledClient.explorer.market.postMarketPrices({ currency }, symbols)
 
-            return prices.map((price, i) => ({ price, symbol: symbols[i] }))
+            // Map over the requested symbols, not the response, so we always return one entry per symbol. Worth loading
+            // in useFetchListedFtsWorth treats a symbol with no entry as "still loading", so a short or reordered
+            // response would otherwise leave a held token uncovered and deadlock its skeleton.
+            return symbols.map((symbol, i) => ({ price: prices[i] ?? 0, symbol }))
           } catch (e) {
             if (is5XXError(e)) {
               const coingeckoIds = symbols.map(symbolToCoingeckoId).filter((id) => id !== '')

--- a/packages/shared-react/test/priceQueries.test.ts
+++ b/packages/shared-react/test/priceQueries.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { TokenPrice, tokensPriceQuery } from '../src/api/queries/priceQueries'
+
+const { postMarketPrices } = vi.hoisted(() => ({ postMarketPrices: vi.fn() }))
+
+vi.mock('@alephium/shared/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@alephium/shared/api')>()),
+  throttledClient: { explorer: { market: { postMarketPrices } } }
+}))
+
+const runQueryFn = (symbols: string[]) => {
+  const { queryFn } = tokensPriceQuery({ symbols, currency: 'chf', networkId: 0 })
+
+  return (queryFn as unknown as () => Promise<TokenPrice[]>)()
+}
+
+describe('tokensPriceQuery queryFn', () => {
+  afterEach(() => {
+    postMarketPrices.mockReset()
+  })
+
+  it('returns one entry per requested symbol, labelled by symbol', async () => {
+    postMarketPrices.mockResolvedValue([10, 1, 0])
+
+    await expect(runQueryFn(['ALPH', 'USDC', 'ZRO'])).resolves.toEqual([
+      { symbol: 'ALPH', price: 10 },
+      { symbol: 'USDC', price: 1 },
+      { symbol: 'ZRO', price: 0 }
+    ])
+  })
+
+  // Guards the coverage invariant useFetchListedFtsWorth relies on: a held token whose price is missing from the
+  // response must still get an entry, otherwise hasMissingTokenPrices would never clear and the worth skeleton deadlocks.
+  it('pads with 0 so every requested symbol stays covered when the response is short', async () => {
+    postMarketPrices.mockResolvedValue([10, 1])
+
+    await expect(runQueryFn(['ALPH', 'USDC', 'ZRO'])).resolves.toEqual([
+      { symbol: 'ALPH', price: 10 },
+      { symbol: 'USDC', price: 1 },
+      { symbol: 'ZRO', price: 0 }
+    ])
+  })
+})

--- a/packages/shared-react/test/useFetchListedFtsWorth.test.ts
+++ b/packages/shared-react/test/useFetchListedFtsWorth.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+
+import { ApiBalances, ListedFT } from '@alephium/shared/types'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createElement, ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { hasMissingTokenPrices, useFetchListedFtsWorth } from '../src/api/apiDataHooks/utils/useFetchListedFtsWorth'
+import { TokenPrice, tokensPriceQuery } from '../src/api/queries/priceQueries'
+
+vi.mock('../src/api/apiDataHooks/wallet/useFetchWalletTokensByType', () => ({
+  useFetchWalletTokensByType: () => ({ data: { listedFts: [] }, isLoading: false })
+}))
+
+vi.mock('../src/network/networkHooks', () => ({
+  useNetworkId: () => 0
+}))
+
+vi.mock('../src/redux', () => ({
+  useSharedSelector: (selector: (state: { sharedSettings: { fiatCurrency: string } }) => unknown) =>
+    selector({ sharedSettings: { fiatCurrency: 'CHF' } })
+}))
+
+const buildListedFt = (symbol: string, totalBalance: string, decimals: number): ListedFT & ApiBalances => ({
+  id: `${symbol}-id`,
+  name: symbol,
+  symbol,
+  decimals,
+  description: '',
+  logoURI: '',
+  totalBalance,
+  lockedBalance: '0',
+  availableBalance: totalBalance
+})
+
+const alph = buildListedFt('ALPH', '2000000000000000000', 18)
+const usdc = buildListedFt('USDC', '5000000', 6)
+const zeroPricedFt = buildListedFt('ZRO', '1000000000000000000', 18)
+
+const prices: TokenPrice[] = [
+  { symbol: 'ALPH', price: 10 },
+  { symbol: 'USDC', price: 1 }
+]
+
+describe('hasMissingTokenPrices', () => {
+  it('returns false when every listed FT has a price entry', () => {
+    expect(hasMissingTokenPrices([alph, usdc], prices)).toBe(false)
+  })
+
+  it('returns false when the price entry of a listed FT is 0', () => {
+    expect(hasMissingTokenPrices([zeroPricedFt], [{ symbol: 'ZRO', price: 0 }])).toBe(false)
+  })
+
+  it('returns false when the price entry of a listed FT is null', () => {
+    expect(hasMissingTokenPrices([zeroPricedFt], [{ symbol: 'ZRO', price: null as unknown as number }])).toBe(false)
+  })
+
+  it('returns false when there are price entries for tokens that are not listed FTs', () => {
+    expect(hasMissingTokenPrices([alph], prices)).toBe(false)
+  })
+
+  it('returns false when there are no listed FTs', () => {
+    expect(hasMissingTokenPrices([], undefined)).toBe(false)
+    expect(hasMissingTokenPrices([], prices)).toBe(false)
+  })
+
+  it('returns true when a listed FT has no price entry', () => {
+    expect(hasMissingTokenPrices([alph, usdc, zeroPricedFt], prices)).toBe(true)
+  })
+
+  it('returns true when there are listed FTs but no prices at all', () => {
+    expect(hasMissingTokenPrices([alph], undefined)).toBe(true)
+    expect(hasMissingTokenPrices([alph], [])).toBe(true)
+  })
+})
+
+describe('useFetchListedFtsWorth', () => {
+  const priceQueryKey = tokensPriceQuery({ symbols: [], currency: 'chf', networkId: 0 }).queryKey
+
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { enabled: false, retry: false } } })
+  })
+
+  afterEach(() => {
+    queryClient.clear()
+  })
+
+  const renderWorthHook = (initialFts: (ListedFT & ApiBalances)[]) =>
+    renderHook((listedFts: (ListedFT & ApiBalances)[]) => useFetchListedFtsWorth(listedFts), {
+      initialProps: initialFts,
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children)
+    })
+
+  it('is not loading and sums the worth of all listed FTs when prices cover all of them', () => {
+    queryClient.setQueryData(priceQueryKey, [...prices, { symbol: 'ZRO', price: 0 }])
+
+    const { result } = renderWorthHook([alph, usdc, zeroPricedFt])
+
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.data).toBe(25)
+  })
+
+  it('keeps loading when a listed FT is missing from the cached prices', () => {
+    queryClient.setQueryData(priceQueryKey, [{ symbol: 'ALPH', price: 10 }])
+
+    const { result } = renderWorthHook([alph, usdc])
+
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('stops loading with the complete worth once prices cover tokens discovered later', async () => {
+    queryClient.setQueryData(priceQueryKey, [{ symbol: 'ALPH', price: 10 }])
+
+    const { result, rerender } = renderWorthHook([alph])
+
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.data).toBe(20)
+
+    rerender([alph, usdc])
+
+    expect(result.current.isLoading).toBe(true)
+
+    queryClient.setQueryData(priceQueryKey, prices)
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.data).toBe(25)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1060,12 +1060,21 @@ importers:
       '@tanstack/react-query-persist-client':
         specifier: ^5.81.2
         version: 5.81.2(@tanstack/react-query@5.81.2(react@19.2.7))(react@19.2.7)
+      '@testing-library/react':
+        specifier: ^14.0.0
+        version: 14.1.2(@types/react@19.1.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ~19.1.10
         version: 19.1.17
+      happy-dom:
+        specifier: ^20.8.9
+        version: 20.9.0
       react:
         specifier: ^19.2.0
         version: 19.2.7
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.7(react@19.2.7)
       react-redux:
         specifier: ^9.2.0
         version: 9.2.0(@types/react@19.1.17)(react@19.2.7)(redux@5.0.1)


### PR DESCRIPTION
Stacked on #1674. On a cold start the wallet worth briefly flashed a wrong value, went back to the skeleton, then settled. The loading flag is derived from a query set that grows during token discovery, and the price query's key intentionally omits the symbols, so there is a render gap where everything known so far is settled while prices only cover a partial symbol set.

Treat missing price coverage as still loading: a listed token whose symbol has no entry in the cached price array keeps `isLoading` true (an entry with price 0 counts as covered). Address worth shares the hook, so it is fixed too.

Verified with a DOM poller: skeleton -> final value in a single transition (before: skeleton -> wrong value -> skeleton -> final).

