### PR TITLE
Extract and test wallet deletion

### DIFF
--- a/apps/desktop-wallet/src/modals/WalletRemovalModal.tsx
+++ b/apps/desktop-wallet/src/modals/WalletRemovalModal.tsx
@@ -1,6 +1,3 @@
-import { keyring } from '@alephium/keyring'
-import { AnalyticsEvent } from '@alephium/shared'
-import { activeWalletDeleted } from '@alephium/shared/store'
 import { usePersistQueryClientContext } from '@alephium/shared-react'
 import { AlertTriangle } from 'lucide-react'
 import { memo } from 'react'
@@ -15,9 +12,7 @@ import { closeModal } from '@/features/modals/modalActions'
 import { ModalBaseProp } from '@/features/modals/modalTypes'
 import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import CenteredModal, { ModalFooterButton, ModalFooterButtons } from '@/modals/CenteredModal'
-import { addressMetadataStorage } from '@/storage/addresses/addressMetadataPersistentStorage'
-import { walletDeleted } from '@/storage/wallets/walletActions'
-import { walletStorage } from '@/storage/wallets/walletPersistentStorage'
+import { deleteWallet } from '@/storage/wallets/walletDeletion'
 
 export interface WalletRemovalModalProps {
   walletId: string
@@ -33,19 +28,9 @@ const WalletRemovalModal = memo(({ id, walletId, walletName }: ModalBaseProp & W
   const { deletePersistedCache } = usePersistQueryClientContext()
 
   const removeWallet = () => {
-    walletStorage.delete(walletId)
-    addressMetadataStorage.delete(walletId)
+    deleteWallet({ walletId, activeWalletId, dispatch, deletePersistedCache, sendAnalytics })
 
-    deletePersistedCache(walletId)
-
-    if (activeWalletId === walletId) {
-      keyring.clear()
-    }
-
-    dispatch(walletId === activeWalletId ? activeWalletDeleted() : walletDeleted(walletId))
     dispatch(closeModal({ id }))
-
-    sendAnalytics({ event: AnalyticsEvent.DELETED_WALLET })
   }
 
   return (

--- a/apps/desktop-wallet/src/storage/wallets/walletDeletion.ts
+++ b/apps/desktop-wallet/src/storage/wallets/walletDeletion.ts
@@ -1,0 +1,40 @@
+import { keyring } from '@alephium/keyring'
+import { AnalyticsEvent } from '@alephium/shared'
+import { activeWalletDeleted } from '@alephium/shared/store'
+import type { PersistQueryClientContextType } from '@alephium/shared-react'
+
+import type useAnalytics from '@/features/analytics/useAnalytics'
+import { addressMetadataStorage } from '@/storage/addresses/addressMetadataPersistentStorage'
+import type { AppDispatch } from '@/storage/store'
+import { walletDeleted } from '@/storage/wallets/walletActions'
+import { walletStorage } from '@/storage/wallets/walletPersistentStorage'
+import type { StoredEncryptedWallet } from '@/types/wallet'
+
+interface DeleteWalletProps {
+  walletId: StoredEncryptedWallet['id']
+  activeWalletId: StoredEncryptedWallet['id'] | undefined
+  dispatch: AppDispatch
+  deletePersistedCache: PersistQueryClientContextType['deletePersistedCache']
+  sendAnalytics: ReturnType<typeof useAnalytics>['sendAnalytics']
+}
+
+export const deleteWallet = ({
+  walletId,
+  activeWalletId,
+  dispatch,
+  deletePersistedCache,
+  sendAnalytics
+}: DeleteWalletProps) => {
+  walletStorage.delete(walletId)
+  addressMetadataStorage.delete(walletId)
+
+  deletePersistedCache(walletId)
+
+  if (activeWalletId === walletId) {
+    keyring.clear()
+  }
+
+  dispatch(walletId === activeWalletId ? activeWalletDeleted() : walletDeleted(walletId))
+
+  sendAnalytics({ event: AnalyticsEvent.DELETED_WALLET })
+}

--- a/apps/desktop-wallet/src/tests/walletDeletion.test.ts
+++ b/apps/desktop-wallet/src/tests/walletDeletion.test.ts
@@ -1,0 +1,188 @@
+vi.mock('@alephium/web3-wallet', () => ({}))
+
+import { keyring } from '@alephium/keyring'
+import { AnalyticsEvent } from '@alephium/shared'
+import {
+  activeWalletDeleted,
+  contactStoredInPersistentStorage,
+  transactionSent,
+  walletLocked,
+  walletUnlockedDesktop
+} from '@alephium/shared/store'
+import type { Contact, SentTransaction } from '@alephium/shared/types'
+import type { PersistQueryClientContextType } from '@alephium/shared-react'
+import type { Mock } from 'vitest'
+
+import type useAnalytics from '@/features/analytics/useAnalytics'
+import { addressMetadataStorage } from '@/storage/addresses/addressMetadataPersistentStorage'
+import { store } from '@/storage/store'
+import { walletDeleted, walletSaved } from '@/storage/wallets/walletActions'
+import { deleteWallet } from '@/storage/wallets/walletDeletion'
+import { walletStorage } from '@/storage/wallets/walletPersistentStorage'
+
+type DeletePersistedCache = PersistQueryClientContextType['deletePersistedCache']
+type SendAnalytics = ReturnType<typeof useAnalytics>['sendAnalytics']
+
+const testMnemonic =
+  'vault alarm sad mass witness property virus style good flower rice alpha viable evidence run glare pretty scout evil judge enroll refuse another lava'
+
+const contact: Contact = { id: 'c1', name: 'Bob', address: '1DrDyTr9RpRsQnDnXo2YRiPzPW4ooHX5LLoqXrqfMrpQH' }
+
+const sentTx: SentTransaction = {
+  hash: 'tx1',
+  fromAddress: '1DrDyTr9RpRsQnDnXo2YRiPzPW4ooHX5LLoqXrqfMrpQH',
+  toAddress: '1TrDyTr9RpRsQnDnXo2YRiPzPW4ooHX5LLoqXrqfMrpQH',
+  timestamp: 1,
+  type: 'transfer',
+  status: 'sent'
+}
+
+let deletePersistedCache: Mock<DeletePersistedCache>
+let sendAnalytics: Mock<SendAnalytics>
+
+const seedWallet = (name: string) => {
+  const wallet = walletStorage.store(name, `encrypted-${name}`)
+
+  addressMetadataStorage.store(wallet.id, [{ index: 0, keyType: 'default', isDefault: true, color: 'blue' }])
+  store.dispatch(walletSaved(wallet))
+
+  return wallet
+}
+
+const makeActive = (walletId: string, name: string) =>
+  store.dispatch(walletUnlockedDesktop({ id: walletId, name, isPassphraseUsed: false, isLedger: false }))
+
+const runDeleteWallet = (walletId: string, activeWalletId: string | undefined) =>
+  deleteWallet({ walletId, activeWalletId, dispatch: store.dispatch, deletePersistedCache, sendAnalytics })
+
+beforeEach(() => {
+  localStorage.clear()
+  keyring.clear()
+  store.dispatch(walletLocked())
+  deletePersistedCache = vi.fn<DeletePersistedCache>()
+  sendAnalytics = vi.fn<SendAnalytics>()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  localStorage.clear()
+  keyring.clear()
+  store.dispatch(walletLocked())
+})
+
+describe('deleteWallet', () => {
+  describe('when the deleted wallet is not the active one', () => {
+    it('removes only the deleted wallet localStorage keys and keeps the other wallet keys', () => {
+      const active = seedWallet('Wallet A')
+      const other = seedWallet('Wallet B')
+      makeActive(active.id, active.name)
+
+      runDeleteWallet(other.id, active.id)
+
+      expect(localStorage.getItem(`wallet-${other.id}`)).toBeNull()
+      expect(localStorage.getItem(`addresses-metadata-${other.id}`)).toBeNull()
+      expect(localStorage.getItem(`wallet-${active.id}`)).not.toBeNull()
+      expect(localStorage.getItem(`addresses-metadata-${active.id}`)).not.toBeNull()
+    })
+
+    it('does not clear the keyring', () => {
+      const active = seedWallet('Wallet A')
+      const other = seedWallet('Wallet B')
+      makeActive(active.id, active.name)
+      keyring.importMnemonicString(testMnemonic)
+      const clearSpy = vi.spyOn(keyring, 'clear')
+
+      runDeleteWallet(other.id, active.id)
+
+      expect(clearSpy).not.toHaveBeenCalled()
+      expect(keyring.isInitialized()).toBe(true)
+    })
+
+    it('dispatches walletDeleted, removing it from global.wallets while leaving the active wallet and contacts untouched', () => {
+      const active = seedWallet('Wallet A')
+      const other = seedWallet('Wallet B')
+      makeActive(active.id, active.name)
+      store.dispatch(contactStoredInPersistentStorage(contact))
+      const dispatchSpy = vi.spyOn(store, 'dispatch')
+
+      runDeleteWallet(other.id, active.id)
+
+      expect(dispatchSpy).toHaveBeenCalledWith(walletDeleted(other.id))
+
+      const state = store.getState()
+      expect(state.global.wallets.map((wallet) => wallet.id)).toEqual([active.id])
+      expect(state.activeWallet.id).toBe(active.id)
+      expect(state.contacts.ids).toContain('c1')
+    })
+  })
+
+  describe('when the deleted wallet is the active one', () => {
+    it('clears the keyring', () => {
+      const active = seedWallet('Wallet A')
+      seedWallet('Wallet B')
+      makeActive(active.id, active.name)
+      keyring.importMnemonicString(testMnemonic)
+      const clearSpy = vi.spyOn(keyring, 'clear')
+
+      runDeleteWallet(active.id, active.id)
+
+      expect(clearSpy).toHaveBeenCalledTimes(1)
+      expect(keyring.isInitialized()).toBe(false)
+    })
+
+    it('dispatches activeWalletDeleted, resetting the active wallet, contacts and sent transactions and re-listing global.wallets without the deleted wallet', () => {
+      const active = seedWallet('Wallet A')
+      const other = seedWallet('Wallet B')
+      makeActive(active.id, active.name)
+      store.dispatch(contactStoredInPersistentStorage(contact))
+      store.dispatch(transactionSent(sentTx))
+      const dispatchSpy = vi.spyOn(store, 'dispatch')
+
+      runDeleteWallet(active.id, active.id)
+
+      expect(dispatchSpy).toHaveBeenCalledWith(activeWalletDeleted())
+
+      const state = store.getState()
+      expect(state.activeWallet.id).toBeUndefined()
+      expect(state.contacts.ids).toHaveLength(0)
+      expect(state.sentTransactions.ids).toHaveLength(0)
+      expect(state.global.wallets.map((wallet) => wallet.id)).toEqual([other.id])
+    })
+
+    it('removes its localStorage keys and deletes its persisted query cache', () => {
+      const active = seedWallet('Wallet A')
+      seedWallet('Wallet B')
+      makeActive(active.id, active.name)
+
+      runDeleteWallet(active.id, active.id)
+
+      expect(localStorage.getItem(`wallet-${active.id}`)).toBeNull()
+      expect(localStorage.getItem(`addresses-metadata-${active.id}`)).toBeNull()
+      expect(deletePersistedCache).toHaveBeenCalledWith(active.id)
+    })
+  })
+
+  it('leaves no wallets in storage or in global.wallets when the last wallet is deleted', () => {
+    const active = seedWallet('Wallet A')
+    makeActive(active.id, active.name)
+
+    runDeleteWallet(active.id, active.id)
+
+    expect(walletStorage.list()).toHaveLength(0)
+    expect(store.getState().global.wallets).toHaveLength(0)
+  })
+
+  it('does not throw when the wallet storage keys are already absent', () => {
+    expect(() => runDeleteWallet('non-existent-wallet-id', undefined)).not.toThrow()
+  })
+
+  it('sends the DELETED_WALLET analytics event', () => {
+    const active = seedWallet('Wallet A')
+    const other = seedWallet('Wallet B')
+    makeActive(active.id, active.name)
+
+    runDeleteWallet(other.id, active.id)
+
+    expect(sendAnalytics).toHaveBeenCalledWith({ event: AnalyticsEvent.DELETED_WALLET })
+  })
+})


### PR DESCRIPTION
Move the inline wallet-deletion logic out of the WalletRemovalModal callback into a dedicated, unit-testable deleteWallet utility and cover it with tests. Behavior-preserving.

- Closes #831
