### PR TITLE
fix(shared): clamp recent tx timestamps to 'ago'

### DIFF
--- a/.changeset/issue-262-relative-time-wording.md
+++ b/.changeset/issue-262-relative-time-wording.md
@@ -1,0 +1,7 @@
+---
+'alephium-desktop-wallet': patch
+'@alephium/mobile-wallet': patch
+'@alephium/explorer': patch
+---
+
+Show "x ago" instead of "in a day" for recently confirmed transactions

--- a/apps/desktop-wallet/src/components/TimeSince.tsx
+++ b/apps/desktop-wallet/src/components/TimeSince.tsx
@@ -11,7 +11,7 @@ interface TimeSinceProps {
 const TimeSince = ({ timestamp, className }: TimeSinceProps) => {
   const { i18n } = useTranslation()
 
-  return <div className={className}>{formatRelativeTime(timestamp, i18n.language)}</div>
+  return <div className={className}>{formatRelativeTime(timestamp, i18n.language, 'long', { neverFuture: true })}</div>
 }
 
 export default styled(TimeSince)`

--- a/apps/desktop-wallet/src/pages/unlockedWallet/addressesPage/addressListRow/AddressLastActivity.tsx
+++ b/apps/desktop-wallet/src/pages/unlockedWallet/addressesPage/addressListRow/AddressLastActivity.tsx
@@ -25,7 +25,7 @@ export default AddressLastActivity
 const LastTransactionTimestamp = ({ timestamp }: Pick<e.Transaction, 'timestamp'>) => {
   const { t, i18n } = useTranslation()
 
-  return `${t('Last activity')} ${formatRelativeTime(timestamp, i18n.language)}`
+  return `${t('Last activity')} ${formatRelativeTime(timestamp, i18n.language, 'long', { neverFuture: true })}`
 }
 
 const AddressListRowLastUsedStyled = styled.div`

--- a/apps/explorer/src/components/Timestamp.tsx
+++ b/apps/explorer/src/components/Timestamp.tsx
@@ -26,7 +26,7 @@ const Timestamp = ({ timeInMs, className, forceFormat, customFormat, formatToggl
   const lowPrecisionTimestamp =
     timeInMs < Date.now() - ONE_DAY_MS
       ? new Intl.DateTimeFormat(i18n.language, SIMPLE_DATE_OPTIONS).format(date)
-      : formatRelativeTime(timeInMs, i18n.language)
+      : formatRelativeTime(timeInMs, i18n.language, 'long', { neverFuture: true })
   const customTimestamp = customFormat ? new Intl.DateTimeFormat(i18n.language, customFormat).format(date) : undefined
 
   return (

--- a/apps/mobile-wallet/src/features/addressesManagement/AddressLastActivity.tsx
+++ b/apps/mobile-wallet/src/features/addressesManagement/AddressLastActivity.tsx
@@ -16,7 +16,11 @@ const AddressLastActivity = ({ addressHash }: AddressListRowLastUsedProps) => {
 
   return (
     <Row title={t('Last activity')} isLast short>
-      <AppText>{data?.latestTx ? formatRelativeTime(data.latestTx.timestamp, i18n.language) : t('Never used')}</AppText>
+      <AppText>
+        {data?.latestTx
+          ? formatRelativeTime(data.latestTx.timestamp, i18n.language, 'long', { neverFuture: true })
+          : t('Never used')}
+      </AppText>
     </Row>
   )
 }

--- a/packages/shared/src/date.ts
+++ b/packages/shared/src/date.ts
@@ -26,10 +26,12 @@ const UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
 export const formatRelativeTime = (
   timestamp: number | Date,
   locale?: string,
-  style: 'long' | 'short' | 'narrow' = 'long'
+  style: 'long' | 'short' | 'narrow' = 'long',
+  options?: { neverFuture?: boolean }
 ): string => {
   const ms = typeof timestamp === 'number' ? timestamp : timestamp.getTime()
-  const diffMs = ms - Date.now()
+  const rawDiffMs = ms - Date.now()
+  const diffMs = options?.neverFuture ? Math.min(rawDiffMs, 0) : rawDiffMs
   const absDiffMs = Math.abs(diffMs)
 
   const formatter = new Intl.RelativeTimeFormat(locale, { numeric: 'auto', style })

--- a/packages/shared/test/date-test.ts
+++ b/packages/shared/test/date-test.ts
@@ -61,6 +61,34 @@ describe('formatRelativeTime', () => {
     const result = formatRelativeTime(justNow)
     expect(result).toMatch(/second|now/)
   })
+
+  describe('neverFuture option', () => {
+    it('should never render future tense for a timestamp slightly in the future', () => {
+      const thirtySecondsInFuture = Date.now() + 30 * 1000
+      const result = formatRelativeTime(thirtySecondsInFuture, 'en', 'long', { neverFuture: true })
+      expect(result).not.toMatch(/\bin\b/)
+      expect(result).toBe('now')
+    })
+
+    it('should not render "in a day" for a timestamp days in the future', () => {
+      const twoDaysInFuture = Date.now() + 2 * ONE_DAY_MS
+      const result = formatRelativeTime(twoDaysInFuture, 'en', 'long', { neverFuture: true })
+      expect(result).not.toMatch(/\bin\b/)
+      expect(result).not.toContain('day')
+    })
+
+    it('should render a few minutes ago as past tense', () => {
+      const fiveMinutesAgo = Date.now() - 5 * 60 * 1000
+      const result = formatRelativeTime(fiveMinutesAgo, 'en', 'long', { neverFuture: true })
+      expect(result).toBe('5 minutes ago')
+    })
+
+    it('should render a few hours ago as past tense', () => {
+      const threeHoursAgo = Date.now() - 3 * 60 * 60 * 1000
+      const result = formatRelativeTime(threeHoursAgo, 'en', 'long', { neverFuture: true })
+      expect(result).toBe('3 hours ago')
+    })
+  })
 })
 
 describe('SHORT_DATE_OPTIONS', () => {


### PR DESCRIPTION
A just-confirmed transaction can carry a block timestamp at or slightly after the local clock. formatRelativeTime then rendered future-tense wording ("in a minute", "tomorrow") for an event that is in the past.

Add an opt-in neverFuture option that clamps at-or-future timestamps to "now", and use it from the activity and transaction timestamp displays in desktop, mobile, and explorer. Lock-time displays keep their default future-capable phrasing.

- Closes #262