### PR TITLE
Fix permanent fallback caching and query key gaps

### DIFF
--- a/.changeset/clean-keys-restart.md
+++ b/.changeset/clean-keys-restart.md
@@ -1,0 +1,6 @@
+---
+'alephium-desktop-wallet': patch
+'@alephium/mobile-wallet': patch
+---
+
+Reset cached data once to fix stale token metadata

--- a/.changeset/mighty-donkeys-refresh.md
+++ b/.changeset/mighty-donkeys-refresh.md
@@ -1,0 +1,5 @@
+---
+'@alephium/mobile-wallet': patch
+---
+
+Fix reloading of balances with pull-to-refresh

--- a/.changeset/tough-parents-repair.md
+++ b/.changeset/tough-parents-repair.md
@@ -1,0 +1,6 @@
+---
+'alephium-desktop-wallet': patch
+'@alephium/mobile-wallet': patch
+---
+
+Recover token info that failed to load while offline

--- a/apps/desktop-wallet/src/routes/UnlockedWalletRoutes.tsx
+++ b/apps/desktop-wallet/src/routes/UnlockedWalletRoutes.tsx
@@ -1,4 +1,4 @@
-import { ApiContextProvider, useAddressesDataPolling } from '@alephium/shared-react'
+import { ApiContextProvider, useAddressesDataPolling, useRecoverTokenResolutionFallbacks } from '@alephium/shared-react'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Route, Routes, useLocation, useNavigate } from 'react-router-dom'
@@ -19,6 +19,7 @@ const WalletRoutes = () => {
   const activeWalletId = useAppSelector((s) => s.activeWallet.id)
 
   useAddressesDataPolling()
+  useRecoverTokenResolutionFallbacks()
   usePrefetchQueries()
 
   const headerTitles: { [key: string]: string } = {

--- a/apps/mobile-wallet/src/App.tsx
+++ b/apps/mobile-wallet/src/App.tsx
@@ -4,7 +4,8 @@ import {
   ApiContextProvider,
   PersistQueryClientContextProvider,
   useAddressesDataPolling,
-  useInitializeThrottledClient
+  useInitializeThrottledClient,
+  useRecoverTokenResolutionFallbacks
 } from '@alephium/shared-react'
 import { StatusBar } from 'expo-status-bar'
 import { ActivityIndicator, View, ViewProps } from 'react-native'
@@ -92,6 +93,7 @@ const Routes = ({ initialRouteName }: { initialRouteName: keyof RootStackParamLi
   useInitializeThrottledClient()
   usePersistQueryCacheOnBackground()
   useAddressesDataPolling()
+  useRecoverTokenResolutionFallbacks()
 
   return (
     <ApiContextProvider>

--- a/apps/mobile-wallet/src/components/RefreshSpinner.tsx
+++ b/apps/mobile-wallet/src/components/RefreshSpinner.tsx
@@ -1,4 +1,5 @@
-import { queryClient, useUnsortedAddressesHashes } from '@alephium/shared-react'
+import { AddressHash } from '@alephium/shared'
+import { queryClient, useRefreshAddressesBalances, useUnsortedAddressesHashesSet } from '@alephium/shared-react'
 import { useCallback, useState } from 'react'
 import { RefreshControl, RefreshControlProps } from 'react-native'
 import { useTheme } from 'styled-components/native'
@@ -6,37 +7,44 @@ import { useTheme } from 'styled-components/native'
 const RefreshSpinner = (props: Partial<RefreshControlProps>) => {
   const theme = useTheme()
 
-  const { refreshBalances, isFetchingBalances } = useRefreshAddressesBalances()
-  const refreshing = props.refreshing ?? isFetchingBalances
-  const onRefresh = props.onRefresh ?? refreshBalances
+  const { refreshData, isRefreshing } = useRefreshAddressesData()
+  const refreshing = props.refreshing ?? isRefreshing
+  const onRefresh = props.onRefresh ?? refreshData
 
   return <RefreshControl {...props} refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.font.primary} />
 }
 
 export default RefreshSpinner
 
-const useRefreshAddressesBalances = () => {
-  const addressHashes = useUnsortedAddressesHashes()
-  const [isFetchingBalances, setIsFetchingBalances] = useState(false)
+const useRefreshAddressesData = () => {
+  const unsortedAddressesHashesSet = useUnsortedAddressesHashesSet()
+  const { refreshBalances, isFetchingBalances } = useRefreshAddressesBalances()
+  const [isRefreshingData, setIsRefreshingData] = useState(false)
 
-  const refreshBalances = useCallback(async () => {
-    if (isFetchingBalances) return
+  const refreshData = useCallback(async () => {
+    if (isRefreshingData) return
 
-    setIsFetchingBalances(true)
+    setIsRefreshingData(true)
 
     try {
-      await Promise.all(
-        addressHashes.map((addressHash) =>
-          queryClient.invalidateQueries({ queryKey: ['address', addressHash, 'transaction', 'latest'] })
-        )
-      )
+      await queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === 'address' &&
+          query.queryKey[2] === 'transaction' &&
+          query.queryKey[3] === 'latest' &&
+          unsortedAddressesHashesSet.has(query.queryKey[1] as AddressHash)
+      })
+
+      await refreshBalances()
     } finally {
-      setIsFetchingBalances(false)
+      setIsRefreshingData(false)
     }
-  }, [addressHashes, isFetchingBalances])
+  }, [unsortedAddressesHashesSet, isRefreshingData, refreshBalances])
 
   return {
-    refreshBalances,
-    isFetchingBalances
+    refreshData,
+    // The local flag keeps the spinner up between the latest-tx check and the moment the balance queries start
+    // fetching, the shared flag keeps it up until they settle.
+    isRefreshing: isRefreshingData || isFetchingBalances
   }
 }

--- a/apps/mobile-wallet/src/features/ecosystem/dAppMessaging/DappBrowserContext.tsx
+++ b/apps/mobile-wallet/src/features/ecosystem/dAppMessaging/DappBrowserContext.tsx
@@ -252,7 +252,9 @@ export const DappBrowserContextProvider = ({ children, dAppName }: DappBrowserCo
                 // address be?
 
                 const publicKey = await signer.getPublicKey(params.signerAddress)
-                const unsignedData = await queryClient.fetchQuery(buildTransferTxQuery({ params, publicKey }))
+                const unsignedData = await queryClient.fetchQuery(
+                  buildTransferTxQuery({ params, publicKey, networkId })
+                )
 
                 dispatch(
                   openModal({
@@ -280,7 +282,9 @@ export const DappBrowserContextProvider = ({ children, dAppName }: DappBrowserCo
 
               case 'EXECUTE_SCRIPT': {
                 const publicKey = await signer.getPublicKey(params.signerAddress)
-                const unsignedData = await queryClient.fetchQuery(buildExecuteScriptTxQuery({ params, publicKey }))
+                const unsignedData = await queryClient.fetchQuery(
+                  buildExecuteScriptTxQuery({ params, publicKey, networkId })
+                )
 
                 dispatch(
                   openModal({
@@ -307,7 +311,9 @@ export const DappBrowserContextProvider = ({ children, dAppName }: DappBrowserCo
               }
               case 'DEPLOY_CONTRACT': {
                 const publicKey = await signer.getPublicKey(params.signerAddress)
-                const unsignedData = await queryClient.fetchQuery(buildDeployContractTxQuery({ params, publicKey }))
+                const unsignedData = await queryClient.fetchQuery(
+                  buildDeployContractTxQuery({ params, publicKey, networkId })
+                )
 
                 dispatch(
                   openModal({

--- a/packages/shared-react/src/api/persistQueryClientContext.tsx
+++ b/packages/shared-react/src/api/persistQueryClientContext.tsx
@@ -1,3 +1,4 @@
+import { isTokenResolutionFallback } from '@alephium/shared/types'
 import { sleep } from '@alephium/web3'
 import { PersistQueryClientOptions, persistQueryClientSave } from '@tanstack/query-persist-client-core'
 import {
@@ -5,6 +6,7 @@ import {
   hydrate,
   IsRestoringProvider,
   OmitKeyof,
+  Query,
   QueryClientProvider,
   QueryClientProviderProps
 } from '@tanstack/react-query'
@@ -63,10 +65,7 @@ export const PersistQueryClientContextProvider = ({
         await persistQueryClientSave({
           queryClient,
           persister: createPersister(getPersisterKey(walletId)),
-          dehydrateOptions: {
-            shouldDehydrateQuery: (query) =>
-              query.meta?.['isMainnet'] === false ? false : defaultShouldDehydrateQuery(query)
-          }
+          dehydrateOptions: { shouldDehydrateQuery }
         })
 
         console.log('✅ query client saved')
@@ -117,6 +116,13 @@ export const PersistQueryClientContextProvider = ({
 export const usePersistQueryClientContext = () => useContext(PersistQueryClientContext)
 
 export const getPersisterKey = (walletId: string) => 'tanstack-cache-for-wallet-' + walletId
+
+// Token resolution fallbacks are placeholders for data that could not be fetched, not real data, so they must not
+// outlive the session by being persisted to disk.
+export const shouldDehydrateQuery = (query: Query) =>
+  query.meta?.['isMainnet'] === false || isTokenResolutionFallback(query.state.data)
+    ? false
+    : defaultShouldDehydrateQuery(query)
 
 const RESTORE_CHUNK_SIZE = 250
 

--- a/packages/shared-react/src/api/persistQueryClientContext.tsx
+++ b/packages/shared-react/src/api/persistQueryClientContext.tsx
@@ -65,6 +65,7 @@ export const PersistQueryClientContextProvider = ({
         await persistQueryClientSave({
           queryClient,
           persister: createPersister(getPersisterKey(walletId)),
+          buster: CACHE_SCHEMA_VERSION,
           dehydrateOptions: { shouldDehydrateQuery }
         })
 
@@ -81,8 +82,6 @@ export const PersistQueryClientContextProvider = ({
       setIsRestoring(true)
 
       if (!isPassphraseUsed) {
-        // TODO: Add buster: CACHE_SCHEMA_VERSION (global variable) for when I want to force a cache refresh to
-        // everyone who updates. Useful for when the API schema or the cached query shapes change.
         await restoreQueryCacheInChunks(createPersister(getPersisterKey(walletId)))
       } else {
         // Even when we don't restore data in the case of passphrase wallet, we need to set `isRestoring` to `true` and
@@ -124,15 +123,25 @@ export const shouldDehydrateQuery = (query: Query) =>
     ? false
     : defaultShouldDehydrateQuery(query)
 
+// Bump to force a one-time cold start of the query cache for everyone who updates, e.g. when query keys or cached
+// query shapes change and the persisted entries would otherwise be orphaned or misread. Payloads persisted before the
+// buster existed carry the persistQueryClientSave default of '' and are treated as mismatched.
+export const CACHE_SCHEMA_VERSION = '1'
+
 const RESTORE_CHUNK_SIZE = 250
 
 // Equivalent to persistQueryClientRestore but hydrating in chunks that yield to the event loop, so that restoring
 // thousands of queries (and scheduling their gc timers) does not block the main thread in one long task at unlock.
-const restoreQueryCacheInChunks = async (persister: Persister) => {
+export const restoreQueryCacheInChunks = async (persister: Persister) => {
   try {
     const persistedClient = await persister.restoreClient()
 
     if (!persistedClient) return
+
+    if (persistedClient.buster !== CACHE_SCHEMA_VERSION) {
+      await persister.removeClient()
+      return
+    }
 
     const { queries, mutations } = persistedClient.clientState
 

--- a/packages/shared-react/src/api/queries/tokenQueries.ts
+++ b/packages/shared-react/src/api/queries/tokenQueries.ts
@@ -84,7 +84,7 @@ export const ftListQuery = ({ networkId, skip }: Omit<TokenQueryProps, 'id' | 'i
 
 export const tokenTypeQuery = ({ id, networkId, isExplorerOnline, skip, skipCaching }: TokenQueryProps) =>
   queryOptions({
-    queryKey: ['token', 'type', getId(id, skipCaching)],
+    queryKey: ['token', 'type', getId(id, skipCaching), { networkId }],
     // We always want to remember the type of a token, even when user navigates for too long from components that use
     // tokens.
     ...getQueryConfig({ staleTime: Infinity, gcTime: Infinity, networkId, skipCaching }),
@@ -128,7 +128,7 @@ export const combineTokenTypes = (tokenTypes: (e.TokenInfo | { data: e.TokenInfo
 
 export const fungibleTokenMetadataQuery = ({ id, networkId, isExplorerOnline, skip, skipCaching }: TokenQueryProps) =>
   queryOptions({
-    queryKey: ['token', 'fungible', 'metadata', getId(id, skipCaching)],
+    queryKey: ['token', 'fungible', 'metadata', getId(id, skipCaching), { networkId }],
     ...getQueryConfig({ staleTime: Infinity, gcTime: Infinity, networkId, skipCaching }),
     queryFn: shouldSkip(isExplorerOnline, skip)
       ? skipToken
@@ -141,7 +141,7 @@ export const fungibleTokenMetadataQuery = ({ id, networkId, isExplorerOnline, sk
 
 const nftMetadataQuery = ({ id, networkId, isExplorerOnline, skip, skipCaching }: TokenQueryProps) =>
   queryOptions({
-    queryKey: ['token', 'non-fungible', 'metadata', getId(id, skipCaching)],
+    queryKey: ['token', 'non-fungible', 'metadata', getId(id, skipCaching), { networkId }],
     ...getQueryConfig({ staleTime: Infinity, gcTime: Infinity, networkId, skipCaching }),
     queryFn: shouldSkip(isExplorerOnline, skip)
       ? skipToken
@@ -150,7 +150,7 @@ const nftMetadataQuery = ({ id, networkId, isExplorerOnline, skip, skipCaching }
 
 const nftDataQuery = ({ id, tokenUri, networkId, skip, skipCaching }: NFTQueryProps) =>
   queryOptions({
-    queryKey: ['token', 'non-fungible', 'data', getId(id, skipCaching)],
+    queryKey: ['token', 'non-fungible', 'data', getId(id, skipCaching), { networkId }],
     // We don't want to delete the NFT data when the user navigates away from NFT components.
     ...getQueryConfig({ gcTime: Infinity, networkId, skipCaching }),
     staleTime: (query) => (skipCaching ? 0 : isTokenResolutionFallback(query.state.data) ? ONE_MINUTE_MS : ONE_DAY_MS),

--- a/packages/shared-react/src/api/queries/tokenQueries.ts
+++ b/packages/shared-react/src/api/queries/tokenQueries.ts
@@ -1,7 +1,8 @@
-import { ONE_DAY_MS } from '@alephium/shared'
+import { ONE_DAY_MS, ONE_MINUTE_MS } from '@alephium/shared'
 import { batchers } from '@alephium/shared/api'
 import {
   FtListMap,
+  isTokenResolutionFallback,
   ListedFT,
   NFT,
   NFTDataType,
@@ -151,7 +152,8 @@ const nftDataQuery = ({ id, tokenUri, networkId, skip, skipCaching }: NFTQueryPr
   queryOptions({
     queryKey: ['token', 'non-fungible', 'data', getId(id, skipCaching)],
     // We don't want to delete the NFT data when the user navigates away from NFT components.
-    ...getQueryConfig({ staleTime: ONE_DAY_MS, gcTime: Infinity, networkId, skipCaching }),
+    ...getQueryConfig({ gcTime: Infinity, networkId, skipCaching }),
+    staleTime: (query) => (skipCaching ? 0 : isTokenResolutionFallback(query.state.data) ? ONE_MINUTE_MS : ONE_DAY_MS),
     queryFn:
       skip || !tokenUri
         ? skipToken
@@ -198,9 +200,17 @@ const nftDataQuery = ({ id, tokenUri, networkId, skip, skipCaching }: NFTQueryPr
                       : `https://placehold.co/400x400/000000/FFFFFF/jpeg?text=${encodeURIComponent(nftData.name)}`
                   }
             } catch (error) {
-              errorResponse.description =
-                error instanceof FetchError ? `${error.message} - ${tokenUri}` : errorResponse.description
-              return errorResponse
+              const isFetchError = error instanceof FetchError
+              // Only a connectivity failure (no HTTP response) is transient and worth re-resolving once back online.
+              // A reachable host that answered with an error status, or a malformed data: URI, fails identically on
+              // retry, so we keep it cached like real data instead of re-hitting the dead source on every trigger.
+              const isConnectivityError = !tokenUri.startsWith('data:') && !isFetchError
+
+              return {
+                ...errorResponse,
+                description: isFetchError ? `${error.message} - ${tokenUri}` : errorResponse.description,
+                isResolutionFallback: isConnectivityError
+              }
             }
           }
   })
@@ -221,11 +231,11 @@ export const tokenQuery = ({
   return queryOptions({
     queryKey: ['token', getId(id, skipCaching), { networkId }],
     ...getQueryConfig({
-      staleTime: Infinity,
       gcTime: Infinity,
       networkId,
       skipCaching
     }),
+    staleTime: (query) => (skipCaching ? 0 : isTokenResolutionFallback(query.state.data) ? ONE_MINUTE_MS : Infinity),
     queryFn: skip
       ? skipToken
       : async (): Promise<Token> => {
@@ -267,7 +277,7 @@ export const tokenQuery = ({
               return nft ?? nst
             }
           } catch (error) {
-            if (!isExplorerOnline) return nst
+            if (!isExplorerOnline) return { ...nst, isResolutionFallback: true }
 
             throw error
           }
@@ -281,7 +291,8 @@ export const tokenQuery = ({
 export const nftQuery = ({ id, networkId, isExplorerOnline, skip, skipCaching }: TokenQueryProps) =>
   queryOptions({
     queryKey: ['token', 'non-fungible', getId(id, skipCaching), { networkId }],
-    ...getQueryConfig({ staleTime: Infinity, gcTime: Infinity, networkId, skipCaching }),
+    ...getQueryConfig({ gcTime: Infinity, networkId, skipCaching }),
+    staleTime: (query) => (skipCaching ? 0 : isTokenResolutionFallback(query.state.data) ? ONE_MINUTE_MS : Infinity),
     queryFn: shouldSkip(isExplorerOnline, skip)
       ? skipToken
       : async (): Promise<NFT | null> => {

--- a/packages/shared-react/src/api/queries/transactionBuildingQueries.ts
+++ b/packages/shared-react/src/api/queries/transactionBuildingQueries.ts
@@ -4,39 +4,42 @@ import { queryOptions } from '@tanstack/react-query'
 
 interface BuildTxQueryBaseProps {
   publicKey: string
-  networkId?: number
+  networkId: number
 }
 
 export const buildTransferTxQuery = ({
   params,
-  publicKey
+  publicKey,
+  networkId
 }: BuildTxQueryBaseProps & {
   params: SignTransferTxParams
 }) =>
   queryOptions({
-    queryKey: ['buildTx', 'transfer', params],
+    queryKey: ['buildTx', 'transfer', params, publicKey, { networkId }],
     queryFn: () => throttledClient.txBuilder.buildTransferTx(params, publicKey)
   })
 
 export const buildExecuteScriptTxQuery = ({
   params,
-  publicKey
+  publicKey,
+  networkId
 }: BuildTxQueryBaseProps & {
   params: SignExecuteScriptTxParams
 }) =>
   queryOptions({
-    queryKey: ['buildTx', 'executeScript', params],
+    queryKey: ['buildTx', 'executeScript', params, publicKey, { networkId }],
     queryFn: () => throttledClient.txBuilder.buildExecuteScriptTx(params, publicKey)
   })
 
 export const buildDeployContractTxQuery = ({
   params,
-  publicKey
+  publicKey,
+  networkId
 }: BuildTxQueryBaseProps & {
   params: SignDeployContractTxParams
 }) =>
   queryOptions({
-    queryKey: ['buildTx', 'deployContract', params],
+    queryKey: ['buildTx', 'deployContract', params, publicKey, { networkId }],
     queryFn: () => throttledClient.txBuilder.buildDeployContractTx(params, publicKey)
   })
 

--- a/packages/shared-react/src/api/queries/transactionBuildingQueries.ts
+++ b/packages/shared-react/src/api/queries/transactionBuildingQueries.ts
@@ -42,9 +42,3 @@ export const buildDeployContractTxQuery = ({
     queryKey: ['buildTx', 'deployContract', params, publicKey, { networkId }],
     queryFn: () => throttledClient.txBuilder.buildDeployContractTx(params, publicKey)
   })
-
-export const decodeUnsignedTxQuery = ({ unsignedTx }: { unsignedTx: string }) =>
-  queryOptions({
-    queryKey: ['decodeUnsignedTx', unsignedTx],
-    queryFn: () => throttledClient.node.transactions.postTransactionsDecodeUnsignedTx({ unsignedTx })
-  })

--- a/packages/shared-react/src/api/queryInvalidation.ts
+++ b/packages/shared-react/src/api/queryInvalidation.ts
@@ -1,4 +1,4 @@
-import { AddressHash } from '@alephium/shared/types'
+import { AddressHash, isTokenResolutionFallback } from '@alephium/shared/types'
 import { InfiniteData } from '@tanstack/react-query'
 
 import {
@@ -22,6 +22,12 @@ export const invalidateWalletQueries = async () => {
 
 export const invalidateTokenPrices = async () => {
   await queryClient.invalidateQueries({ queryKey: ['tokenPrices', 'currentPrice'] })
+}
+
+export const invalidateTokenResolutionFallbacks = async () => {
+  await queryClient.invalidateQueries({
+    predicate: (query) => query.queryKey[0] === 'token' && isTokenResolutionFallback(query.state.data)
+  })
 }
 
 type WalletTransactionsQueryData = InfiniteData<

--- a/packages/shared-react/src/features/fallbackRecovery/index.ts
+++ b/packages/shared-react/src/features/fallbackRecovery/index.ts
@@ -1,0 +1,1 @@
+export * from './useRecoverTokenResolutionFallbacks'

--- a/packages/shared-react/src/features/fallbackRecovery/useRecoverTokenResolutionFallbacks.ts
+++ b/packages/shared-react/src/features/fallbackRecovery/useRecoverTokenResolutionFallbacks.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+
+import { invalidateTokenResolutionFallbacks } from '../../api/queryInvalidation'
+import { useIsExplorerOnline } from '../../network/networkHooks'
+
+// Token queries cache fallback results (see isTokenResolutionFallback) when their data cannot be fetched, so that the
+// UI keeps working while offline. Once the explorer comes back online, refetch them to replace the fallbacks with real
+// data.
+export const useRecoverTokenResolutionFallbacks = () => {
+  const isExplorerOnline = useIsExplorerOnline()
+
+  useEffect(() => {
+    if (!isExplorerOnline) return
+
+    invalidateTokenResolutionFallbacks()
+  }, [isExplorerOnline])
+}

--- a/packages/shared-react/src/features/index.ts
+++ b/packages/shared-react/src/features/index.ts
@@ -1,1 +1,2 @@
 export * from './dataPolling'
+export * from './fallbackRecovery'

--- a/packages/shared-react/test/queryCachePersistence.test.ts
+++ b/packages/shared-react/test/queryCachePersistence.test.ts
@@ -1,0 +1,75 @@
+import { PersistedClient, Persister } from '@tanstack/query-persist-client-core'
+import { dehydrate } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  CACHE_SCHEMA_VERSION,
+  restoreQueryCacheInChunks,
+  shouldDehydrateQuery
+} from '../src/api/persistQueryClientContext'
+import { queryClient } from '../src/api/queryClient'
+
+const PERSISTED_QUERY_KEY = ['token', 'persisted-id', { networkId: 0 }]
+const PERSISTED_DATA = { id: 'persisted-id', name: 'Persisted Token', symbol: 'PT', decimals: 0 }
+
+const makePersistedClient = (buster?: string): PersistedClient => {
+  queryClient.setQueryData(PERSISTED_QUERY_KEY, PERSISTED_DATA)
+  const clientState = dehydrate(queryClient, { shouldDehydrateQuery })
+  queryClient.clear()
+
+  return { timestamp: Date.now(), buster: buster as string, clientState }
+}
+
+const makePersister = (persistedClient?: PersistedClient) => {
+  const removeClient = vi.fn()
+
+  const persister: Persister = {
+    persistClient: vi.fn(),
+    restoreClient: () => persistedClient,
+    removeClient
+  }
+
+  return { persister, removeClient }
+}
+
+afterEach(() => {
+  queryClient.clear()
+})
+
+describe('restoreQueryCacheInChunks', () => {
+  it('hydrates the cache when the persisted buster matches', async () => {
+    const { persister, removeClient } = makePersister(makePersistedClient(CACHE_SCHEMA_VERSION))
+
+    await restoreQueryCacheInChunks(persister)
+
+    expect(queryClient.getQueryData(PERSISTED_QUERY_KEY)).toEqual(PERSISTED_DATA)
+    expect(removeClient).not.toHaveBeenCalled()
+  })
+
+  it('removes the persisted cache and skips hydration on buster mismatch', async () => {
+    const { persister, removeClient } = makePersister(makePersistedClient('0'))
+
+    await restoreQueryCacheInChunks(persister)
+
+    expect(queryClient.getQueryCache().getAll()).toHaveLength(0)
+    expect(removeClient).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([undefined, ''])('treats a payload persisted with buster %j as mismatched', async (legacyBuster) => {
+    const { persister, removeClient } = makePersister(makePersistedClient(legacyBuster))
+
+    await restoreQueryCacheInChunks(persister)
+
+    expect(queryClient.getQueryCache().getAll()).toHaveLength(0)
+    expect(removeClient).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when there is no persisted cache', async () => {
+    const { persister, removeClient } = makePersister(undefined)
+
+    await restoreQueryCacheInChunks(persister)
+
+    expect(queryClient.getQueryCache().getAll()).toHaveLength(0)
+    expect(removeClient).not.toHaveBeenCalled()
+  })
+})

--- a/packages/shared-react/test/tokenResolutionFallbacks.test.ts
+++ b/packages/shared-react/test/tokenResolutionFallbacks.test.ts
@@ -1,0 +1,220 @@
+import { ONE_MINUTE_MS } from '@alephium/shared'
+import { dehydrate } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { shouldDehydrateQuery } from '../src/api/persistQueryClientContext'
+import { nftQuery, tokenQuery } from '../src/api/queries/tokenQueries'
+import { queryClient } from '../src/api/queryClient'
+import { invalidateTokenResolutionFallbacks } from '../src/api/queryInvalidation'
+
+const { tokenTypeFetch, ftMetadataFetch, nftMetadataFetch } = vi.hoisted(() => ({
+  tokenTypeFetch: vi.fn(),
+  ftMetadataFetch: vi.fn(),
+  nftMetadataFetch: vi.fn()
+}))
+
+vi.mock('@alephium/shared/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@alephium/shared/api')>()),
+  batchers: {
+    tokenTypeBatcher: { fetch: tokenTypeFetch },
+    ftMetadataBatcher: { fetch: ftMetadataFetch },
+    nftMetadataBatcher: { fetch: nftMetadataFetch }
+  }
+}))
+
+const TOKEN_ID = 'unlisted-token-id'
+const NFT_ID = 'nft-token-id'
+const NETWORK_ID = 0
+
+const mockFetch = vi.fn()
+
+// Makes every cached entry look older than the given age without touching timers, so that per-entry staleTime
+// behavior can be asserted through public APIs only
+const backdateQueryCache = (ageMs: number) => {
+  const updatedAt = Date.now() - ageMs
+
+  queryClient
+    .getQueryCache()
+    .getAll()
+    .forEach((query) => queryClient.setQueryData(query.queryKey, (data: unknown) => data, { updatedAt }))
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch)
+  vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  mockFetch.mockReset()
+  mockFetch.mockRejectedValue(new Error('network unreachable'))
+})
+
+afterEach(() => {
+  queryClient.clear()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  tokenTypeFetch.mockReset()
+  ftMetadataFetch.mockReset()
+  nftMetadataFetch.mockReset()
+})
+
+describe('tokenQuery resolved while the explorer is offline', () => {
+  const offlineOptions = tokenQuery({ id: TOKEN_ID, networkId: NETWORK_ID, isExplorerOnline: false })
+  const onlineOptions = tokenQuery({ id: TOKEN_ID, networkId: NETWORK_ID, isExplorerOnline: true })
+
+  it('caches a flagged fallback that stays usable until its short staleTime elapses', async () => {
+    const offlineResult = await queryClient.fetchQuery(offlineOptions)
+
+    expect(offlineResult).toEqual({ id: TOKEN_ID, isResolutionFallback: true })
+
+    const cachedResult = await queryClient.fetchQuery(onlineOptions)
+
+    expect(cachedResult).toEqual({ id: TOKEN_ID, isResolutionFallback: true })
+    expect(tokenTypeFetch).not.toHaveBeenCalled()
+  })
+
+  it('refetches the flagged fallback after its short staleTime and then stays Infinity-fresh', async () => {
+    await queryClient.fetchQuery(offlineOptions)
+
+    tokenTypeFetch.mockResolvedValue({ token: TOKEN_ID, stdInterfaceId: 'fungible' })
+    ftMetadataFetch.mockResolvedValue({ id: TOKEN_ID, name: 'Test Token', symbol: 'TT', decimals: '6' })
+
+    backdateQueryCache(ONE_MINUTE_MS + 1)
+    const resolvedResult = await queryClient.fetchQuery(onlineOptions)
+
+    expect(resolvedResult).toEqual({ id: TOKEN_ID, name: 'Test Token', symbol: 'TT', decimals: 6 })
+    expect(tokenTypeFetch).toHaveBeenCalledTimes(1)
+
+    backdateQueryCache(ONE_MINUTE_MS + 1)
+    const freshResult = await queryClient.fetchQuery(onlineOptions)
+
+    expect(freshResult).toEqual(resolvedResult)
+    expect(tokenTypeFetch).toHaveBeenCalledTimes(1)
+    expect(ftMetadataFetch).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('nftQuery when the NFT data cannot be fetched', () => {
+  const nftOptions = nftQuery({ id: NFT_ID, networkId: NETWORK_ID, isExplorerOnline: true })
+
+  beforeEach(() => {
+    nftMetadataFetch.mockResolvedValue({
+      id: NFT_ID,
+      tokenUri: 'https://example.com/nft.json',
+      collectionId: 'collection-id',
+      nftIndex: '1'
+    })
+  })
+
+  it('caches a flagged "Unknown NFT" fallback and re-resolves it after its short staleTime', async () => {
+    const fallbackResult = await queryClient.fetchQuery(nftOptions)
+
+    expect(fallbackResult).toMatchObject({ id: NFT_ID, name: 'Unknown NFT', isResolutionFallback: true })
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve({ name: 'Cool NFT', image: '' })
+    })
+
+    backdateQueryCache(ONE_MINUTE_MS + 1)
+    const resolvedResult = await queryClient.fetchQuery(nftOptions)
+
+    expect(resolvedResult).toMatchObject({ id: NFT_ID, name: 'Cool NFT' })
+    expect(resolvedResult?.isResolutionFallback).toBeUndefined()
+    expect(nftMetadataFetch).toHaveBeenCalledTimes(1)
+
+    backdateQueryCache(ONE_MINUTE_MS + 1)
+    await queryClient.fetchQuery(nftOptions)
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not flag an NFT whose metadata host answered with an error status', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' })
+
+    const result = await queryClient.fetchQuery(nftOptions)
+
+    expect(result).toMatchObject({ id: NFT_ID, name: 'Unknown NFT' })
+    expect(result?.isResolutionFallback).toBe(false)
+  })
+
+  it('does not flag an NFT with a malformed data: URI', async () => {
+    nftMetadataFetch.mockResolvedValue({
+      id: NFT_ID,
+      tokenUri: 'data:application/json,{ this is not valid json',
+      collectionId: 'collection-id',
+      nftIndex: '1'
+    })
+
+    const result = await queryClient.fetchQuery(nftOptions)
+
+    expect(result).toMatchObject({ id: NFT_ID, name: 'Unknown NFT' })
+    expect(result?.isResolutionFallback).toBe(false)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('invalidateTokenResolutionFallbacks', () => {
+  it('invalidates exactly the flagged entries of the token namespace', async () => {
+    queryClient.setQueryData(['token', 'flagged-id', { networkId: NETWORK_ID }], {
+      id: 'flagged-id',
+      isResolutionFallback: true
+    })
+    queryClient.setQueryData(['token', 'non-fungible', 'data', 'flagged-nft-id'], {
+      id: 'flagged-nft-id',
+      name: 'Unknown NFT',
+      isResolutionFallback: true
+    })
+    queryClient.setQueryData(['token', 'real-id', { networkId: NETWORK_ID }], {
+      id: 'real-id',
+      name: 'Real Token',
+      symbol: 'RT',
+      decimals: 0
+    })
+    queryClient.setQueryData(['tokenPrices', 'currentPrice', 'ALPH'], 1.23)
+
+    await invalidateTokenResolutionFallbacks()
+
+    expect(queryClient.getQueryState(['token', 'flagged-id', { networkId: NETWORK_ID }])?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(['token', 'non-fungible', 'data', 'flagged-nft-id'])?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(['token', 'real-id', { networkId: NETWORK_ID }])?.isInvalidated).toBe(false)
+    expect(queryClient.getQueryState(['tokenPrices', 'currentPrice', 'ALPH'])?.isInvalidated).toBe(false)
+  })
+})
+
+describe('shouldDehydrateQuery', () => {
+  it('excludes flagged fallback entries from persistence', () => {
+    queryClient.setQueryData(['token', 'flagged-id', { networkId: NETWORK_ID }], {
+      id: 'flagged-id',
+      isResolutionFallback: true
+    })
+    queryClient.setQueryData(['token', 'real-id', { networkId: NETWORK_ID }], {
+      id: 'real-id',
+      name: 'Real Token',
+      symbol: 'RT',
+      decimals: 0
+    })
+
+    const dehydratedState = dehydrate(queryClient, { shouldDehydrateQuery })
+    const dehydratedIds = dehydratedState.queries.map(({ queryKey }) => queryKey[1])
+
+    expect(dehydratedIds).toEqual(['real-id'])
+  })
+
+  it('keeps excluding non-mainnet entries from persistence', async () => {
+    await queryClient.fetchQuery({
+      queryKey: ['testnet-query'],
+      queryFn: () => 'testnet-data',
+      meta: { isMainnet: false }
+    })
+    await queryClient.fetchQuery({
+      queryKey: ['mainnet-query'],
+      queryFn: () => 'mainnet-data',
+      meta: { isMainnet: true }
+    })
+
+    const dehydratedState = dehydrate(queryClient, { shouldDehydrateQuery })
+    const dehydratedKeys = dehydratedState.queries.map(({ queryKey }) => queryKey[0])
+
+    expect(dehydratedKeys).toEqual(['mainnet-query'])
+  })
+})

--- a/packages/shared-react/test/tokenResolutionFallbacks.test.ts
+++ b/packages/shared-react/test/tokenResolutionFallbacks.test.ts
@@ -159,7 +159,7 @@ describe('invalidateTokenResolutionFallbacks', () => {
       id: 'flagged-id',
       isResolutionFallback: true
     })
-    queryClient.setQueryData(['token', 'non-fungible', 'data', 'flagged-nft-id'], {
+    queryClient.setQueryData(['token', 'non-fungible', 'data', 'flagged-nft-id', { networkId: NETWORK_ID }], {
       id: 'flagged-nft-id',
       name: 'Unknown NFT',
       isResolutionFallback: true
@@ -175,7 +175,10 @@ describe('invalidateTokenResolutionFallbacks', () => {
     await invalidateTokenResolutionFallbacks()
 
     expect(queryClient.getQueryState(['token', 'flagged-id', { networkId: NETWORK_ID }])?.isInvalidated).toBe(true)
-    expect(queryClient.getQueryState(['token', 'non-fungible', 'data', 'flagged-nft-id'])?.isInvalidated).toBe(true)
+    expect(
+      queryClient.getQueryState(['token', 'non-fungible', 'data', 'flagged-nft-id', { networkId: NETWORK_ID }])
+        ?.isInvalidated
+    ).toBe(true)
     expect(queryClient.getQueryState(['token', 'real-id', { networkId: NETWORK_ID }])?.isInvalidated).toBe(false)
     expect(queryClient.getQueryState(['tokenPrices', 'currentPrice', 'ALPH'])?.isInvalidated).toBe(false)
   })

--- a/packages/shared/src/types/assets.ts
+++ b/packages/shared/src/types/assets.ts
@@ -53,13 +53,15 @@ export enum NFTDataTypes {
 
 export type NFTDataType = keyof typeof NFTDataTypes
 
-export type NFT = NFTTokenUriMetaData & Omit<e.NFTMetadata, 'tokenUri'> & { dataType: NFTDataType }
+export type NFT = NFTTokenUriMetaData &
+  Omit<e.NFTMetadata, 'tokenUri'> & { dataType: NFTDataType; isResolutionFallback?: boolean }
 
 // For better code readability
 export interface ListedFT extends TokenInfo {}
 export interface UnlistedFT extends FungibleTokenBasicMetadata {}
 export interface NonStandardToken {
   id: string
+  isResolutionFallback?: boolean
 }
 
 // To represent a token that is not in the token list but we haven't discovered its type yet
@@ -110,6 +112,11 @@ export const isListedFT = (token: Token): token is ListedFT => (token as ListedF
 export const isUnlistedFT = (token: Token) => isFT(token) && !isListedFT(token)
 
 export const isNFT = (token: Token): token is NFT => (token as NFT).nftIndex !== undefined
+
+// Marks data returned in place of token info that could not be fetched (e.g. while offline), so that it can be
+// re-resolved instead of being cached as if it were real data
+export const isTokenResolutionFallback = (data: unknown): boolean =>
+  typeof data === 'object' && data !== null && (data as NonStandardToken | NFT).isResolutionFallback === true
 
 export type FtListMap = Record<TokenId, TokenInfo | undefined>
 


### PR DESCRIPTION
Stacked on #1674. Correctness batch from an architectural review of the query layer, one commit per fix:

- Token lookups that fail (e.g. while offline) were cached as successes with `staleTime: Infinity` and no invalidation path, permanently mislabeling tokens as non-standard and NFTs as unknown. Fallback results are now flagged, go stale after a minute, refetch when the explorer comes back online, and never persist to disk.
- buildTx query keys omitted the `publicKey` and `networkId` their queryFns use.
- Mobile pull-to-refresh only re-checked the latest-tx gate, so balances did not refresh unless a new transaction existed; it now runs the same level-ordered refresh as desktop.
- Token metadata keys were missing `networkId` (cross-network cache bleed); added together with a persisted-cache schema buster, so everyone gets one clean cold start instead of orphaned entries.
- Deleted the unused `decodeUnsignedTxQuery` duplicate.

