### PR TITLE
Make translated strings react to language change

### DIFF
--- a/.changeset/desktop-translations-reactive.md
+++ b/.changeset/desktop-translations-reactive.md
@@ -1,0 +1,5 @@
+---
+'alephium-desktop-wallet': patch
+---
+
+Make network-select and transaction time-period options and the required-field error react to language changes

--- a/.changeset/explorer-translations-reactive.md
+++ b/.changeset/explorer-translations-reactive.md
@@ -1,0 +1,5 @@
+---
+'@alephium/explorer': patch
+---
+
+Make the CSV export time-period list and timestamp-toggle tooltips react to language changes

--- a/.changeset/mobile-translations-reactive.md
+++ b/.changeset/mobile-translations-reactive.md
@@ -1,0 +1,5 @@
+---
+'@alephium/mobile-wallet': patch
+---
+
+Make onboarding instructions, auto-lock and group-select options, and the required-field error react to language changes

--- a/apps/desktop-wallet/src/features/send/sendModal/SendModalAddressesStep.tsx
+++ b/apps/desktop-wallet/src/features/send/sendModal/SendModalAddressesStep.tsx
@@ -8,7 +8,7 @@ import AddressInputs from '@/features/send/sendModal/AddressInputs'
 import { TransferAddressesTxModalOnSubmitData, TransferTxModalData } from '@/features/send/sendModal/sendTypes'
 import { useAppSelector } from '@/hooks/redux'
 import { ModalFooterButton, ModalFooterButtons } from '@/modals/CenteredModal'
-import { isAddressValid, requiredErrorMessage } from '@/utils/form-validation'
+import { isAddressValid } from '@/utils/form-validation'
 
 interface SendModalAddressesStepProps {
   data: TransferTxModalData
@@ -36,7 +36,10 @@ const SendModalAddressesStep = ({ data, onSubmit, onCancel }: SendModalAddresses
 
   const handleToAddressChange = useCallback(
     (value: string) => {
-      setToAddress(value, !value ? requiredErrorMessage : isAddressValid(value) ? '' : t('This address is not valid'))
+      setToAddress(
+        value,
+        !value ? t('This field is required') : isAddressValid(value) ? '' : t('This address is not valid')
+      )
     },
     [setToAddress, t]
   )

--- a/apps/desktop-wallet/src/modals/CSVExportModal.tsx
+++ b/apps/desktop-wallet/src/modals/CSVExportModal.tsx
@@ -13,12 +13,13 @@ import CenteredModal, { ModalFooterButton, ModalFooterButtons } from '@/modals/C
 import { csvFileGenerationFinished, fetchTransactionsCsv } from '@/storage/transactions/transactionsActions'
 import { TransactionTimePeriod } from '@/types/transactions'
 import { generateCsvFile, getCsvExportTimeRangeQueryParams } from '@/utils/csvExport'
-import { timePeriodsOptions } from '@/utils/transactions'
+import { useTimePeriodsOptions } from '@/utils/transactions'
 
 const CSVExportModal = ({ id, addressHash }: AddressModalProps) => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const { sendAnalytics } = useAnalytics()
+  const timePeriodsOptions = useTimePeriodsOptions()
 
   const address = useAppSelector((s) => selectAddressByHash(s, addressHash))
 

--- a/apps/desktop-wallet/src/modals/ContactFormModal.tsx
+++ b/apps/desktop-wallet/src/modals/ContactFormModal.tsx
@@ -15,12 +15,7 @@ import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import CenteredModal, { ModalFooterButton, ModalFooterButtons } from '@/modals/CenteredModal'
 import { contactDeletionFailed, contactStorageFailed } from '@/storage/addresses/addressesActions'
 import { contactsStorage } from '@/storage/addresses/contactsPersistentStorage'
-import {
-  isAddressValid,
-  isContactAddressValid,
-  isContactNameValid,
-  requiredErrorMessage
-} from '@/utils/form-validation'
+import { isAddressValid, isContactAddressValid, isContactNameValid } from '@/utils/form-validation'
 
 export interface ContactFormModalProps {
   contact?: Contact
@@ -101,7 +96,7 @@ const ContactFormModal = memo(({ id, contact }: ModalBaseProp & ContactFormModal
               value={value}
               onChange={onChange}
               onBlur={onBlur}
-              error={errors.name?.type === 'required' ? requiredErrorMessage : errors.name?.message}
+              error={errors.name?.type === 'required' ? t('This field is required') : errors.name?.message}
               isValid={!!value && !errors.name}
             />
           )}
@@ -119,7 +114,7 @@ const ContactFormModal = memo(({ id, contact }: ModalBaseProp & ContactFormModal
               value={value}
               onChange={onChange}
               onBlur={onBlur}
-              error={errors.address?.type === 'required' ? requiredErrorMessage : errors.address?.message}
+              error={errors.address?.type === 'required' ? t('This field is required') : errors.address?.message}
               isValid={!!value && !errors.address}
             />
           )}

--- a/apps/desktop-wallet/src/modals/SettingsModal/EditWalletNameModal.tsx
+++ b/apps/desktop-wallet/src/modals/SettingsModal/EditWalletNameModal.tsx
@@ -13,7 +13,7 @@ import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import CenteredModal, { ModalFooterButton, ModalFooterButtons } from '@/modals/CenteredModal'
 import { newWalletNameStored, walletNameStorageFailed } from '@/storage/wallets/walletActions'
 import { walletStorage } from '@/storage/wallets/walletPersistentStorage'
-import { isWalletNameValid, requiredErrorMessage } from '@/utils/form-validation'
+import { isWalletNameValid } from '@/utils/form-validation'
 
 type FormData = {
   name: ActiveWalletDesktop['name']
@@ -60,7 +60,7 @@ const EditWalletNameModal = memo(({ id }: ModalBaseProp) => {
               value={value}
               onChange={onChange}
               onBlur={onBlur}
-              error={errors.name?.type === 'required' ? requiredErrorMessage : errors.name?.message}
+              error={errors.name?.type === 'required' ? t('This field is required') : errors.name?.message}
               isValid={!!value && !errors.name}
               heightSize="big"
             />

--- a/apps/desktop-wallet/src/modals/SettingsModal/NetworkSettingsSection.tsx
+++ b/apps/desktop-wallet/src/modals/SettingsModal/NetworkSettingsSection.tsx
@@ -15,7 +15,6 @@ import Select from '@/components/Inputs/Select'
 import { Section } from '@/components/PageComponents/PageContainers'
 import ToggleSection from '@/components/ToggleSection'
 import useAnalytics from '@/features/analytics/useAnalytics'
-import i18next from '@/features/localization/i18n'
 import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import { useMountEffect } from '@/utils/hooks'
 
@@ -24,22 +23,22 @@ interface NetworkSelectOption {
   value: NetworkName
 }
 
-const networkSelectOptions: NetworkSelectOption[] = Object.values(NetworkNames).map((networkName) => ({
-  label: {
-    mainnet: i18next.t('Mainnet'),
-    testnet: i18next.t('Testnet'),
-    devnet: i18next.t('Devnet'),
-    custom: i18next.t('Custom')
-  }[networkName],
-  value: networkName
-}))
-
 const NetworkSettingsSection = () => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const network = useAppSelector((state) => state.network)
   const { sendAnalytics } = useAnalytics()
   const theme = useTheme()
+
+  const networkSelectOptions: NetworkSelectOption[] = Object.values(NetworkNames).map((networkName) => ({
+    label: {
+      mainnet: t('Mainnet'),
+      testnet: t('Testnet'),
+      devnet: t('Devnet'),
+      custom: t('Custom')
+    }[networkName],
+    value: networkName
+  }))
 
   const [tempNetworkSettings, setTempNetworkSettings] = useState<NetworkSettings>(network.settings)
   const [selectedNetwork, setSelectedNetwork] = useState<NetworkName>()

--- a/apps/desktop-wallet/src/utils/form-validation.ts
+++ b/apps/desktop-wallet/src/utils/form-validation.ts
@@ -4,8 +4,6 @@ import { isValidAddress, Optional } from '@alephium/web3'
 import i18n from '@/features/localization/i18n'
 import { store } from '@/storage/store'
 
-export const requiredErrorMessage = i18n.t('This field is required')
-
 export const isAddressValid = (value: string) => isValidAddress(value) || i18n.t('This address is not valid')
 
 export const isContactAddressValid = ({ address, id }: Optional<Omit<Contact, 'name'>, 'id'>) => {

--- a/apps/desktop-wallet/src/utils/transactions.ts
+++ b/apps/desktop-wallet/src/utils/transactions.ts
@@ -1,8 +1,9 @@
 import { SHORT_DATE_OPTIONS } from '@alephium/shared'
 import { TransactionInfoType2 } from '@alephium/shared/transactions'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { SelectOption } from '@/components/Inputs/Select'
-import i18n from '@/features/localization/i18n'
 import { TranslationKey } from '@/features/localization/i18next'
 import { Direction, TransactionTimePeriod } from '@/types/transactions'
 
@@ -13,39 +14,46 @@ const today = dateFormatter.format(now)
 const oneYearAgo = new Date(now)
 oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1)
 
-export const timePeriodsOptions: SelectOption<TransactionTimePeriod>[] = [
-  {
-    value: '24h',
-    label: i18n.t('Last 24h')
-  },
-  {
-    value: '1w',
-    label: i18n.t('Last week')
-  },
-  {
-    value: '1m',
-    label: i18n.t('Last month')
-  },
-  {
-    value: '6m',
-    label: i18n.t('Last 6 months')
-  },
-  {
-    value: '12m',
-    label: `${i18n.t('Last 12 months')}
+export const useTimePeriodsOptions = (): SelectOption<TransactionTimePeriod>[] => {
+  const { t } = useTranslation()
+
+  return useMemo(
+    () => [
+      {
+        value: '24h',
+        label: t('Last 24h')
+      },
+      {
+        value: '1w',
+        label: t('Last week')
+      },
+      {
+        value: '1m',
+        label: t('Last month')
+      },
+      {
+        value: '6m',
+        label: t('Last 6 months')
+      },
+      {
+        value: '12m',
+        label: `${t('Last 12 months')}
     (${dateFormatter.format(oneYearAgo)}
     - ${today})`
-  },
-  {
-    value: 'previousYear',
-    label: `${i18n.t('Previous year')}
+      },
+      {
+        value: 'previousYear',
+        label: `${t('Previous year')}
     (01/01/${currentYear - 1} - 31/12/${currentYear - 1})`
-  },
-  {
-    value: 'thisYear',
-    label: `${i18n.t('This year')} (01/01/${currentYear - 1} - ${today})`
-  }
-]
+      },
+      {
+        value: 'thisYear',
+        label: `${t('This year')} (01/01/${currentYear - 1} - ${today})`
+      }
+    ],
+    [t]
+  )
+}
 
 export const directionOptions: {
   value: Direction

--- a/apps/explorer/src/components/Buttons/TimestampExpandButton.tsx
+++ b/apps/explorer/src/components/Buttons/TimestampExpandButton.tsx
@@ -1,29 +1,30 @@
 import { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
 import { IconBaseProps } from 'react-icons'
 import { RiContractLeftRightLine, RiExpandLeftRightLine } from 'react-icons/ri'
 import styled from 'styled-components'
 
 import { useSettings } from '@/contexts/settingsContext'
-import i18n from '@/features/localization/i18n'
 import { OnOff } from '@/types/generics'
 
 interface TimestampExpandButtonProps {
   className?: string
 }
 
-const config: Record<OnOff, { Icon: (props: IconBaseProps) => ReactNode; tooltipContent: string }> = {
-  on: {
-    Icon: RiContractLeftRightLine,
-    tooltipContent: i18n.t('Switch to simple time')
-  },
-  off: {
-    Icon: RiExpandLeftRightLine,
-    tooltipContent: i18n.t('Switch to precise time')
-  }
-}
-
 const TimestampExpandButton = ({ className }: TimestampExpandButtonProps) => {
+  const { t } = useTranslation()
   const { timestampPrecisionMode, setTimestampPrecisionMode } = useSettings()
+
+  const config: Record<OnOff, { Icon: (props: IconBaseProps) => ReactNode; tooltipContent: string }> = {
+    on: {
+      Icon: RiContractLeftRightLine,
+      tooltipContent: t('Switch to simple time')
+    },
+    off: {
+      Icon: RiExpandLeftRightLine,
+      tooltipContent: t('Switch to precise time')
+    }
+  }
 
   const handleClick = () => {
     setTimestampPrecisionMode(timestampPrecisionMode === 'on' ? 'off' : 'on')

--- a/apps/explorer/src/pages/AddressInfoPage/ExportAddressTXsModal.tsx
+++ b/apps/explorer/src/pages/AddressInfoPage/ExportAddressTXsModal.tsx
@@ -10,7 +10,6 @@ import HighlightedHash from '@/components/HighlightedHash'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import Modal, { ModalProps } from '@/components/Modal/Modal'
 import Select, { SelectListItem } from '@/components/Select'
-import i18n from '@/features/localization/i18n'
 import { useSnackbar } from '@/hooks/useSnackbar'
 import { SIMPLE_DATE_OPTIONS } from '@/utils/strings'
 
@@ -34,6 +33,47 @@ const ExportAddressTXsModal = ({ addressHash, onClose, ...props }: ExportAddress
   const { t } = useTranslation()
 
   const [timePeriodValue, setTimePeriodValue] = useState<TimePeriodValue>('24h')
+
+  const timePeriodsItems: SelectListItem<TimePeriodValue>[] = [
+    {
+      value: '24h',
+      label: t('Last 24h')
+    },
+    {
+      value: '1w',
+      label: t('Last week')
+    },
+    {
+      value: '1m',
+      label: t('Last month')
+    },
+    {
+      value: '6m',
+      label: t('Last 6 months')
+    },
+    {
+      value: '12m',
+      label: t('Last 12 months')
+    },
+    {
+      value: 'currentYear',
+      label: `${t('This year so far')} (01/01/${currentYear} - ${today})`
+    },
+    {
+      value: 'oneYearAgo',
+      label: `${t('Last year')} (${currentYear - 1})`
+    },
+    {
+      value: 'twoYearsAgo',
+      label: `${t('Two years ago')}
+    (${currentYear - 2})`
+    },
+    {
+      value: 'threeYearsAgo',
+      label: `${t('Three years ago')}
+    (${currentYear - 3})`
+    }
+  ]
 
   const getCSVFile = useCallback(async () => {
     onClose()
@@ -113,47 +153,6 @@ const thisMoment = now.getTime()
 const currentYear = now.getFullYear()
 const dateFormatter = new Intl.DateTimeFormat(undefined, SIMPLE_DATE_OPTIONS)
 const today = dateFormatter.format(now)
-
-const timePeriodsItems: SelectListItem<TimePeriodValue>[] = [
-  {
-    value: '24h',
-    label: i18n.t('Last 24h')
-  },
-  {
-    value: '1w',
-    label: i18n.t('Last week')
-  },
-  {
-    value: '1m',
-    label: i18n.t('Last month')
-  },
-  {
-    value: '6m',
-    label: i18n.t('Last 6 months')
-  },
-  {
-    value: '12m',
-    label: i18n.t('Last 12 months')
-  },
-  {
-    value: 'currentYear',
-    label: `${i18n.t('This year so far')} (01/01/${currentYear} - ${today})`
-  },
-  {
-    value: 'oneYearAgo',
-    label: `${i18n.t('Last year')} (${currentYear - 1})`
-  },
-  {
-    value: 'twoYearsAgo',
-    label: `${i18n.t('Two years ago')}
-    (${currentYear - 2})`
-  },
-  {
-    value: 'threeYearsAgo',
-    label: `${i18n.t('Three years ago')}
-    (${currentYear - 3})`
-  }
-]
 
 const timePeriods: Record<TimePeriodValue, { from: number; to: number }> = {
   '24h': { from: thisMoment - ONE_DAY_MS, to: thisMoment },

--- a/apps/mobile-wallet/src/components/DeprecatedAuthenticationModal.tsx
+++ b/apps/mobile-wallet/src/components/DeprecatedAuthenticationModal.tsx
@@ -12,7 +12,6 @@ import { ScreenSection } from '~/components/layout/Screen'
 import ModalWithBackdrop, { ModalWithBackdropProps } from '~/components/ModalWithBackdrop'
 import CenteredInstructions, { Instruction } from '~/components/text/CenteredInstructions'
 import { Spinner } from '~/features/loader/SpinnerModal'
-import i18n from '~/features/localization/i18n'
 import { loadBiometricsSettings } from '~/features/settings/settingsPersistentStorage'
 import { getDeprecatedStoredWallet, GetDeprecatedStoredWalletProps } from '~/persistent-storage/legacyWallet'
 import { ShouldClearPin } from '~/types/misc'
@@ -26,8 +25,6 @@ interface DeprecatedAuthenticationModalProps extends ModalWithBackdropProps, Get
 }
 
 const pinLength = 6
-
-const firstInstructionSet: Instruction[] = [{ text: i18n.t('Please enter your pin'), type: 'primary' }]
 
 const errorInstructionSet: Instruction[] = [
   { text: 'Oops, wrong pin!', type: 'error' },
@@ -44,6 +41,8 @@ const DeprecatedAuthenticationModal = ({
 }: DeprecatedAuthenticationModalProps) => {
   const insets = useSafeAreaInsets()
   const { t } = useTranslation()
+
+  const firstInstructionSet: Instruction[] = [{ text: t('Please enter your pin'), type: 'primary' }]
 
   const [shownInstructions, setShownInstructions] = useState(firstInstructionSet)
   const [deprecatedEncryptedWallet, setDeprecatedEncryptedWallet] = useState<DeprecatedWalletState>()

--- a/apps/mobile-wallet/src/features/auto-lock/AutoLockOptionsModal.tsx
+++ b/apps/mobile-wallet/src/features/auto-lock/AutoLockOptionsModal.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { ScreenSection } from '~/components/layout/Screen'
 import Surface from '~/components/layout/Surface'
 import RadioButtonRow from '~/components/RadioButtonRow'
-import { autoLockSecondsOptions } from '~/features/auto-lock/utils'
+import { useAutoLockSecondsOptions } from '~/features/auto-lock/utils'
 import BottomModal from '~/features/modals/BottomModal'
 import { useModalContext } from '~/features/modals/ModalContext'
 import { autoLockSecondsChanged } from '~/features/settings/settingsSlice'
@@ -15,6 +15,7 @@ const AutoLockOptionsModal = memo(() => {
   const autoLockSeconds = useAppSelector((s) => s.settings.autoLockSeconds)
   const dispatch = useAppDispatch()
   const { dismissModal } = useModalContext()
+  const autoLockSecondsOptions = useAutoLockSecondsOptions()
 
   const handleAutoLockChange = (seconds: number) => {
     dispatch(autoLockSecondsChanged(seconds))

--- a/apps/mobile-wallet/src/features/auto-lock/utils.ts
+++ b/apps/mobile-wallet/src/features/auto-lock/utils.ts
@@ -1,21 +1,32 @@
-import i18n from '~/features/localization/i18n'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 
 const autoLockSeconds = [5, 15, 30, 60]
 
-export const autoLockSecondsOptions = [
-  {
-    label: i18n.t('Fast'),
-    value: 0
-  },
-  ...autoLockSeconds.map((sec) => ({
-    label: i18n.t('{{ seconds }} seconds', { seconds: sec }),
-    value: sec
-  })),
-  {
-    label: i18n.t('Never'),
-    value: -1
-  }
-]
+export const useAutoLockSecondsOptions = () => {
+  const { t } = useTranslation()
 
-export const getAutoLockLabel = (autoLockSeconds: number) =>
-  autoLockSecondsOptions.find((option) => option.value === autoLockSeconds)?.label
+  return useMemo(
+    () => [
+      {
+        label: t('Fast'),
+        value: 0
+      },
+      ...autoLockSeconds.map((sec) => ({
+        label: t('{{ seconds }} seconds', { seconds: sec }),
+        value: sec
+      })),
+      {
+        label: t('Never'),
+        value: -1
+      }
+    ],
+    [t]
+  )
+}
+
+export const useAutoLockLabel = (seconds: number) => {
+  const options = useAutoLockSecondsOptions()
+
+  return options.find((option) => option.value === seconds)?.label
+}

--- a/apps/mobile-wallet/src/features/settings/settingsScreen/SettingsSecuritySection.tsx
+++ b/apps/mobile-wallet/src/features/settings/settingsScreen/SettingsSecuritySection.tsx
@@ -9,7 +9,7 @@ import { ScreenSection, ScreenSectionTitle } from '~/components/layout/Screen'
 import Surface from '~/components/layout/Surface'
 import Row from '~/components/Row'
 import Toggle from '~/components/Toggle'
-import { getAutoLockLabel } from '~/features/auto-lock/utils'
+import { useAutoLockLabel } from '~/features/auto-lock/utils'
 import FundPasswordSettingsRow from '~/features/fund-password/FundPasswordSettingsRow'
 import { openModal } from '~/features/modals/modalActions'
 import { biometricsToggled, passwordRequirementToggled } from '~/features/settings/settingsSlice'
@@ -129,6 +129,7 @@ const BiometricsSettingsRows = () => {
 const AutoLockSettingsRow = () => {
   const { t } = useTranslation()
   const autoLockSeconds = useAppSelector((s) => s.settings.autoLockSeconds)
+  const autoLockLabel = useAutoLockLabel(autoLockSeconds)
   const dispatch = useAppDispatch()
 
   const openAutoLockOptionsModal = () => dispatch(openModal({ name: 'AutoLockOptionsModal' }))
@@ -140,7 +141,7 @@ const AutoLockSettingsRow = () => {
       isLast
       onPress={openAutoLockOptionsModal}
     >
-      <AppText bold>{getAutoLockLabel(autoLockSeconds)}</AppText>
+      <AppText bold>{autoLockLabel}</AppText>
     </Row>
   )
 }

--- a/apps/mobile-wallet/src/screens/Addresses/Address/GroupSelectModal.tsx
+++ b/apps/mobile-wallet/src/screens/Addresses/Address/GroupSelectModal.tsx
@@ -3,7 +3,6 @@ import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import RadioButtonRow from '~/components/RadioButtonRow'
-import i18n from '~/features/localization/i18n'
 import BottomModal from '~/features/modals/BottomModal'
 import { useModalContext } from '~/features/modals/ModalContext'
 
@@ -12,14 +11,14 @@ interface GroupSelectModalProps {
   onSelect: (group?: number) => void
 }
 
-const groupSelectOptions = Array.from({ length: TOTAL_NUMBER_OF_GROUPS + 1 }, (_, i) => ({
-  value: i === 0 ? undefined : i - 1,
-  label: i === 0 ? i18n.t('Groupless') : i18n.t('Group {{ groupNumber }}', { groupNumber: i - 1 })
-}))
-
 const GroupSelectModal = memo<GroupSelectModalProps>(({ onSelect, selectedGroup }) => {
   const { dismissModal } = useModalContext()
   const { t } = useTranslation()
+
+  const groupSelectOptions = Array.from({ length: TOTAL_NUMBER_OF_GROUPS + 1 }, (_, i) => ({
+    value: i === 0 ? undefined : i - 1,
+    label: i === 0 ? t('Groupless') : t('Group {{ groupNumber }}', { groupNumber: i - 1 })
+  }))
 
   const onGroupSelect = (group?: number) => {
     onSelect(group)

--- a/apps/mobile-wallet/src/screens/Addresses/Contact/ContactFormBaseScreen.tsx
+++ b/apps/mobile-wallet/src/screens/Addresses/Contact/ContactFormBaseScreen.tsx
@@ -7,7 +7,6 @@ import Button from '~/components/buttons/Button'
 import Input from '~/components/inputs/Input'
 import { ScreenSection } from '~/components/layout/Screen'
 import ScrollScreen, { ScrollScreenProps } from '~/components/layout/ScrollScreen'
-import i18n from '~/features/localization/i18n'
 import NewContactCameraScanButton from '~/features/qrCodeScan/NewContactCameraScanButton'
 import { isContactAddressValid, isContactNameValid } from '~/utils/form-validation'
 import { validateIsAddressValid } from '~/utils/forms'
@@ -18,8 +17,6 @@ interface ContactFormBaseScreenProps extends ScrollScreenProps {
   onDelete?: () => void
   buttonText?: string
 }
-
-const requiredErrorMessage = i18n.t('This field is required')
 
 const ContactFormBaseScreen = ({
   initialValues,
@@ -36,6 +33,8 @@ const ContactFormBaseScreen = ({
     setValue
   } = useForm<ContactFormData>({ defaultValues: initialValues })
   const { t } = useTranslation()
+
+  const requiredErrorMessage = t('This field is required')
 
   const handleQRCodeScan = (addressHash: AddressHash) => setValue('address', addressHash)
 

--- a/apps/mobile-wallet/src/screens/new-wallet/AddBiometricsScreen.tsx
+++ b/apps/mobile-wallet/src/screens/new-wallet/AddBiometricsScreen.tsx
@@ -12,7 +12,6 @@ import Button from '~/components/buttons/Button'
 import { ScreenProps } from '~/components/layout/Screen'
 import ScrollScreen from '~/components/layout/ScrollScreen'
 import CenteredInstructions, { Instruction } from '~/components/text/CenteredInstructions'
-import i18n from '~/features/localization/i18n'
 import { openModal } from '~/features/modals/modalActions'
 import { allBiometricsEnabled } from '~/features/settings/settingsActions'
 import { useAppDispatch, useAppSelector } from '~/hooks/redux'
@@ -21,16 +20,16 @@ import { resetNavigation } from '~/utils/navigation'
 
 interface AddBiometricsScreenProps extends StackScreenProps<RootStackParamList, 'AddBiometricsScreen'>, ScreenProps {}
 
-const instructions: Instruction[] = [
-  { text: `${i18n.t('Do you want to activate biometric security?')} 👆`, type: 'primary' },
-  { text: i18n.t('Use fingerprint or face recognition instead of the pin to unlock the wallet'), type: 'secondary' }
-]
-
 const AddBiometricsScreen = ({ navigation, ...props }: AddBiometricsScreenProps) => {
   const method = useAppSelector((s) => s.walletGeneration.method)
   const dispatch = useAppDispatch()
   const addressHashes = useUnsortedAddressesHashes()
   const { t } = useTranslation()
+
+  const instructions: Instruction[] = [
+    { text: `${t('Do you want to activate biometric security?')} 👆`, type: 'primary' },
+    { text: t('Use fingerprint or face recognition instead of the pin to unlock the wallet'), type: 'secondary' }
+  ]
 
   const skipAddressDiscovery = method === 'create' || addressHashes.length > 1
 

--- a/apps/mobile-wallet/src/screens/new-wallet/NewWalletNameScreen.tsx
+++ b/apps/mobile-wallet/src/screens/new-wallet/NewWalletNameScreen.tsx
@@ -13,7 +13,6 @@ import { ScreenProps } from '~/components/layout/Screen'
 import ScrollScreen from '~/components/layout/ScrollScreen'
 import CenteredInstructions, { Instruction } from '~/components/text/CenteredInstructions'
 import { activateAppLoading, deactivateAppLoading } from '~/features/loader/loaderActions'
-import i18n from '~/features/localization/i18n'
 import { useAppDispatch, useAppSelector } from '~/hooks/redux'
 import { useBiometrics } from '~/hooks/useBiometrics'
 import useCaptureOnboardingStep from '~/hooks/useCaptureOnboardingStep'
@@ -29,11 +28,6 @@ import { showExceptionToast } from '~/utils/layout'
 import { sleep } from '~/utils/misc'
 import { resetNavigation } from '~/utils/navigation'
 
-const instructions: Instruction[] = [
-  { text: i18n.t("Alright, let's get to it."), type: 'secondary' },
-  { text: i18n.t('How should we name this wallet?'), type: 'primary' }
-]
-
 interface NewWalletNameScreenProps
   extends NativeStackScreenProps<RootStackParamList, 'NewWalletNameScreen'>,
     ScreenProps {}
@@ -45,6 +39,11 @@ const NewWalletNameScreen = ({ navigation, ...props }: NewWalletNameScreenProps)
   const dispatch = useAppDispatch()
   const { t } = useTranslation()
   const { clearQueryCache, restoreQueryCache } = usePersistQueryClientContext()
+
+  const instructions: Instruction[] = [
+    { text: t("Alright, let's get to it."), type: 'secondary' },
+    { text: t('How should we name this wallet?'), type: 'primary' }
+  ]
 
   const [name, setName] = useState('')
 

--- a/apps/mobile-wallet/src/screens/new-wallet/WatchOnlyAddressScreen.tsx
+++ b/apps/mobile-wallet/src/screens/new-wallet/WatchOnlyAddressScreen.tsx
@@ -15,7 +15,6 @@ import ScrollScreen from '~/components/layout/ScrollScreen'
 import QRCodeScannerModal from '~/components/QRCodeScannerModal'
 import CenteredInstructions, { Instruction } from '~/components/text/CenteredInstructions'
 import { activateAppLoading, deactivateAppLoading } from '~/features/loader/loaderActions'
-import i18n from '~/features/localization/i18n'
 import { useAppDispatch, useAppSelector } from '~/hooks/redux'
 import RootStackParamList from '~/navigation/rootStackRoutes'
 import { createWatchOnlyWallet } from '~/persistent-storage/wallet'
@@ -24,11 +23,6 @@ import { walletAddedToList } from '~/store/wallet/walletsSlice'
 import { DEFAULT_MARGIN } from '~/style/globalStyle'
 import { showExceptionToast, showToast } from '~/utils/layout'
 import { resetNavigation } from '~/utils/navigation'
-
-const instructions: Instruction[] = [
-  { text: i18n.t('Watch an address'), type: 'primary' },
-  { text: i18n.t('Enter an Alephium address to track its balance and transactions.'), type: 'secondary' }
-]
 
 interface WatchOnlyAddressScreenProps
   extends NativeStackScreenProps<RootStackParamList, 'WatchOnlyAddressScreen'>,
@@ -39,6 +33,11 @@ const WatchOnlyAddressScreen = ({ navigation, ...props }: WatchOnlyAddressScreen
   const isCameraOpen = useAppSelector((s) => s.app.isCameraOpen)
   const { t } = useTranslation()
   const { clearQueryCache, restoreQueryCache } = usePersistQueryClientContext()
+
+  const instructions: Instruction[] = [
+    { text: t('Watch an address'), type: 'primary' },
+    { text: t('Enter an Alephium address to track its balance and transactions.'), type: 'secondary' }
+  ]
 
   const [address, setAddress] = useState('')
   const [name, setName] = useState('')


### PR DESCRIPTION
Module-level const strings built from the i18next singleton froze to the language active at import and never updated on a runtime language switch. Build them from useTranslation().t inside render instead, so they re-render in the newly selected language.

- Closes #722
